### PR TITLE
loadbalancer: improve validation message for V2 jobs

### DIFF
--- a/titus-api/src/main/java/io/netflix/titus/api/jobmanager/service/JobManagerException.java
+++ b/titus-api/src/main/java/io/netflix/titus/api/jobmanager/service/JobManagerException.java
@@ -65,6 +65,10 @@ public class JobManagerException extends RuntimeException {
         return new JobManagerException(ErrorCode.JobNotFound, format("Job with id %s does not exist", jobId));
     }
 
+    public static JobManagerException v3JobNotFound(String jobId) {
+        return new JobManagerException(ErrorCode.JobNotFound, format("Job with id %s does not exist, or is running on the V2 engine", jobId));
+    }
+
     public static JobManagerException unexpectedJobState(Job job, JobState expectedState) {
         return new JobManagerException(
                 ErrorCode.UnexpectedJobState,

--- a/titus-api/src/main/java/io/netflix/titus/api/loadbalancer/model/sanitizer/DefaultLoadBalancerJobValidator.java
+++ b/titus-api/src/main/java/io/netflix/titus/api/loadbalancer/model/sanitizer/DefaultLoadBalancerJobValidator.java
@@ -51,7 +51,7 @@ public class DefaultLoadBalancerJobValidator implements LoadBalancerJobValidator
     @Override
     public void validateJobId(String jobId) throws LoadBalancerException, JobManagerException {
         // Job must exist
-        Job<?> job = v3JobOperations.getJob(jobId).orElseThrow(() -> JobManagerException.jobNotFound(jobId));
+        Job job = v3JobOperations.getJob(jobId).orElseThrow(() -> JobManagerException.v3JobNotFound(jobId));
 
         // Job must be active
         JobState state = job.getStatus().getState();


### PR DESCRIPTION
Jobs on the V2 engine fail validation with the wrong message, saying they don't exist (but they do).

This was feedback from @tomaslin.