### PR TITLE
System level retries

### DIFF
--- a/titus-api/src/main/java/io/netflix/titus/api/model/v2/V2JobState.java
+++ b/titus-api/src/main/java/io/netflix/titus/api/model/v2/V2JobState.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.netflix.titus.api.jobmanager.model.job.TaskState;
-import io.netflix.titus.api.jobmanager.model.job.TaskStatus;
 
 public enum V2JobState {
     Accepted,
@@ -127,24 +126,5 @@ public enum V2JobState {
             case Failed:
         }
         return TaskState.Finished;
-    }
-
-    public static String toV3ReasonCode(V2JobState v2TaskState, JobCompletedReason reason) {
-        if (v2TaskState != V2JobState.Failed) {
-            return TaskStatus.REASON_NORMAL;
-        }
-        switch (reason) {
-            case Normal:
-                return TaskStatus.REASON_NORMAL;
-            case Error:
-                return TaskStatus.REASON_ERROR;
-            case Lost:
-                return TaskStatus.REASON_TASK_LOST;
-            case Killed:
-                return TaskStatus.REASON_TASK_KILLED;
-            case Failed:
-                return TaskStatus.REASON_FAILED;
-        }
-        return TaskStatus.REASON_UNKNOWN;
     }
 }

--- a/titus-common/src/main/java/io/netflix/titus/common/util/RegExpExt.java
+++ b/titus-common/src/main/java/io/netflix/titus/common/util/RegExpExt.java
@@ -1,0 +1,58 @@
+package io.netflix.titus.common.util;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.netflix.titus.common.util.tuple.Pair;
+import org.slf4j.Logger;
+
+public final class RegExpExt {
+
+    private RegExpExt() {
+    }
+
+    /**
+     * Create a {@link Matcher} factory function, with dynamic update of the regular expression pattern.
+     * This class is primarily to be used with patterns setup via dynamic configuration.
+     */
+    public static Function<String, Matcher> dynamicMatcher(Supplier<String> regExpSource, int flags, Consumer<Throwable> onError) {
+        return dynamicMatcherInternal(regExpSource, flags, onError);
+    }
+
+    /**
+     * A convenience wrapper for {@link #dynamicMatcher(Supplier, int, Consumer)} which automatically logs errors to the provided logger.
+     */
+    public static Function<String, Matcher> dynamicMatcher(Supplier<String> regExpSource, String propertyName, int flags, Logger errorLogger) {
+        return dynamicMatcherInternal(
+                regExpSource,
+                flags, e -> errorLogger.warn("Not valid regular expression value in '{}' property: {}", propertyName, e.getMessage())
+        );
+    }
+
+    private static Function<String, Matcher> dynamicMatcherInternal(Supplier<String> regExpSource, int flags, Consumer<Throwable> onError) {
+        String patternString = regExpSource.get();
+        AtomicReference<Pair<String, Pattern>> lastGoodPattern = new AtomicReference<>(Pair.of(patternString, Pattern.compile(patternString, flags)));
+        return text -> {
+            Pair<String, Pattern> current = lastGoodPattern.get();
+
+            String currentPatternString = current.getLeft();
+            String newPatternString = regExpSource.get();
+
+            if (!currentPatternString.equals(newPatternString)) {
+                try {
+                    Pattern newPattern = Pattern.compile(newPatternString, flags);
+                    lastGoodPattern.set(Pair.of(newPatternString, newPattern));
+                    return newPattern.matcher(text);
+                } catch (Exception e) {
+                    onError.accept(e);
+                }
+            }
+
+            return current.getRight().matcher(text);
+        };
+    }
+}

--- a/titus-common/src/test/java/io/netflix/titus/common/util/RegExpExtTest.java
+++ b/titus-common/src/test/java/io/netflix/titus/common/util/RegExpExtTest.java
@@ -1,0 +1,19 @@
+package io.netflix.titus.common.util;
+
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RegExpExtTest {
+
+    @Test
+    public void testDynamicMatcher() {
+        String message = "hello\nend";
+        boolean matches = RegExpExt.dynamicMatcher(() -> ".*hello.*", Pattern.DOTALL, e -> {
+            throw new IllegalStateException(e);
+        }).apply(message).matches();
+        assertThat(matches).isTrue();
+    }
+}

--- a/titus-server-master/src/main/java/io/netflix/titus/master/Status.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/Status.java
@@ -27,8 +27,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netflix.titus.api.model.v2.JobCompletedReason;
 import io.netflix.titus.api.model.v2.V2JobState;
