### PR TITLE
bump integration test timeouts so they get less flaky on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 jdk:
   - oraclejdk8
 sudo: false
-install: "./installViaTravis.sh"
-script: "./buildViaTravis.sh"
+install: ./installViaTravis.sh
+script: travis_wait ./buildViaTravis.sh
 cache:
   directories:
     - "$HOME/.gradle"

--- a/titus-ext/cassandra/src/test/java/io/netflix/titus/ext/cassandra/store/CassAppScalePolicyStoreTest.java
+++ b/titus-ext/cassandra/src/test/java/io/netflix/titus/ext/cassandra/store/CassAppScalePolicyStoreTest.java
@@ -55,7 +55,7 @@ import rx.Observable;
 public class CassAppScalePolicyStoreTest {
     private static Logger log = LoggerFactory.getLogger(CassAppScalePolicyStoreTest.class);
 
-    private static final long STARTUP_TIMEOUT = 30_000L;
+    private static final long STARTUP_TIMEOUT = 60_000L;
     private static final String CONFIGURATION_FILE_NAME = "relocated-cassandra.yaml";
 
     @Rule

--- a/titus-server-master/src/test/java/io/netflix/titus/master/integration/TerminateAndShrinkTest.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/integration/TerminateAndShrinkTest.java
@@ -277,7 +277,7 @@ public class TerminateAndShrinkTest extends BaseIntegrationTest {
                 new JobSetInstanceCountsCmd("myUser", jobId, 21, 0, 100)
         ).toBlocking().firstOrDefault(null);
 
-        await().timeout(10, TimeUnit.SECONDS).until(() -> newHolders.size() == 20);
+        await().timeout(20, TimeUnit.SECONDS).until(() -> newHolders.size() == 20);
         List<TaskExecutorHolder> invalidIndexes = newHolders.stream().filter(h -> TitusTaskIdParser.getTaskIndexFromTaskId(h.getTaskId()) > 20).collect(Collectors.toList());
         assertThat(invalidIndexes).isEmpty();
     }

--- a/titus-server-master/src/test/java/io/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
@@ -144,12 +144,12 @@ public class JobCriteriaQueryTest {
         assertThat(taskQueryResult.getItemsList()).hasSize(2);
     }
 
-    @Test(timeout = 30_000)
+    @Test(timeout = 60_000)
     public void testFindArchivedTasksByTaskIdsV2() throws Exception {
         testFindArchivedTasksByTaskIds(true);
     }
 
-    @Test(timeout = 30_000)
+    @Test(timeout = 60_000)
     public void testFindArchivedTasksByTaskIdsV3() throws Exception {
         testFindArchivedTasksByTaskIds(false);
     }

--- a/titus-server-master/src/test/java/io/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
+++ b/titus-server-master/src/test/java/io/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
@@ -31,7 +31,7 @@ import static io.netflix.titus.runtime.endpoint.v3.grpc.GrpcAgentModelConverters
 
 public class InstanceGroupScenarioBuilder {
 
-    static final long TIMEOUT_MS = 5000;
+    static final long TIMEOUT_MS = 10_000L;
 
     private static final Logger logger = LoggerFactory.getLogger(InstanceGroupScenarioBuilder.class);
 


### PR DESCRIPTION
Going through some of the recent integration test failures on Travis, they all seem to boil down to a few places timing out, presumably because things run slower on Travis VMs and shared envs.

https://travis-ci.com/Netflix/titus-control-plane/jobs/113021467
https://travis-ci.com/Netflix/titus-control-plane/jobs/112994567
https://travis-ci.com/Netflix/titus-control-plane/jobs/112948704
https://travis-ci.com/Netflix/titus-control-plane/jobs/112828902
https://travis-ci.com/Netflix/titus-control-plane/jobs/112406502
https://travis-ci.com/Netflix/titus-control-plane/jobs/112417977
https://travis-ci.com/Netflix/titus-control-plane/jobs/112354326
https://travis-ci.com/Netflix/titus-control-plane/jobs/111862701