### PR TITLE
Enable load balancer gRPC service and engine by default

### DIFF
--- a/titus-server-gateway/src/main/java/io/netflix/titus/gateway/endpoint/v3/grpc/GrpcEndpointConfiguration.java
+++ b/titus-server-gateway/src/main/java/io/netflix/titus/gateway/endpoint/v3/grpc/GrpcEndpointConfiguration.java
@@ -30,7 +30,7 @@ public interface GrpcEndpointConfiguration {
     int getPort();
 
     @PropertyName(name = "loadbalancer.enabled")
-    @DefaultValue("false")
+    @DefaultValue("true")
     boolean getLoadBalancerGrpcEnabled();
 
     /**

--- a/titus-server-master/src/main/java/io/netflix/titus/master/endpoint/grpc/GrpcEndpointConfiguration.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/endpoint/grpc/GrpcEndpointConfiguration.java
@@ -34,7 +34,7 @@ public interface GrpcEndpointConfiguration {
     String getV3EnabledApps();
 
     @PropertyName(name = "loadbalancer.enabled")
-    @DefaultValue("false")
+    @DefaultValue("true")
     boolean getLoadBalancerGrpcEnabled();
 
     /**

--- a/titus-server-master/src/main/java/io/netflix/titus/master/loadbalancer/service/LoadBalancerConfiguration.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/loadbalancer/service/LoadBalancerConfiguration.java
@@ -22,7 +22,7 @@ import com.netflix.archaius.api.annotations.DefaultValue;
 @Configuration(prefix = "titus.master.loadBalancer")
 public interface LoadBalancerConfiguration {
 
-    @DefaultValue("false")
+    @DefaultValue("true")
     boolean isEngineEnabled();
 
     @DefaultValue("4")


### PR DESCRIPTION
This change enables the load balancer feature by default. It has been running in development stacks on for months with no issues. Ideally, this change rolls out in coordination with Spinnaker's UI support.