### PR TITLE
Scheduler Improvements

### DIFF
--- a/titus-server-master/src/main/java/io/netflix/titus/master/agent/service/AgentManagementConfiguration.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/agent/service/AgentManagementConfiguration.java
@@ -46,6 +46,12 @@ public interface AgentManagementConfiguration {
     @DefaultValue("600")
     int getAutoScaleRuleCoolDownSec();
 
-    @DefaultValue("1")
+    @DefaultValue("8")
     int getAutoScaleRuleShortfallAdjustingFactor();
+
+    /**
+     * @return whether or not agent management should allow capacity updates to instance groups
+     */
+    @DefaultValue("true")
+    boolean isInstanceGroupUpdateCapacityEnabled();
 }

--- a/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/SchedulerConfiguration.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/SchedulerConfiguration.java
@@ -62,6 +62,14 @@ public interface SchedulerConfiguration {
     @DefaultValue("true")
     boolean isExitUponFenzoSchedulingErrorEnabled();
 
+    /**
+     * An option to enable fenzo downscaling of agents.
+     *
+     * @return whether or not fenzo should downscale agents.
+     */
+    @DefaultValue("true")
+    boolean isFenzoDownScalingEnabled();
+
     @DefaultValue("30000")
     long getTierSlaUpdateIntervalMs();
 

--- a/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/AgentFitnessCalculator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/AgentFitnessCalculator.java
@@ -69,7 +69,8 @@ public class AgentFitnessCalculator implements VMTaskFitnessCalculator {
         List<WeightedFitnessCalculator> calculators = new ArrayList<>();
         calculators.add(new WeightedFitnessCalculator(BinPackingFitnessCalculators.cpuMemBinPacker, 0.1));
         calculators.add(new WeightedFitnessCalculator(new JobTypeFitnessCalculator(), 0.1));
-        calculators.add(new WeightedFitnessCalculator(new JobSpreadingFitnessCalculator(), 0.8));
+        calculators.add(new WeightedFitnessCalculator(new ImageSpreadingFitnessCalculator(), 0.2));
+        calculators.add(new WeightedFitnessCalculator(new SecurityGroupSpreadingFitnessCalculator(), 0.6));
         return new WeightedAverageFitnessCalculator(calculators);
     }
 
@@ -77,8 +78,8 @@ public class AgentFitnessCalculator implements VMTaskFitnessCalculator {
         List<WeightedFitnessCalculator> calculators = new ArrayList<>();
         calculators.add(new WeightedFitnessCalculator(new JobTypeFitnessCalculator(), 0.1));
         calculators.add(new WeightedFitnessCalculator(BinPackingFitnessCalculators.cpuMemBinPacker, 0.2));
-        calculators.add(new WeightedFitnessCalculator(new ImageFitnessCalculator(agentResourceCache), 0.3));
-        calculators.add(new WeightedFitnessCalculator(new SecurityGroupFitnessCalculator(agentResourceCache), 0.4));
+        calculators.add(new WeightedFitnessCalculator(new CachedImageFitnessCalculator(agentResourceCache), 0.3));
+        calculators.add(new WeightedFitnessCalculator(new CachedSecurityGroupFitnessCalculator(agentResourceCache), 0.4));
         return new WeightedAverageFitnessCalculator(calculators);
     }
 
@@ -86,8 +87,8 @@ public class AgentFitnessCalculator implements VMTaskFitnessCalculator {
         List<WeightedFitnessCalculator> calculators = new ArrayList<>();
         calculators.add(new WeightedFitnessCalculator(BinPackingFitnessCalculators.cpuMemBinPacker, 0.2));
         calculators.add(new WeightedFitnessCalculator(new JobTypeFitnessCalculator(), 0.2));
-        calculators.add(new WeightedFitnessCalculator(new ImageFitnessCalculator(agentResourceCache), 0.3));
-        calculators.add(new WeightedFitnessCalculator(new SecurityGroupFitnessCalculator(agentResourceCache), 0.3));
+        calculators.add(new WeightedFitnessCalculator(new CachedImageFitnessCalculator(agentResourceCache), 0.3));
+        calculators.add(new WeightedFitnessCalculator(new CachedSecurityGroupFitnessCalculator(agentResourceCache), 0.3));
         return new WeightedAverageFitnessCalculator(calculators);
     }
 }

--- a/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/CachedImageFitnessCalculator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/CachedImageFitnessCalculator.java
@@ -22,43 +22,46 @@ import com.netflix.fenzo.TaskRequest;
 import com.netflix.fenzo.TaskTrackerState;
 import com.netflix.fenzo.VMTaskFitnessCalculator;
 import com.netflix.fenzo.VirtualMachineCurrentState;
+import io.netflix.titus.api.jobmanager.model.job.Job;
+import io.netflix.titus.api.store.v2.V2JobMetadata;
+import io.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
+import io.netflix.titus.master.scheduler.ScheduledRequest;
 import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCache;
