### PR TITLE
Task migration fails on v3 task when it is already finished

### DIFF
--- a/titus-server-master/src/main/java/io/netflix/titus/master/taskmigration/V3TaskMigrationDetails.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/taskmigration/V3TaskMigrationDetails.java
@@ -27,6 +27,7 @@ import io.netflix.titus.api.jobmanager.model.job.Task;
 import io.netflix.titus.api.jobmanager.model.job.TaskState;
 import io.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import io.netflix.titus.api.jobmanager.model.job.migration.MigrationDetails;
+import io.netflix.titus.api.jobmanager.service.JobManagerException;
 import io.netflix.titus.api.jobmanager.service.V3JobOperations;
 import io.netflix.titus.api.jobmanager.service.V3JobOperations.Trigger;
 import io.netflix.titus.common.util.tuple.Pair;
@@ -145,20 +146,11 @@ public class V3TaskMigrationDetails implements TaskMigrationDetails {
     }
 
     public Job<?> getJob() {
-        Optional<Job<?>> jobOpt = v3JobOperations.getJob(jobId);
-        if (!jobOpt.isPresent()) {
-            throw new IllegalStateException("jobId: " + jobId + " was not present");
-        }
-        return jobOpt.get();
+        return v3JobOperations.getJob(jobId).orElseThrow(() -> JobManagerException.jobNotFound(jobId));
     }
 
     public Task getTask() {
-        Optional<Pair<Job<?>, Task>> taskByIdOpt = v3JobOperations.findTaskById(taskId);
-        if (!taskByIdOpt.isPresent()) {
-            throw new IllegalStateException("taskId: " + taskId + " was not present");
-        }
-        Pair<Job<?>, Task> jobTaskPair = taskByIdOpt.get();
-        return jobTaskPair.getRight();
+        return v3JobOperations.findTaskById(taskId).map(Pair::getRight).orElseThrow(() -> JobManagerException.taskNotFound(taskId));
     }
 
     public V3JobOperations getV3JobOperations() {

--- a/titus-server-master/src/main/java/io/netflix/titus/master/taskmigration/job/DefaultTaskMigrationManager.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/taskmigration/job/DefaultTaskMigrationManager.java
@@ -26,6 +26,7 @@ import io.netflix.titus.api.jobmanager.model.job.Capacity;
 import io.netflix.titus.api.jobmanager.model.job.Task;
 import io.netflix.titus.api.jobmanager.model.job.TaskState;
 import io.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
+import io.netflix.titus.api.jobmanager.service.JobManagerException;
 import io.netflix.titus.api.jobmanager.service.V3JobOperations;
 import io.netflix.titus.api.model.v2.V2JobState;
 import io.netflix.titus.api.model.v2.WorkerNaming;
@@ -197,6 +198,12 @@ public class DefaultTaskMigrationManager implements TaskMigrationManager {
                         }
                     }
                 }