+import io.netflix.titus.master.mesos.ContainerEvent;
 
-public class Status {
+public class Status implements ContainerEvent {
 
     public static class Payload {
         private final String type;

--- a/titus-server-master/src/main/java/io/netflix/titus/master/VirtualMachineMasterService.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/VirtualMachineMasterService.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.netflix.fenzo.VirtualMachineLease;
 import com.netflix.fenzo.functions.Action1;
+import io.netflix.titus.master.mesos.ContainerEvent;
 import org.apache.mesos.Protos;
 import rx.Observable;
 
@@ -35,5 +36,5 @@ public interface VirtualMachineMasterService {
 
     Observable<String> getLeaseRescindedObservable();
 
-    Observable<Status> getTaskStatusObservable();
+    Observable<ContainerEvent> getTaskStatusObservable();
 }

--- a/titus-server-master/src/main/java/io/netflix/titus/master/jobmanager/endpoint/v3/grpc/gateway/V2GrpcModelConverters.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/jobmanager/endpoint/v3/grpc/gateway/V2GrpcModelConverters.java
@@ -80,7 +80,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.netflix.titus.api.jobmanager.model.job.Container.RESOURCE_GPU;
-import static io.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_ERROR;
 import static io.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_FAILED;
 import static io.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_NORMAL;
 import static io.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_TASK_KILLED;
@@ -436,7 +435,7 @@ public final class V2GrpcModelConverters {
                         grpcReason = REASON_NORMAL;
                         break;
                     case Error:
-                        grpcReason = REASON_ERROR;
+                        grpcReason = REASON_FAILED;
                         break;
                     case Lost:
                         grpcReason = REASON_TASK_LOST;

--- a/titus-server-master/src/main/java/io/netflix/titus/master/jobmanager/service/batch/action/CreateOrReplaceBatchTaskActions.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/jobmanager/service/batch/action/CreateOrReplaceBatchTaskActions.java
@@ -137,7 +137,7 @@ public class CreateOrReplaceBatchTaskActions {
                 .withStatus(TaskStatus.newBuilder().withState(TaskState.Accepted).withTimestamp(clock.wallTime()).build())
                 .withOriginalId(oldTask.getOriginalId())
                 .withResubmitOf(oldTask.getId())
-                .withResubmitNumber(oldTask.getResubmitNumber() + 1)
+                .withResubmitNumber(TaskStatus.isSystemError(oldTask.getStatus()) ? oldTask.getResubmitNumber() : oldTask.getResubmitNumber() + 1)
                 .build();
     }
 }

--- a/titus-server-master/src/main/java/io/netflix/titus/master/mesos/ContainerEvent.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/mesos/ContainerEvent.java
@@ -1,0 +1,4 @@
+package io.netflix.titus.master.mesos;
+
+public interface ContainerEvent {
+}

--- a/titus-server-master/src/main/java/io/netflix/titus/master/mesos/MesosConfiguration.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/mesos/MesosConfiguration.java
@@ -1,0 +1,23 @@
+package io.netflix.titus.master.mesos;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+
+@Configuration(prefix = "titus.mesos")
+public interface MesosConfiguration {
+
+    @DefaultValue("invalidRequest")
+    String getInvalidRequestMessagePattern();
+
+    @DefaultValue("crashed")
+    String getCrashedMessagePattern();
+
+    @DefaultValue("transientSystemError")
+    String getTransientSystemErrorMessagePattern();
+
+    @DefaultValue("localSystemError")
+    String getLocalSystemErrorMessagePattern();
+
+    @DefaultValue("unknownSystemError")
+    String getUnknownSystemErrorMessagePattern();
+}

--- a/titus-server-master/src/main/java/io/netflix/titus/master/mesos/MesosModule.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/mesos/MesosModule.java
@@ -16,7 +16,11 @@
 
 package io.netflix.titus.master.mesos;
 
+import javax.inject.Singleton;
+
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.runtime.health.guice.HealthModule;
 import io.netflix.titus.master.VirtualMachineMasterService;
 import io.netflix.titus.master.mesos.resolver.DefaultMesosMasterResolver;
@@ -34,5 +38,11 @@ public class MesosModule extends AbstractModule {
                 bindAdditionalHealthIndicator().to(MesosHealthIndicator.class);
             }
         });
+    }
+
+    @Provides
+    @Singleton
+    public MesosConfiguration getMesosConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(MesosConfiguration.class);
     }
 }