+import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheImage;
 import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheInstance;
-import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheNetworkInterface;
 
-import static io.netflix.titus.master.scheduler.fitness.FitnessCalculatorFunctions.*;
+import static io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheFunctions.createImage;
+import static io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheFunctions.getImage;
 
 /**
- * A fitness calculator that will prefer placing tasks on agents that have previous launched the containers with
- * the same security groups so that the network interface already exists.
+ * A fitness calculator that will prefer placing tasks on agents that have previous launched the same image so that the
+ * image is already cached.
  */
-public class SecurityGroupFitnessCalculator implements VMTaskFitnessCalculator {
-    private static final double SECURITY_GROUPS_NOT_CACHED_SCORE = 0.01;
-    private static final double SECURITY_GROUPS_CACHED_SCORE = 1.0;
+public class CachedImageFitnessCalculator implements VMTaskFitnessCalculator {
 
+    private static final double IMAGE_NOT_CACHED_SCORE = 0.01;
+    private static final double IMAGE_CACHED_SCORE = 1.0;
     private final AgentResourceCache agentResourceCache;
 
-    public SecurityGroupFitnessCalculator(AgentResourceCache agentResourceCache) {
+    public CachedImageFitnessCalculator(AgentResourceCache agentResourceCache) {
         this.agentResourceCache = agentResourceCache;
     }
 
     @Override
     public String getName() {
-        return "Security Group Fitness Calculator";
+        return "Cached Image Fitness Calculator";
     }
 
     @Override
     public double calculateFitness(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
         Optional<AgentResourceCacheInstance> instanceOpt = agentResourceCache.getActive(targetVM.getHostname());
         if (instanceOpt.isPresent()) {
-            String joinSecurityGroupIds = getJoinedSecurityGroupIds(taskRequest);
             AgentResourceCacheInstance instance = instanceOpt.get();
-            Optional<AgentResourceCacheNetworkInterface> matchingNetworkInterface = instance.getNetworkInterfaces()
-                    .values().stream().filter(i -> i.getJoinedSecurityGroupIds().equals(joinSecurityGroupIds)).findFirst();
-            if (matchingNetworkInterface.isPresent()) {
-                return SECURITY_GROUPS_CACHED_SCORE;
+            AgentResourceCacheImage image = getImage(taskRequest);
+            if (instance.getImages().contains(image)) {
+                return IMAGE_CACHED_SCORE;
             }
         }
-        return SECURITY_GROUPS_NOT_CACHED_SCORE;
+        return IMAGE_NOT_CACHED_SCORE;
     }
 }

--- a/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/CachedSecurityGroupFitnessCalculator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/CachedSecurityGroupFitnessCalculator.java
@@ -22,46 +22,43 @@ import com.netflix.fenzo.TaskRequest;
 import com.netflix.fenzo.TaskTrackerState;
 import com.netflix.fenzo.VMTaskFitnessCalculator;
 import com.netflix.fenzo.VirtualMachineCurrentState;
-import io.netflix.titus.api.jobmanager.model.job.Job;
-import io.netflix.titus.api.store.v2.V2JobMetadata;
-import io.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
-import io.netflix.titus.master.scheduler.ScheduledRequest;
 import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCache;
-import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheImage;
 import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheInstance;
+import io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheNetworkInterface;
 
-import static io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheFunctions.createImage;
-import static io.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheFunctions.getImage;
+import static io.netflix.titus.master.scheduler.fitness.FitnessCalculatorFunctions.*;
 
 /**
- * A fitness calculator that will prefer placing tasks on agents that have previous launched the same image so that the
- * image is already cached.
+ * A fitness calculator that will prefer placing tasks on agents that have previous launched the containers with
+ * the same security groups so that the network interface already exists.
  */
-public class ImageFitnessCalculator implements VMTaskFitnessCalculator {
+public class CachedSecurityGroupFitnessCalculator implements VMTaskFitnessCalculator {
+    private static final double SECURITY_GROUPS_NOT_CACHED_SCORE = 0.01;
+    private static final double SECURITY_GROUPS_CACHED_SCORE = 1.0;
 
-    private static final double IMAGE_NOT_CACHED_SCORE = 0.01;
-    private static final double IMAGE_CACHED_SCORE = 1.0;
     private final AgentResourceCache agentResourceCache;
 
-    public ImageFitnessCalculator(AgentResourceCache agentResourceCache) {
+    public CachedSecurityGroupFitnessCalculator(AgentResourceCache agentResourceCache) {
         this.agentResourceCache = agentResourceCache;
     }
 
     @Override
     public String getName() {
-        return "Image Fitness Calculator";
+        return "Cached Security Group Fitness Calculator";
     }
 
     @Override
     public double calculateFitness(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
         Optional<AgentResourceCacheInstance> instanceOpt = agentResourceCache.getActive(targetVM.getHostname());
         if (instanceOpt.isPresent()) {
+            String joinSecurityGroupIds = getJoinedSecurityGroupIds(taskRequest);
             AgentResourceCacheInstance instance = instanceOpt.get();
-            AgentResourceCacheImage image = getImage(taskRequest);
-            if (instance.getImages().contains(image)) {
-                return IMAGE_CACHED_SCORE;
+            Optional<AgentResourceCacheNetworkInterface> matchingNetworkInterface = instance.getNetworkInterfaces()
+                    .values().stream().filter(i -> i.getJoinedSecurityGroupIds().equals(joinSecurityGroupIds)).findFirst();
+            if (matchingNetworkInterface.isPresent()) {
+                return SECURITY_GROUPS_CACHED_SCORE;
             }
         }
-        return IMAGE_NOT_CACHED_SCORE;
+        return SECURITY_GROUPS_NOT_CACHED_SCORE;
     }
 }

--- a/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/SecurityGroupSpreadingFitnessCalculator.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/scheduler/fitness/SecurityGroupSpreadingFitnessCalculator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netflix.titus.master.scheduler.fitness;
+
+import java.util.List;
+
+import com.netflix.fenzo.TaskRequest;
+import com.netflix.fenzo.TaskTrackerState;
+import com.netflix.fenzo.VMTaskFitnessCalculator;
+import com.netflix.fenzo.VirtualMachineCurrentState;
+
+import static io.netflix.titus.master.scheduler.fitness.FitnessCalculatorFunctions.countMatchingTasks;
+import static io.netflix.titus.master.scheduler.fitness.FitnessCalculatorFunctions.getAllTasksOnAgent;
+
+/**
+ * A fitness calculator that will prefer placing tasks on agents that do not have a task with the same security groups.
+ */
+public class SecurityGroupSpreadingFitnessCalculator implements VMTaskFitnessCalculator {
+    private static final double MATCHING_TASK_SCORE = 0.5;
+    private static final double NO_MATCHING_TASK_SCORE = 1.0;
+
+    @Override
+    public String getName() {
+        return "Security Group Spreading Fitness Calculator";
+    }
+
+    @Override
+    public double calculateFitness(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
+        List<TaskRequest> allTasksOnAgent = getAllTasksOnAgent(targetVM);
+        String currentTaskRequestJoinedSecurityGroupIds = FitnessCalculatorFunctions.getJoinedSecurityGroupIds(taskRequest);
+        long matchingTaskCount = countMatchingTasks(allTasksOnAgent, taskOnAgent -> {
+            String taskOnAgentJoinedSecurityGroupIds = FitnessCalculatorFunctions.getJoinedSecurityGroupIds(taskOnAgent);
+            return currentTaskRequestJoinedSecurityGroupIds.equals(taskOnAgentJoinedSecurityGroupIds);
+        });
+
+        if (matchingTaskCount == 0) {
+            return NO_MATCHING_TASK_SCORE;
+        }
+
+        double matchingTaskRatio = 1.0 / (double) matchingTaskCount;
+        return matchingTaskRatio * MATCHING_TASK_SCORE;
+    }
+}

--- a/titus-server-master/src/test/java/io/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
@@ -60,12 +60,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultAgentManagementServiceTest {
-
+    private final AgentManagementConfiguration configuration = mock(AgentManagementConfiguration.class);
     private final InstanceCloudConnector connector = mock(InstanceCloudConnector.class);
-
     private final AgentCache agentCache = mock(AgentCache.class);
 
-    private final DefaultAgentManagementService service = new DefaultAgentManagementService(connector, agentCache);
+    private final DefaultAgentManagementService service = new DefaultAgentManagementService(configuration, connector, agentCache);
 
     private final PublishSubject<CacheUpdateEvent> agentCacheEventSubject = PublishSubject.create();
     private final ExtTestSubscriber<AgentEvent> eventSubscriber = new ExtTestSubscriber<>();
@@ -82,6 +81,8 @@ public class DefaultAgentManagementServiceTest {
         this.serverGroups = agentServerGroups(Tier.Flex, 5).toList(2);
         this.serverGen0 = agentInstances(serverGroups.get(0)).apply(serverSet0::add, 5);
         this.serverGen1 = agentInstances(serverGroups.get(1)).apply(serverSet1::add, 5);
+
+        when(configuration.isInstanceGroupUpdateCapacityEnabled()).thenReturn(true);
 
         when(agentCache.getInstanceGroups()).thenReturn(serverGroups);
         when(agentCache.getInstanceGroup(serverGroups.get(0).getId())).thenReturn(serverGroups.get(0));


### PR DESCRIPTION
- Add flag to disable fenzo downscaling and agent management instance group capacity updates.
- Split out the job spreading fitness calculator into 2 separate calculators to just spread security group combinations and images across as many agents as possible.