### PR TITLE
Enable Cassandra Load Balancer store by default

### DIFF
--- a/titus-ext/cassandra/src/main/java/io/netflix/titus/ext/cassandra/store/CassandraStoreModule.java
+++ b/titus-ext/cassandra/src/main/java/io/netflix/titus/ext/cassandra/store/CassandraStoreModule.java
@@ -23,6 +23,7 @@ import com.netflix.archaius.ConfigProxyFactory;
 import io.netflix.titus.api.agent.store.AgentStore;
 import io.netflix.titus.api.appscale.store.AppScalePolicyStore;
 import io.netflix.titus.api.jobmanager.store.JobStore;
+import io.netflix.titus.api.loadbalancer.store.LoadBalancerStore;
 
 public class CassandraStoreModule extends AbstractModule {
     @Override
@@ -30,6 +31,7 @@ public class CassandraStoreModule extends AbstractModule {
         bind(AgentStore.class).to(CassandraAgentStore.class);
         bind(AppScalePolicyStore.class).to(CassAppScalePolicyStore.class);
         bind(JobStore.class).to(CassandraJobStore.class);
+        bind(LoadBalancerStore.class).to(CassandraLoadBalancerStore.class);
     }
 
     @Provides

--- a/titus-server-master/src/main/java/io/netflix/titus/master/loadbalancer/LoadBalancerModule.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/loadbalancer/LoadBalancerModule.java
@@ -23,21 +23,18 @@ import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import io.netflix.titus.api.loadbalancer.model.sanitizer.DefaultLoadBalancerJobValidator;
-import io.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerValidationConfiguration;
 import io.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerJobValidator;
+import io.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerValidationConfiguration;
 import io.netflix.titus.api.loadbalancer.service.LoadBalancerService;
-import io.netflix.titus.api.loadbalancer.store.LoadBalancerStore;
 import io.netflix.titus.master.loadbalancer.endpoint.grpc.DefaultLoadBalancerServiceGrpc;
 import io.netflix.titus.master.loadbalancer.service.DefaultLoadBalancerService;
 import io.netflix.titus.master.loadbalancer.service.LoadBalancerConfiguration;
-import io.netflix.titus.runtime.store.v3.memory.InMemoryLoadBalancerStore;
 
 public class LoadBalancerModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(LoadBalancerServiceGrpc.LoadBalancerServiceImplBase.class).to(DefaultLoadBalancerServiceGrpc.class);
         bind(LoadBalancerService.class).to(DefaultLoadBalancerService.class);
-        bind(LoadBalancerStore.class).to(InMemoryLoadBalancerStore.class);
         bind(LoadBalancerJobValidator.class).to(DefaultLoadBalancerJobValidator.class);
     }
 

--- a/titus-server-master/src/main/java/io/netflix/titus/master/store/StoreModule.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/store/StoreModule.java
@@ -23,6 +23,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import io.netflix.titus.api.jobmanager.store.JobStore;
 import io.netflix.titus.api.appscale.store.AppScalePolicyStore;
+import io.netflix.titus.api.loadbalancer.store.LoadBalancerStore;
+import io.netflix.titus.runtime.store.v3.memory.InMemoryLoadBalancerStore;
 import io.netflix.titus.runtime.store.v3.memory.InMemoryPolicyStore;
 import io.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import io.netflix.titus.master.store.cache.ApplicationSlaStoreCache;
@@ -39,6 +41,7 @@ public class StoreModule extends AbstractModule {
         bind(V2StorageProvider.class).to(SimpleCachedFileStorageProvider.class);
         bind(JobStore.class).to(InMemoryJobStore.class);
         bind(AppScalePolicyStore.class).to(InMemoryPolicyStore.class);
+        bind(LoadBalancerStore.class).to(InMemoryLoadBalancerStore.class);
     }
 
     @Singleton

--- a/titus-server-runtime/src/main/java/io/netflix/titus/runtime/TitusEntitySanitizerModule.java
+++ b/titus-server-runtime/src/main/java/io/netflix/titus/runtime/TitusEntitySanitizerModule.java
@@ -25,8 +25,11 @@ import com.netflix.archaius.ConfigProxyFactory;
 import io.netflix.titus.api.agent.model.sanitizer.AgentSanitizerBuilder;
 import io.netflix.titus.api.jobmanager.model.job.sanitizer.JobConfiguration;
 import io.netflix.titus.api.jobmanager.model.job.sanitizer.JobSanitizerBuilder;
+import io.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerSanitizerBuilder;
 import io.netflix.titus.api.model.ResourceDimension;
 import io.netflix.titus.common.model.sanitizer.EntitySanitizer;
+
+import static io.netflix.titus.api.loadbalancer.store.LoadBalancerStore.LOAD_BALANCER_SANITIZER;
 
 /**
  */
@@ -57,6 +60,13 @@ public class TitusEntitySanitizerModule extends AbstractModule {
     @Named(AGENT_SANITIZER)
     public EntitySanitizer getAgentEntitySanitizer() {
         return new AgentSanitizerBuilder().build();
+    }
+
+    @Provides
+    @Singleton
+    @Named(LOAD_BALANCER_SANITIZER)
+    public EntitySanitizer getLoadBalancerEntitySanitizer() {
+        return new LoadBalancerSanitizerBuilder().build();
     }
 
     @Provides


### PR DESCRIPTION
The dev/staging stack's have been updated to include the LoadBalancer table. The mainvpc stacks will be updated after the quiet period.