--- a/titus-server-master/src/main/java/io/netflix/titus/master/mesos/V3ContainerEvent.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/mesos/V3ContainerEvent.java
@@ -1,0 +1,53 @@
+package io.netflix.titus.master.mesos;
+
+import java.util.Optional;
+
+import io.netflix.titus.api.jobmanager.model.job.TaskState;
+
+public class V3ContainerEvent implements ContainerEvent {
+
+    private final String taskId;
+    private final TaskState taskState;
+    private final String reasonCode;
+    private final String reasonMessage;
+    private final long timestamp;
+    private final Optional<TitusExecutorDetails> titusExecutorDetails;
+
+    public V3ContainerEvent(String taskId,
+                            TaskState taskState,
+                            String reasonCode,
+                            String reasonMessage,
+                            long timestamp,
+                            Optional<TitusExecutorDetails> titusExecutorDetails) {
+        this.taskId = taskId;
+        this.taskState = taskState;
+        this.reasonCode = reasonCode;
+        this.reasonMessage = reasonMessage;
+        this.timestamp = timestamp;
+        this.titusExecutorDetails = titusExecutorDetails;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public TaskState getTaskState() {
+        return taskState;
+    }
+
+    public String getReasonCode() {
+        return reasonCode;
+    }
+
+    public String getReasonMessage() {
+        return reasonMessage;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public Optional<TitusExecutorDetails> getTitusExecutorDetails() {
+        return titusExecutorDetails;
+    }
+}

--- a/titus-server-master/src/main/java/io/netflix/titus/master/mesos/VirtualMachineMasterServiceMesosImpl.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/mesos/VirtualMachineMasterServiceMesosImpl.java
@@ -69,9 +69,10 @@ public class VirtualMachineMasterServiceMesosImpl implements VirtualMachineMaste
     private SchedulerDriver mesosDriver;
     private MesosSchedulerCallbackHandler mesosCallbackHandler;
     private ExecutorService executor;
+    private final MesosConfiguration mesosConfiguration;
     private MesosMasterResolver mesosMasterResolver;
     private Subject<String, String> vmLeaseRescindedObserver;
-    private Subject<Status, Status> vmTaskStatusObserver;
+    private Subject<ContainerEvent, ContainerEvent> vmTaskStatusObserver;
     private ObjectMapper mapper = new ObjectMapper();
     private final AtomicBoolean initializationDone = new AtomicBoolean(false);
     private double offerSecDelayInterval = 5;
@@ -85,11 +86,13 @@ public class VirtualMachineMasterServiceMesosImpl implements VirtualMachineMaste
     @Inject
     public VirtualMachineMasterServiceMesosImpl(MasterConfiguration config,
                                                 SchedulerConfiguration schedulerConfiguration,
+                                                MesosConfiguration mesosConfiguration,
                                                 MesosMasterResolver mesosMasterResolver,
                                                 MesosSchedulerDriverFactory mesosDriverFactory,
                                                 Injector injector,
                                                 Registry metricsRegistry) {
         this.config = config;
+        this.mesosConfiguration = mesosConfiguration;
         this.mesosMasterResolver = mesosMasterResolver;
         this.mesosDriverFactory = mesosDriverFactory;
         this.injector = injector;
@@ -208,7 +211,7 @@ public class VirtualMachineMasterServiceMesosImpl implements VirtualMachineMaste
     }
 
     @Override
-    public Observable<Status> getTaskStatusObservable() {
+    public Observable<ContainerEvent> getTaskStatusObservable() {
         return vmTaskStatusObserver;
     }
 
@@ -225,7 +228,7 @@ public class VirtualMachineMasterServiceMesosImpl implements VirtualMachineMaste
         }
 
         mesosCallbackHandler = new MesosSchedulerCallbackHandler(leaseHandler, vmLeaseRescindedObserver, vmTaskStatusObserver,
-                v2JobOperations, v3JobOperations, config, metricsRegistry);
+                v2JobOperations, v3JobOperations, config, mesosConfiguration, metricsRegistry);
 
         FrameworkInfo framework = FrameworkInfo.newBuilder()
                 .setUser("root") // Fix to root, to enable running master as non-root

--- a/titus-server-master/src/test/java/io/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
@@ -52,6 +52,7 @@ import io.netflix.titus.common.util.tuple.Pair;
 import io.netflix.titus.master.jobmanager.service.JobManagerUtil;
 import io.netflix.titus.master.jobmanager.service.integration.scenario.StubbedJobStore.StoreEvent;
 import io.netflix.titus.master.jobmanager.service.integration.scenario.StubbedVirtualMachineMasterService.MesosEvent;
+import io.netflix.titus.master.mesos.TitusExecutorDetails;
 import io.netflix.titus.testkit.rx.ExtTestSubscriber;
 import rx.Subscriber;
 import rx.schedulers.TestScheduler;
@@ -476,7 +477,9 @@ public class JobScenarioBuilder<E extends JobDescriptor.JobDescriptorExt> {
         }
 
         AtomicBoolean done = new AtomicBoolean();
-        String data = taskState == TaskState.StartInitiated ? vmService.toString(vmService.buildExecutorDetails(task.getId())) : "";
+        Optional<TitusExecutorDetails> data = taskState == TaskState.StartInitiated
+                ? Optional.of(vmService.buildExecutorDetails(task.getId()))
+                : Optional.empty();
 
         TaskStatus taskStatus = JobModel.newTaskStatus()
                 .withState(taskState)

--- a/titus-server-master/src/test/java/io/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
@@ -28,8 +28,8 @@ import com.netflix.fenzo.functions.Action1;
 import io.netflix.titus.api.json.ObjectMappers;
 import io.netflix.titus.common.util.CollectionsExt;
 import io.netflix.titus.common.util.tuple.Pair;
-import io.netflix.titus.master.Status;
 import io.netflix.titus.master.VirtualMachineMasterService;
+import io.netflix.titus.master.mesos.ContainerEvent;
 import io.netflix.titus.master.mesos.TitusExecutorDetails;
 import org.apache.mesos.Protos;
 import rx.Observable;
@@ -166,7 +166,7 @@ class StubbedVirtualMachineMasterService implements VirtualMachineMasterService 
     }
 
     @Override