+            }
+        } catch (JobManagerException e) {
+            if (e.getErrorCode() == JobManagerException.ErrorCode.JobNotFound || e.getErrorCode() == JobManagerException.ErrorCode.TaskNotFound) {
+                logger.info("Job/task already terminated. Migration not needed: {}", e.getMessage());
+            } else {
+                logger.error("Unable to migrate tasks for jobId: {} with error:", jobId, e);
             }
         } catch (Exception e) {
             logger.error("Unable to migrate tasks for jobId: {} with error:", jobId, e);

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/endpoint/SimulatedCloudGateway.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/endpoint/SimulatedCloudGateway.java
@@ -11,11 +11,14 @@ import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedInstance;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedInstanceGroup;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedInstanceGroup.Capacity;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedTask;
+import io.netflix.titus.common.aws.AwsInstanceType;
 import io.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
 import io.netflix.titus.testkit.embedded.cloud.agent.SimulatedTitusAgent;
 import io.netflix.titus.testkit.embedded.cloud.agent.SimulatedTitusAgentCluster;
 import io.netflix.titus.testkit.embedded.cloud.agent.TaskExecutorHolder;
 import org.apache.mesos.Protos;
+
+import static io.netflix.titus.testkit.embedded.cloud.model.SimulatedAgentGroupDescriptor.awsInstanceGroup;
 
 @Singleton
 public class SimulatedCloudGateway {
@@ -36,6 +39,10 @@ public class SimulatedCloudGateway {
                 .filter(g -> instanceGroupIds.contains(g.getName()))
                 .map(this::toSimulatedInstanceGroup)
                 .collect(Collectors.toList());
+    }
+
+    public void addInstanceGroup(String id, AwsInstanceType instanceType, int min, int desired, int max) {
+        simulatedCloud.createAgentInstanceGroups(awsInstanceGroup(id, instanceType, min, desired, max));
     }
 
     public List<SimulatedInstance> getInstances(String instanceGroupId) {

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/endpoint/rest/SimulatedAgentsServiceResource.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/endpoint/rest/SimulatedAgentsServiceResource.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -20,7 +21,9 @@ import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedInstance;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedInstanceGroup;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedTask;
 import com.sun.jersey.spi.resource.Singleton;
+import io.netflix.titus.common.aws.AwsInstanceType;
 import io.netflix.titus.testkit.embedded.cloud.endpoint.SimulatedCloudGateway;
+import io.netflix.titus.testkit.embedded.cloud.endpoint.rest.representation.AddSimulatedInstanceGroup;
 
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -42,6 +45,19 @@ public class SimulatedAgentsServiceResource {
             return gateway.getAllInstanceGroups();
         }
         return gateway.getInstanceGroups(new HashSet<>(ids));
+    }
+
+    @POST
+    @Path("/instanceGroups")
+    public Response addInstanceGroup(AddSimulatedInstanceGroup newInstanceGroup) {
+        gateway.addInstanceGroup(
+                newInstanceGroup.getId(),
+                AwsInstanceType.withName(newInstanceGroup.getInstanceType()),
+                newInstanceGroup.getMin(),
+                newInstanceGroup.getDesired(),
+                newInstanceGroup.getMax()
+        );
+        return Response.noContent().build();
     }
 
     @GET

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/endpoint/rest/representation/AddSimulatedInstanceGroup.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/endpoint/rest/representation/AddSimulatedInstanceGroup.java
@@ -1,0 +1,46 @@
+package io.netflix.titus.testkit.embedded.cloud.endpoint.rest.representation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AddSimulatedInstanceGroup {
+
+    private final String id;
+    private final String instanceType;
+    private final int min;
+    private final int desired;
+    private final int max;
+
+    @JsonCreator
+    public AddSimulatedInstanceGroup(@JsonProperty("id") String id,
+                                     @JsonProperty("instanceType") String instanceType,
+                                     @JsonProperty("min") int min,
+                                     @JsonProperty("desired") int desired,
+                                     @JsonProperty("max") int max) {
+        this.id = id;
+        this.instanceType = instanceType;
+        this.min = min;
+        this.desired = desired;
+        this.max = max;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getInstanceType() {
+        return instanceType;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getDesired() {
+        return desired;
+    }
+
+    public int getMax() {
+        return max;
+    }
+}

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/perf/load/LoadGenerator.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/perf/load/LoadGenerator.java
@@ -59,8 +59,8 @@ public class LoadGenerator {
         boolean clean = getOptions().hasOption("c");
         int scaleFactor = getIntOpt(cli, 's', 1);
         Map<String, String> config = ImmutableMap.<String, String>builder()
-                .put("scaleFactor", Integer.toString(scaleFactor))
-                .put("clean", Boolean.toString(clean))
+                .put("titus.load.scaleFactor", Integer.toString(scaleFactor))
+                .put("titus.load.clean", Boolean.toString(clean))
                 .build();
 
         this.injector = Guice.createInjector(new AbstractModule() {


### PR DESCRIPTION
A finished task always stays in Fenzo queue for some time. In V2 engine as we use mutable
objects it was not an issue. In V3 engine we need to ask for the latest version of the
job/task which may no longer be in the active data set.

In V3 engine, as everything runs on a reconciler loop, there is some delay between the time
the task state changes to 'Finished', and the time the task is removed from the Fenzo queue.
We could optimize it, and remove from Fenzo much earlier, and thus reduce the delay
from >100ms to single Fenzo loop evaluation time. But this delay we cannot eliminate it
completely. Instead we should change the task migrator implementation to handle this fact directly.