### PR TITLE
gc completable metrics

### DIFF
--- a/titus-server-master/src/main/java/io/netflix/titus/master/agent/service/cache/InstanceCache.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/agent/service/cache/InstanceCache.java
@@ -272,7 +272,10 @@ class InstanceCache {
                 .flatMap(result -> {
                     if (result.isEmpty()) {
                         logger.info("Instance group: {} has been removed", instanceGroupId);
-                        onEventLoop(() -> removeInstanceGroupFromCache(instanceGroupId));
+                        onEventLoop(() -> {
+                            removeInstanceGroupFromCache(instanceGroupId);
+                            instanceGroupRefreshMetricsTransforms.remove(instanceGroupId);
+                        });
                         return Observable.empty();
                     }
 

--- a/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/AgentFitnessCalculator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/AgentFitnessCalculator.java
@@ -35,7 +35,7 @@ public class AgentFitnessCalculator implements VMTaskFitnessCalculator {
     private final WeightedAverageFitnessCalculator weightedAverageFitnessCalculator;
 
     public static final com.netflix.fenzo.functions.Func1<Double, Boolean> fitnessGoodEnoughFunc =
-            f -> f > 1.0;
+            f -> f > 0.9;
 
     public AgentFitnessCalculator() {
         List<WeightedFitnessCalculator> calculators = new ArrayList<>();

--- a/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/JobTypeFitnessCalculator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/JobTypeFitnessCalculator.java
@@ -34,7 +34,7 @@ import io.netflix.titus.master.scheduler.ScheduledRequest;
 public class JobTypeFitnessCalculator implements VMTaskFitnessCalculator {
 
     private static final double EMPTY_HOST_SCORE = 0.7;
-    private static final double ZERO_SAME_JOB_TASKS_SCORE = 0.1;
+    private static final double ZERO_SAME_JOB_TASKS_SCORE = 0.01;
 
     private enum JobType {Batch, Service}
 


### PR DESCRIPTION
remove the instance group metrics class when an instance group is removed
tune scheduling constants
use timer instead of long task timer in completable metrics since these operations are in seconds and not hours