### PR TITLE
Fix AWS detached instance reaper

### DIFF
--- a/titus-ext/aws/src/main/java/io/netflix/titus/ext/aws/Main.java
+++ b/titus-ext/aws/src/main/java/io/netflix/titus/ext/aws/Main.java
@@ -89,7 +89,7 @@ public class Main {
 
     private void fetchTaggedInstances(List<String> tags) {
         List<Instance> instances = connector.getTaggedInstances(tags.get(0)).toBlocking().first();
-        System.out.println("Loaded tagged instances:");
+        System.out.format("Loaded tagged instances (%s):\n", instances.size());
         instances.forEach(System.out::println);
     }
 


### PR DESCRIPTION
Remove unnecessary calls to AWS autoscale service, which are restricted to 50 ids
per query operation.