### PR TITLE
Add job scale down evaluator

### DIFF
--- a/titus-common/src/main/java/io/netflix/titus/common/util/CollectionsExt.java
+++ b/titus-common/src/main/java/io/netflix/titus/common/util/CollectionsExt.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.netflix.titus.common.util.tuple.Pair;
 
 /**
  * A set of additional collections related functions.
@@ -230,6 +231,19 @@ public final class CollectionsExt {
             result.putAll(next);
         }
         return result;
+    }
+
+    public static <T> Pair<List<T>, List<T>> split(List<T> items, Predicate<T> predicate) {
+        List<T> matching = new ArrayList<>();
+        List<T> notMatching = new ArrayList<>();
+        items.forEach(item -> {
+            if (predicate.test(item)) {
+                matching.add(item);
+            } else {
+                notMatching.add(item);
+            }
+        });
+        return Pair.of(matching, notMatching);
     }
 
     @SafeVarargs

--- a/titus-server-master/src/main/java/io/netflix/titus/master/jobmanager/service/service/ScaleDownEvaluator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/jobmanager/service/service/ScaleDownEvaluator.java
@@ -1,0 +1,242 @@
+package io.netflix.titus.master.jobmanager.service.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.netflix.titus.api.jobmanager.model.job.ServiceJobTask;
+import io.netflix.titus.api.jobmanager.model.job.Task;
+import io.netflix.titus.api.jobmanager.model.job.TaskState;
+import io.netflix.titus.common.util.CollectionsExt;
+import io.netflix.titus.common.util.tuple.Pair;
+import io.netflix.titus.runtime.endpoint.v3.grpc.TaskAttributes;
+
+import static io.netflix.titus.common.util.code.CodeInvariants.codeInvariants;
+
+/**
+ * Helper class for evaluating which tasks from a job active task set should be terminated during scale down process.
+ * Terminating tasks in random order might result in an undesired task setup, like having all tasks running on one agent
+ * instance (availability issue) or in a single zone.
+ * <p>
+ * As Titus does not support scale down polices that would allow a user to define explicitly the termination rules, we
+ * provide here a set of reasonable rules, that should give much better behavior than blind task termination.
+ * <p>
+ * <h1>Termination steps</h1>
+ * An active task can be in one of the following states: Active, Launched, StartInitiated, Started and KillInitiated.
+ * To maximize system availability, we consider for termination tasks in Started state only if there are no tasks in other
+ * states.
+ * <p>
+ * <h2>Step 1: scale down task in KillInitiated state</h2>
+ * As tasks in these state are in the termination process already, scaling them down means they should not be restarted after
+ * they move to Finished state.
+ * <p>
+ * <h2>Step 2: scale down tasks in Accepted state</h2>
+ * These task have no resources allocated yet, and it is not guaranteed that they can be successfully started.
+ * Tasks in Accepted state are not yet associated with any agent, so no additional rules must be applied here.
+ * <p>
+ * <h2>Step 3: scale down tasks in Launched and StartInitiated states</h2>
+ * These states can be considered as equivalent. The group of tasks with these states should be evaluated according
+ * to rules defined in 'Equivalent group termination rules' in section below.
+ * <p>
+ * <h2>Step 4: scale down tasks in Started state</h2>
+ * As in step 3, this task set should be evaluated according to rules defined in 'Equivalent group termination rules'.
+ * <p>
+ * <h1>Equivalent group termination rules</h1>
+ * <p>
+ * The selection process described below is applied repeatedly until desired number of tasks is terminated. At each
+ * step a subset of tasks is selected. The last step ('Terminate oldest task first'), makes final selection.
+ * <p>
+ * <h2>Scale down largest groups of task on an agent</h2>
+ * To maximize availability we should eliminate large groups of tasks running on the same agent.
+ * <p>
+ * <h2>Enforce zone balancing</h2>
+ * We want our tasks to be zone balanced (if applicable), If one zone runs more tasks than the other, we should terminate
+ * tasks in this zone first.
+ * <p>
+ * <h2>Terminate oldest task first</h2>
+ * From the give collection of tasks, pick one with the oldest creation timestamp and terminate it.
+ * If there are more tasks to terminate, restart the evaluation process.
+ */
+class ScaleDownEvaluator {
+
+    static List<ServiceJobTask> selectTasksToTerminate(List<ServiceJobTask> allTasks, int expectedSize) {
+        int targetTerminateCount = allTasks.size() - expectedSize;
+        if (targetTerminateCount <= 0) {
+            return Collections.emptyList();
+        }
+
+        List<ServiceJobTask> tasksToKill = new ArrayList<>();
+
+        // Step 1: scale down task in KillInitiated state
+        Pair<List<ServiceJobTask>, List<ServiceJobTask>> killInitiatedAndRunnableGroups = splitIntoKillInitiatedAndRunnableGroups(allTasks);
+        if (appendCandidatesToTerminate(tasksToKill, killInitiatedAndRunnableGroups.getLeft(), targetTerminateCount)) {
+            return tasksToKill;
+        }
+        List<ServiceJobTask> runnableTasks = killInitiatedAndRunnableGroups.getRight();
+
+        // Step 2: scale down tasks in Accepted state
+        Pair<List<ServiceJobTask>, List<ServiceJobTask>> acceptedAndPlacedOnAgentsGroup = splitIntoAcceptedAndPlacedOnAgentsGroup(runnableTasks);
+        if (appendCandidatesToTerminate(tasksToKill, acceptedAndPlacedOnAgentsGroup.getLeft(), targetTerminateCount)) {
+            return tasksToKill;
+        }
+        List<ServiceJobTask> tasksOnAgent = acceptedAndPlacedOnAgentsGroup.getRight();
+
+        // Step 3: scale down tasks in Launched and StartInitiated states
+        Pair<List<ServiceJobTask>, List<ServiceJobTask>> notStartedAndStartedTaskGroups = splitIntoNotStartedAndStartedTaskGroups(tasksOnAgent);
+        List<ServiceJobTask> notStartedToRemove = selectTasksToTerminateInEquivalenceGroup(notStartedAndStartedTaskGroups.getLeft(), targetTerminateCount - tasksToKill.size());
+        if (appendCandidatesToTerminate(tasksToKill, notStartedToRemove, targetTerminateCount)) {
+            return tasksToKill;
+        }
+        List<ServiceJobTask> startedTasks = notStartedAndStartedTaskGroups.getRight();
+
+        // Step 4: scale down tasks in Started state
+        List<ServiceJobTask> startedToRemove = selectTasksToTerminateInEquivalenceGroup(startedTasks, targetTerminateCount - tasksToKill.size());
+        appendCandidatesToTerminate(tasksToKill, startedToRemove, targetTerminateCount);
+
+        // Extra check in case we messed up somewhere.
+        if (tasksToKill.size() != targetTerminateCount) {
+            codeInvariants().inconsistent("Wrong number of tasks to terminate %s (expected) != %s (actual). Got list: %s", targetTerminateCount, tasksToKill.size(), tasksToKill);
+            if (tasksToKill.size() > targetTerminateCount) {
+                tasksToKill = tasksToKill.subList(0, targetTerminateCount);
+            }
+        }
+
+        return tasksToKill;
+    }
+
+    private static boolean appendCandidatesToTerminate(List<ServiceJobTask> accumulator, List<ServiceJobTask> candidates, int targetTerminateCount) {
+        if (accumulator.size() + candidates.size() >= targetTerminateCount) {
+            accumulator.addAll(candidates.subList(0, targetTerminateCount - accumulator.size()));
+            return true;
+        }
+        accumulator.addAll(candidates);
+        return false;
+    }
+
+    private static Pair<List<ServiceJobTask>, List<ServiceJobTask>> splitIntoKillInitiatedAndRunnableGroups(List<ServiceJobTask> tasks) {
+        return CollectionsExt.split(tasks, t -> t.getStatus().getState() == TaskState.KillInitiated);
+    }
+
+    private static Pair<List<ServiceJobTask>, List<ServiceJobTask>> splitIntoAcceptedAndPlacedOnAgentsGroup(List<ServiceJobTask> tasks) {
+        return CollectionsExt.split(tasks, t -> t.getStatus().getState() == TaskState.Accepted);
+    }
+
+    private static Pair<List<ServiceJobTask>, List<ServiceJobTask>> splitIntoNotStartedAndStartedTaskGroups(List<ServiceJobTask> tasks) {
+        return CollectionsExt.split(tasks, t -> t.getStatus().getState() != TaskState.Started);
+    }
+
+    private static List<ServiceJobTask> selectTasksToTerminateInEquivalenceGroup(List<ServiceJobTask> allTasks, int targetTerminateCount) {
+        List<ServiceJobTask> tasksToKill = new ArrayList<>();
+        Region region = new Region(allTasks);
+
+        while (tasksToKill.size() < targetTerminateCount && region.hasMoreTasks()) {
+            // Step 1: select largest groups of tasks to scale down
+            int largestGroup = region.getLargestTaskGroup();
+
+            // Step 2: kill tasks from the largest groups, trying to maintain zone balancing
+            boolean hasMore = true;
+            while (tasksToKill.size() < targetTerminateCount && hasMore) {
+                Optional<Zone> zoneOpt = region.getLargestZoneWithTaskGroupSize(largestGroup);
+                if (hasMore = zoneOpt.isPresent()) {
+                    // Step 3: remove oldest task
+                    Optional<ServiceJobTask> removedTask = zoneOpt.get().removeOldestTaskFromLargestTaskGroup();
+                    removedTask.ifPresent(tasksToKill::add);
+                    if (!removedTask.isPresent()) {
+                        codeInvariants().inconsistent("Expected task, but found nothing. Terminating evaluation loop of job %s", allTasks.get(0).getJobId());
+                        return tasksToKill;
+                    }
+                }
+            }
+        }
+
+        return tasksToKill;
+    }
+
+    static class Region {
+
+        private final Map<String, Zone> zones;
+
+        Region(List<ServiceJobTask> allTasks) {
+            Map<String, List<ServiceJobTask>> byZone = new HashMap<>();
+            allTasks.forEach(task -> byZone.computeIfAbsent(toZoneId(task), t -> new ArrayList<>()).add(task));
+            this.zones = byZone.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> new Zone(e.getValue())));
+        }
+
+        String toZoneId(Task task) {
+            return task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE, "default");
+        }
+
+        int getLargestTaskGroup() {
+            return zones.values().stream().mapToInt(Zone::getLargestTaskGroupSize).max().orElse(0);
+        }
+
+        Optional<Zone> getLargestZoneWithTaskGroupSize(int largestGroup) {
+            Zone selectedZone = null;
+            for (Zone zone : zones.values()) {
+                if (zone.getLargestTaskGroupSize() >= largestGroup) {
+                    if (selectedZone == null) {
+                        selectedZone = zone;
+                    } else {
+                        if (selectedZone.getTaskCount() < zone.getTaskCount()) {
+                            selectedZone = zone;
+                        }
+                    }
+                }
+            }
+            return Optional.ofNullable(selectedZone);
+        }
+
+        boolean hasMoreTasks() {
+            return zones.values().stream().anyMatch(z -> z.getTaskCount() > 0);
+        }
+    }
+
+    static class Zone {
+
+        private final Map<String, List<ServiceJobTask>> tasksByAgentId;
+        private int taskCount;
+
+        Zone(List<ServiceJobTask> tasks) {
+            this.taskCount = tasks.size();
+            this.tasksByAgentId = new HashMap<>();
+            tasks.forEach(task -> tasksByAgentId.computeIfAbsent(toAgentId(task), t -> new ArrayList<>()).add(task));
+        }
+
+        String toAgentId(Task task) {
+            return task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, "default");
+        }
+
+        int getLargestTaskGroupSize() {
+            return tasksByAgentId.values().stream().mapToInt(List::size).max().orElse(0);
+        }
+
+        Optional<ServiceJobTask> removeOldestTaskFromLargestTaskGroup() {
+            if (taskCount == 0) {
+                return Optional.empty();
+            }
+            return tasksByAgentId.entrySet().stream()
+                    .max(Comparator.comparingInt(l -> l.getValue().size()))
+                    .map(largestGroupEntry -> {
+                                List<ServiceJobTask> tasks = largestGroupEntry.getValue();
+                                int bestIdx = 0;
+                                for (int i = 1; i < tasks.size(); i++) {
+                                    if (tasks.get(bestIdx).getStatus().getTimestamp() > tasks.get(i).getStatus().getTimestamp()) {
+                                        bestIdx = i;
+                                    }
+                                }
+                                taskCount--;
+                                return tasks.remove(bestIdx);
+                            }
+                    );
+        }
+
+        int getTaskCount() {
+            return taskCount;
+        }
+    }
+}

