### PR TITLE
Introduce a mechanism to dynamically support executor-per-task

### DIFF
--- a/titus-server-master/src/main/java/io/netflix/titus/master/job/BaseJobMgr.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/job/BaseJobMgr.java
@@ -126,6 +126,7 @@ public abstract class BaseJobMgr implements V2JobMgrIntf {
     protected final Injector injector;
     private final ApplicationSlaManagementService applicationSlaManagementService;
     private final TitusTaskInfoCreator titusTaskInfoCreator;
+    private static final String EXECUTOR_PER_TASK_LABEL = "executorpertask";
 
     private volatile boolean pendingInitialization = false;
     private final BlockingQueue<ScheduledRequest> taskQueueRequests = new LinkedBlockingQueue<>();
@@ -549,6 +550,12 @@ public abstract class BaseJobMgr implements V2JobMgrIntf {
                                                         List<Integer> portsAssigned)
             throws InvalidJobStateChangeException, InvalidJobException {
         List<V2WorkerMetadata.TwoLevelResource> twoLevelResources = new ArrayList<>();
+        boolean executorPerTask = false;
+
+        // The presence of this label is enough to trigger executor-per-task mode; We do not need to inspect the value.
+        if (attributeMap.containsKey(EXECUTOR_PER_TASK_LABEL))
+            executorPerTask = true;
+
         if (consumedResourceSet != null) {
             logger.info(task.getId() + ": allocated res " + consumedResourceSet.getAttrName() + ", " +
                     consumedResourceSet.getResName() + ", label " + consumedResourceSet.getIndex()
@@ -597,7 +604,7 @@ public abstract class BaseJobMgr implements V2JobMgrIntf {
         task.setAssignedResources(assignedResources);
 
         // create taskInfo object
-        return titusTaskInfoCreator.createTitusTaskInfo(slaveID, job.getParameters(), task, portsAssigned, mwmd.getWorkerInstanceId());
+        return titusTaskInfoCreator.createTitusTaskInfo(slaveID, job.getParameters(), task, portsAssigned, mwmd.getWorkerInstanceId(), executorPerTask);
     }
 
     @Override

--- a/titus-server-master/src/main/java/io/netflix/titus/master/mesos/TitusTaskInfoCreator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/mesos/TitusTaskInfoCreator.java
@@ -71,15 +71,24 @@ public class TitusTaskInfoCreator {
 
     public Protos.TaskInfo createTitusTaskInfo(Protos.SlaveID slaveID, List<Parameter> parameters,
                                                TitusQueuableTask<V2JobMetadata, V2WorkerMetadata> fenzoTask, List<Integer> portsAssigned,
-                                               String taskInstanceId) {
+                                               String taskInstanceId, boolean executorPerTask) {
         final WorkerNaming.JobWorkerIdPair jobAndWorkerId = WorkerNaming.getJobAndWorkerId(fenzoTask.getId());
         String _taskId = fenzoTask.getId();
         Protos.TaskID taskId = Protos.TaskID.newBuilder()
                 .setValue(_taskId).build();
         Protos.CommandInfo commandInfo = Protos.CommandInfo.newBuilder().setValue(config.pathToTitusExecutor()).build();
-        Protos.ExecutorInfo executorInfo = Protos.ExecutorInfo.newBuilder()
-                .setExecutorId(Protos.ExecutorID.newBuilder().setValue("docker-executor").build())
-                .setName("docker-executor")
+        final Protos.ExecutorInfo executorInfo;
+        String executorName = "docker-executor";
+        String executorId = "docker-executor";
+
+        if (executorPerTask) {
+            executorName = "docker-per-task-executor";
+            executorId = "docker-per-task-executor-" + _taskId;
+        }
+
+        executorInfo = Protos.ExecutorInfo.newBuilder()
+                .setExecutorId(Protos.ExecutorID.newBuilder().setValue(executorId).build())
+                .setName(executorName)
                 .setCommand(commandInfo)
                 .build();
         Protos.TaskInfo.Builder taskInfoBuilder = Protos.TaskInfo.newBuilder();


### PR DESCRIPTION
This patch adds a feature where it checks for the presence of a specific
Mesos agent attribute. If this attribute exists, it launches one executor
per task, rather than sending all tasks to a single executor.