### PR TITLE
appscale: runnable was being ignored

### DIFF
--- a/titus-server-master/src/main/java/io/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
@@ -102,7 +102,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
                                   AppScaleManagerConfiguration appScaleManagerConfiguration) {
         this(appScalePolicyStore, cloudAlarmClient, applicationAutoScalingClient, v2JobOperations, v3JobOperations,
                 rxEventBus, registry, appScaleManagerConfiguration,
-                Schedulers.from(Executors.newSingleThreadExecutor(runnable -> new Thread("DefaultAppScaleManager")))
+                Schedulers.from(Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "DefaultAppScaleManager")))
         );
     }
 
@@ -115,8 +115,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
                                   RxEventBus rxEventBus,
                                   Registry registry,
                                   AppScaleManagerConfiguration appScaleManagerConfiguration,
-                                  Scheduler awsInteractionScheduler
-                                  ) {
+                                  Scheduler awsInteractionScheduler) {
         this.appScalePolicyStore = appScalePolicyStore;
         this.cloudAlarmClient = cloudAlarmClient;
         this.appAutoScalingClient = applicationAutoScalingClient;


### PR DESCRIPTION
We need to use the runnable in the ThreadFactory, otherwise the scheduler will never execute anything.