--- a/titus-server-master/src/test/java/io/netflix/titus/master/jobmanager/service/service/ScaleDownEvaluatorTest.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/jobmanager/service/service/ScaleDownEvaluatorTest.java
@@ -1,0 +1,138 @@
+package io.netflix.titus.master.jobmanager.service.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+import io.netflix.titus.api.jobmanager.model.job.ServiceJobTask;
+import io.netflix.titus.api.jobmanager.model.job.Task;
+import io.netflix.titus.api.jobmanager.model.job.TaskState;
+import io.netflix.titus.api.jobmanager.model.job.TaskStatus;
+import io.netflix.titus.common.data.generator.DataGenerator;
+import io.netflix.titus.runtime.endpoint.v3.grpc.TaskAttributes;
+import org.junit.Test;
+
+import static io.netflix.titus.api.jobmanager.model.job.JobFunctions.changeServiceJobCapacity;
+import static io.netflix.titus.common.util.CollectionsExt.first;
+import static io.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskServiceJobDescriptor;
+import static io.netflix.titus.testkit.model.job.JobGenerator.serviceJobs;
+import static io.netflix.titus.testkit.model.job.JobGenerator.serviceTasks;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScaleDownEvaluatorTest {
+
+    private DataGenerator<ServiceJobTask> taskDataGenerator = serviceTasks(
+            serviceJobs(changeServiceJobCapacity(oneTaskServiceJobDescriptor(), 1_000)).getValue()
+    );
+
+    @Test
+    public void testTasksInKillInitiatedStateAreSelectedFirst() {
+        List<ServiceJobTask> tasks = asList(
+                nextTask("zoneA", "agentA1", TaskState.Accepted),
+                nextTask("zoneA", "agentA1", TaskState.KillInitiated),
+                nextTask("zoneB", "agentB1", TaskState.Started),
+                nextTask("zoneB", "agentB1", TaskState.KillInitiated)
+        );
+        evaluateAndCheck(tasks, 3, TaskState.KillInitiated);
+        evaluateAndCheck(tasks, 2, TaskState.KillInitiated);
+    }
+
+    @Test
+    public void testTasksInAcceptedStateAreSelectedAfterTasksInKillInitiatedState() {
+        List<ServiceJobTask> tasks = asList(
+                nextTask("zoneA", "agentA1", TaskState.Accepted),
+                nextTask("zoneA", "agentA1", TaskState.Started),
+                nextTask("zoneA", "agentA1", TaskState.KillInitiated),
+                nextTask("zoneB", "agentB1", TaskState.Accepted),
+                nextTask("zoneB", "agentB1", TaskState.Started),
+                nextTask("zoneB", "agentB1", TaskState.KillInitiated)
+        );
+        evaluateAndCheck(tasks, 3, TaskState.KillInitiated, 2, TaskState.Accepted, 1);
+        evaluateAndCheck(tasks, 2, TaskState.KillInitiated, 2, TaskState.Accepted, 2);
+    }
+
+    @Test
+    public void testTasksInLaunchedOrStartInitiatedStateAreSelectedBeforeTasksInStartedState() {
+        List<ServiceJobTask> tasks = asList(
+                nextTask("zoneA", "agentA1", TaskState.Launched),
+                nextTask("zoneA", "agentA1", TaskState.Started),
+                nextTask("zoneB", "agentB1", TaskState.StartInitiated),
+                nextTask("zoneB", "agentB1", TaskState.Started)
+        );
+        evaluateAndCheck(tasks, 2, TaskState.Launched, 1, TaskState.StartInitiated, 1);
+    }
+
+    @Test
+    public void testScaleDownToZero() {
+        List<ServiceJobTask> tasks = asList(
+                nextTask("zoneA", "agentA1", TaskState.Launched),
+                nextTask("zoneA", "agentA1", TaskState.StartInitiated),
+                nextTask("zoneB", "agentB1", TaskState.Started),
+                nextTask("zoneB", "agentB1", TaskState.KillInitiated)
+        );
+        List<ServiceJobTask> toRemove = doEvaluate(tasks, 0);
+        assertThat(toRemove).hasSize(4);
+    }
+
+    @Test
+    public void testLargeTaskGroupsAreScaledDownFirst() {
+        List<ServiceJobTask> tasks = asList(
+                nextTask("zoneA", "agentA1", TaskState.Launched),
+                nextTask("zoneB", "agentB1", TaskState.Launched),
+                nextTask("zoneB", "agentB1", TaskState.Launched),
+                nextTask("zoneB", "agentB1", TaskState.StartInitiated),
+                nextTask("zoneB", "agentB1", TaskState.StartInitiated),
+                nextTask("zoneB", "agentB1", TaskState.StartInitiated),
+                nextTask("zoneC", "agentC1", TaskState.Launched)
+        );
+        List<ServiceJobTask> toRemove = doEvaluate(tasks, 3);
+        Map<String, List<ServiceJobTask>> toRemoveGrouped = groupByZone(toRemove);
+        assertThat(toRemoveGrouped).hasSize(1);
+        assertThat(first(toRemoveGrouped.keySet())).isEqualTo("zoneB");
+        assertThat(toRemoveGrouped.get("zoneB")).hasSize(4);
+    }
+
+    private List<ServiceJobTask> doEvaluate(List<ServiceJobTask> tasks, int expectedSize) {
+        List<ServiceJobTask> toRemove = ScaleDownEvaluator.selectTasksToTerminate(tasks, expectedSize);
+        checkAreForDuplicates(toRemove);
+        return toRemove;
+    }
+
+    private void evaluateAndCheck(List<ServiceJobTask> tasks, int expectedSize, TaskState expectedSelectedTasksState) {
+        List<ServiceJobTask> toRemove = doEvaluate(tasks, expectedSize);
+        assertThat(toRemove).hasSize(tasks.size() - expectedSize);
+        toRemove.forEach(t -> assertThat(t.getStatus().getState()).isEqualTo(expectedSelectedTasksState));
+    }
+
+    private void evaluateAndCheck(List<ServiceJobTask> tasks, int expectedSize, TaskState expectedState1, int expectedSize1, TaskState expectedState2, int expectedSize2) {
+        List<ServiceJobTask> toRemove = doEvaluate(tasks, expectedSize);
+        assertThat(toRemove).hasSize(tasks.size() - expectedSize);
+        Map<TaskState, List<ServiceJobTask>> byState = toRemove.stream().collect(Collectors.groupingBy(t -> t.getStatus().getState()));
+        assertThat(byState.get(expectedState1)).hasSize(expectedSize1);
+        assertThat(byState.get(expectedState2)).hasSize(expectedSize2);
+    }
+
+    private void checkAreForDuplicates(List<ServiceJobTask> tasks) {
+        List<String> duplicatedIds = tasks.stream().collect(Collectors.groupingBy(Task::getId)).values().stream()
+                .filter(v -> v.size() > 1).map(l -> l.get(0).getId()).collect(Collectors.toList());
+        assertThat(duplicatedIds).isEmpty();
+    }
+
+    private Map<String, List<ServiceJobTask>> groupByZone(List<ServiceJobTask> toRemove) {
+        return toRemove.stream().collect(Collectors.groupingBy(t -> t.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE)));
+    }
+
+    private ServiceJobTask nextTask(String zoneId, String agentId, TaskState taskState) {
+        ServiceJobTask task = taskDataGenerator.getValue().toBuilder()
+                .withStatus(TaskStatus.newBuilder().withState(taskState).build())
+                .withTaskContext(ImmutableMap.of(
+                        TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE, zoneId,
+                        TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, agentId
+                ))
+                .build();
+        this.taskDataGenerator = taskDataGenerator.apply();
+        return task;
+    }
+}

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/agent/player/ContainerPlayersManager.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/agent/player/ContainerPlayersManager.java
@@ -55,6 +55,7 @@ public class ContainerPlayersManager {
                 return false;
             }
             jobPlayer = new JobPlayer(parseResult, scheduler);
