### PR TITLE
loadbalancer: reconcile dissociated states

### DIFF
--- a/titus-server-master/src/test/java/io/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerReconcilerTest.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerReconcilerTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -37,6 +38,7 @@ import io.netflix.titus.runtime.endpoint.v3.grpc.TaskAttributes;
 import io.netflix.titus.runtime.store.v3.memory.InMemoryLoadBalancerStore;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.stubbing.OngoingStubbing;
 import rx.Single;
 import rx.observers.AssertableSubscriber;
 import rx.schedulers.Schedulers;
@@ -224,7 +226,7 @@ public class DefaultLoadBalancerReconcilerTest {
     }
 
     @Test
-    public void orphanAssociationsAreSetAsDissociated() {
+    public void orphanAssociationsAreSetAsDissociatedAndRemoved() {
         final JobLoadBalancer jobLoadBalancer = new JobLoadBalancer(jobId, loadBalancerId);
         when(v3JobOperations.getTasks(jobId)).thenThrow(JobManagerException.jobNotFound(jobId));
         when(v3JobOperations.getJob(jobId)).thenReturn(Optional.empty());
@@ -247,12 +249,38 @@ public class DefaultLoadBalancerReconcilerTest {
         testScheduler.advanceTimeBy(delayMs, TimeUnit.MILLISECONDS);
         subscriber.assertNoTerminalEvent().assertNoValues();
 
-        final List<JobLoadBalancerState> associations = store.getAssociations();
-        assertThat(associations).isNotEmpty();
-        for (JobLoadBalancerState association : associations) {
-            assertThat(association.getState()).isEqualTo(JobLoadBalancer.State.Dissociated);
-        }
+        assertThat(store.getAssociations()).isEmpty();
         assertThat(store.getAssociatedLoadBalancersSetForJob(jobId)).isEmpty();
+    }
+
+    @Test
+    public void dissociatedJobsAreNotRemovedUntilAllTargetsAreDeregistered() {
+        final JobLoadBalancer jobLoadBalancer = new JobLoadBalancer(jobId, loadBalancerId);
+        when(v3JobOperations.getTasks(jobId)).thenThrow(JobManagerException.jobNotFound(jobId));
+        when(v3JobOperations.getJob(jobId)).thenReturn(Optional.empty());
+        final OngoingStubbing<Single<Set<String>>> getRegisteredIpsStubbing = when(connector.getRegisteredIps(loadBalancerId));
+        getRegisteredIpsStubbing.thenReturn(Single.just(Collections.singleton("1.2.3.4")));
+        store = new InMemoryLoadBalancerStore();
+        assertThat(store.addOrUpdateLoadBalancer(jobLoadBalancer, JobLoadBalancer.State.Dissociated)
+                .await(5, TimeUnit.SECONDS)).isTrue();
+
+        final LoadBalancerReconciler reconciler = new DefaultLoadBalancerReconciler(configuration, store, connector, loadBalancerJobOperations, testScheduler);
+        final AssertableSubscriber<TargetStateBatchable> subscriber = reconciler.events().test();
+
+        testScheduler.triggerActions();
+        subscriber.assertNotCompleted().assertNoValues();
+
+        testScheduler.advanceTimeBy(delayMs, TimeUnit.MILLISECONDS);
+        subscriber.assertNoTerminalEvent().assertValueCount(1);
+
+        assertThat(store.getAssociations()).isNotEmpty().hasSize(1);
+
+        getRegisteredIpsStubbing.thenReturn(Single.just(Collections.emptySet()));
+
+        testScheduler.advanceTimeBy(delayMs, TimeUnit.MILLISECONDS);
+        subscriber.assertNoTerminalEvent().assertValueCount(1);
+
+        assertThat(store.getAssociations()).isEmpty();
     }
 
     private LoadBalancerConfiguration mockConfigWithDelay(long delayMs) {


### PR DESCRIPTION
... and remove entries when there is nothing else to do with them.

Only remove loadbalancer <-> job associations after all targets from these jobs have been successfully deregistered from load balancers.