### PR TITLE
Bump V2 validator default values for R4.16XLs

### DIFF
--- a/titus-server-master/src/main/java/io/netflix/titus/master/config/MasterConfiguration.java
+++ b/titus-server-master/src/main/java/io/netflix/titus/master/config/MasterConfiguration.java
@@ -142,8 +142,8 @@ public interface MasterConfiguration extends CoreConfiguration {
     int getMaxDisk();
 
     @PropertyName(name = "titus.jobspec.network.mbps.max")
-    @DefaultValue("6000")
-        // r3.8xl limit
+    @DefaultValue("15000")
+        // r4.16xl limit
     int getMaxNetworkMbps();
 
     @PropertyName(name = "titus.jobspec.batch.instances.max")


### PR DESCRIPTION
Meson would like to use the larger instances but won't be able to switch to V3 until the end of the month. This should unblock them on V2.