+            jobPlayers.put(taskHolder.getJobId(), jobPlayer);
         }
         jobPlayer.play(taskHolder);
         return true;

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/stack/EmbeddedTitusStackRunner.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/stack/EmbeddedTitusStackRunner.java
@@ -30,6 +30,7 @@ public class EmbeddedTitusStackRunner {
     public static void main(String[] args) throws InterruptedException {
         EmbeddedTitusMaster.Builder masterBuilder = EmbeddedTitusMaster.aTitusMaster()
                 .withProperty("titus.master.grpcServer.v3EnabledApps", ".*")
+                .withProperty("titus.scheduler.globalTaskLaunchingConstraintEvaluatorEnabled", "false")
                 .withApiPort(8080)
                 .withGrpcPort(8090);
 

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/model/job/JobGenerator.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/model/job/JobGenerator.java
@@ -24,6 +24,7 @@ import io.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import io.netflix.titus.api.jobmanager.model.job.JobModel;
 import io.netflix.titus.api.jobmanager.model.job.JobState;
 import io.netflix.titus.api.jobmanager.model.job.JobStatus;
+import io.netflix.titus.api.jobmanager.model.job.ServiceJobTask;
 import io.netflix.titus.api.jobmanager.model.job.TaskState;
 import io.netflix.titus.api.jobmanager.model.job.TaskStatus;
 import io.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
@@ -94,6 +95,22 @@ public class JobGenerator {
                     .withStatus(TaskStatus.newBuilder().withState(TaskState.Accepted).build())
                     .withJobId(batchJob.getId())
                     .withIndex(taskIndex)
+                    .build();
+        });
+    }
+
+    /**
+     * Generates a sequence of tasks for a given job.
+     */
+    public static DataGenerator<ServiceJobTask> serviceTasks(Job<ServiceJobExt> serviceJob) {
+        int size = serviceJob.getJobDescriptor().getExtensions().getCapacity().getDesired();
+        return zip(taskIds(serviceJob.getId(), range(1)), range(0, size)).map(p -> {
+            String taskId = p.getLeft();
+            return ServiceJobTask.newBuilder()
+                    .withId(taskId)
+                    .withOriginalId(taskId)
+                    .withStatus(TaskStatus.newBuilder().withState(TaskState.Accepted).build())
+                    .withJobId(serviceJob.getId())
                     .build();
         });
     }


### PR DESCRIPTION
Terminating tasks in random order might result in an undesired task setup,
like having all tasks running on one agent instance (availability issue) or in a single zone.