-    public Observable<Status> getTaskStatusObservable() {
+    public Observable<ContainerEvent> getTaskStatusObservable() {
         return null;
     }
 }

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/agent/player/ContainerPlayer.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/cloud/agent/player/ContainerPlayer.java
@@ -88,8 +88,6 @@ class ContainerPlayer {
                 return Protos.TaskState.TASK_FAILED;
             case TaskStatus.REASON_TASK_LOST:
                 return Protos.TaskState.TASK_LOST;
-            case TaskStatus.REASON_ERROR:
-                return Protos.TaskState.TASK_ERROR;
         }
         return Protos.TaskState.TASK_ERROR;
     }

--- a/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/master/EmbeddedVirtualMachineMasterService.java
+++ b/titus-testkit/src/main/java/io/netflix/titus/testkit/embedded/master/EmbeddedVirtualMachineMasterService.java
@@ -26,6 +26,7 @@ import javax.inject.Singleton;
 import com.google.inject.Injector;
 import com.netflix.spectator.api.Registry;
 import io.netflix.titus.master.config.MasterConfiguration;
+import io.netflix.titus.master.mesos.MesosConfiguration;
 import io.netflix.titus.master.mesos.MesosMasterResolver;
 import io.netflix.titus.master.mesos.MesosSchedulerDriverFactory;
 import io.netflix.titus.master.mesos.VirtualMachineMasterServiceMesosImpl;
@@ -55,10 +56,11 @@ public class EmbeddedVirtualMachineMasterService extends VirtualMachineMasterSer
     @Inject
     public EmbeddedVirtualMachineMasterService(MasterConfiguration config,
                                                SchedulerConfiguration schedulerConfiguration,
+                                               MesosConfiguration mesosConfiguration,
                                                MesosSchedulerDriverFactory mesosSchedulerDriverFactory,
                                                Injector injector,
                                                Registry metricsRegistry) {
-        super(config, schedulerConfiguration, FIXED_RESOLVER, mesosSchedulerDriverFactory, injector, metricsRegistry);
+        super(config, schedulerConfiguration, mesosConfiguration, FIXED_RESOLVER, mesosSchedulerDriverFactory, injector, metricsRegistry);
     }
 
     SimulatedLocalMesosSchedulerDriver getSimulatedMesosDriver() {


### PR DESCRIPTION
There are a class of transient agent errors that occur before the job is ever scheduled.
Those errors should not be counted as task retries.