### PR TITLE
federation: findTasks, extract page aggregation and cell/grpc logic

### DIFF
--- a/titus-server-federation/src/main/java/io/netflix/titus/federation/service/AggregatingJobManagementService.java
+++ b/titus-server-federation/src/main/java/io/netflix/titus/federation/service/AggregatingJobManagementService.java
@@ -17,11 +17,11 @@
 package io.netflix.titus.federation.service;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -40,7 +40,6 @@ import com.netflix.titus.grpc.protogen.JobProcessesUpdate;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
 import com.netflix.titus.grpc.protogen.JobStatusUpdate;
-import com.netflix.titus.grpc.protogen.Page;
 import com.netflix.titus.grpc.protogen.Pagination;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
@@ -54,6 +53,7 @@ import io.netflix.titus.common.grpc.GrpcUtil;
 import io.netflix.titus.common.grpc.SessionContext;
 import io.netflix.titus.common.util.StringExt;
 import io.netflix.titus.common.util.concurrency.CallbackCountDownLatch;
+import io.netflix.titus.common.util.tuple.Pair;
 import io.netflix.titus.federation.startup.GrpcConfiguration;
 import io.netflix.titus.federation.startup.TitusFederationConfiguration;
 import io.netflix.titus.runtime.jobmanager.JobManagerCursors;
@@ -67,6 +67,9 @@ import static io.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_STACK
 import static io.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_STACK;
 import static io.netflix.titus.common.grpc.GrpcUtil.createRequestObservable;
 import static io.netflix.titus.common.grpc.GrpcUtil.createWrappedStub;
+import static io.netflix.titus.federation.service.CellConnectorUtil.callToAllCells;
+import static io.netflix.titus.federation.service.PageAggregationUtil.combinePagination;
+import static io.netflix.titus.federation.service.PageAggregationUtil.takeCombinedPage;
 import static io.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.emptyGrpcPagination;
 
 @Singleton
@@ -137,9 +140,8 @@ public class AggregatingJobManagementService implements JobManagementService {
     @Override
     public Observable<JobQueryResult> findJobs(JobQuery request) {
         if (request.getPage().getPageSize() <= 0) {
-            Pagination pagination = emptyGrpcPagination(request.getPage());
             return Observable.just(JobQueryResult.newBuilder()
-                    .setPagination(pagination)
+                    .setPagination(emptyGrpcPagination(request.getPage()))
                     .build());
         }
         if (StringExt.isNotEmpty(request.getPage().getCursor()) || request.getPage().getPageNumber() == 0) {
@@ -150,79 +152,42 @@ public class AggregatingJobManagementService implements JobManagementService {
     }
 
     private Observable<JobQueryResult> findJobsWithCursorPagination(JobQuery request) {
-        Map<Cell, JobManagementServiceStub> clients = CellConnectorUtil.stubs(connector, JobManagementServiceGrpc::newStub);
-        List<Observable<JobQueryResult>> requests = clients.values().stream()
-                .map(client -> findJobsInCell(client, request))
+        BiConsumer<JobManagementServiceStub, StreamObserver<JobQueryResult>> findJobs =
+                (client, streamObserver) -> wrap(client).findJobs(request, streamObserver);
+
+        List<Observable<JobQueryResult>> requests = callToAllCells(connector, JobManagementServiceGrpc::newStub, findJobs)
+                .stream()
+                .map(observable -> observable.map(CellResponse::getResult))
                 .collect(Collectors.toList());
 
         return Observable.combineLatest(requests, (rawResults) -> {
             JobQueryResult[] results = Arrays.copyOf(rawResults, rawResults.length, JobQueryResult[].class);
-            Optional<JobQueryResult> combinedResults = combineResults(request, results);
-
-            List<Job> allJobs = combinedResults.map(r -> r.getItemsList().stream()
-                    .sorted(JobManagerCursors.jobCursorOrderComparator())
-                    .map(this::addStackName)
-                    .collect(Collectors.toList()))
-                    .orElse(Collections.emptyList());
-
-            int lastItemOffset = Math.min(allJobs.size(), request.getPage().getPageSize());
-            List<Job> pageItems = allJobs.subList(0, lastItemOffset);
-            String cursor = allJobs.isEmpty() ? "" : JobManagerCursors.newCursorFrom(pageItems.get(pageItems.size() - 1));
-
-            Pagination combinedPagination = combinedResults.map(JobQueryResult::getPagination)
-                    .map(p -> addCombinedPage(p, request.getPage(), allJobs.size(), lastItemOffset, cursor))
-                    .orElse(emptyGrpcPagination(request.getPage()));
+            JobQueryResult combinedResults = combineJobResults(results);
+            Pair<List<Job>, Pagination> combinedPage = takeCombinedPage(
+                    request.getPage(),
+                    combinedResults.getItemsList(),
+                    combinedResults.getPagination(),
+                    this::addStackName,
+                    JobManagerCursors.jobCursorOrderComparator(),
+                    JobManagerCursors::newCursorFrom
+            );
 
             return JobQueryResult.newBuilder()
-                    .addAllItems(pageItems)
-                    .setPagination(combinedPagination)
+                    .addAllItems(combinedPage.getLeft())
+                    .setPagination(combinedPage.getRight())
                     .build();
         });
     }
 
-    private static Optional<JobQueryResult> combineResults(JobQuery request, JobQueryResult[] results) {
+    private static JobQueryResult combineJobResults(JobQueryResult[] results) {
         return Arrays.stream(results).reduce((one, other) -> {
-            int cursorPosition = one.getPagination().getCursorPosition() + other.getPagination().getCursorPosition();
-            if (one.getPagination().getTotalItems() > 0 && other.getPagination().getTotalItems() > 0) {
-                // the cursorPosition on each cell always points to (totalItemsReturned - 1), when merging two cells
-                // with items, we need to compensate two deductions on the total number of items, so the final (merged)
-                // cursorPosition is still (totalItemsBeingReturned - 1).
-                // Note that when either one of the cells is empty, the cursorPosition from the empty cell will be 0 and
-                // there is nothing to compensate since there are no items in that cell.
-                cursorPosition++;
-            }
-            Pagination pagination = Pagination.newBuilder()
-                    // combined currentPage.pageNumber and cursor will be computed later
-                    .setHasMore(one.getPagination().getHasMore() || other.getPagination().getHasMore())
-                    .setTotalPages(one.getPagination().getTotalPages() + other.getPagination().getTotalPages())
-                    .setTotalItems(one.getPagination().getTotalItems() + other.getPagination().getTotalItems())
-                    .setCursorPosition(cursorPosition)
-                    .build();
+            Pagination pagination = combinePagination(one.getPagination(), other.getPagination());
             return JobQueryResult.newBuilder()
                     .setPagination(pagination)
                     .addAllItems(one.getItemsList())
                     .addAllItems(other.getItemsList())
                     .build();
-        });
-    }
-
-    private static Pagination addCombinedPage(Pagination combinedPagination, Page requested, int allJobsSize, int lastItemOffset, String cursor) {
-        // first item position relative to totalItems from all Cells
-        int firstItemPosition = Math.max(0, combinedPagination.getCursorPosition() - (allJobsSize - 1));
-        int pageNumber = firstItemPosition / requested.getPageSize();
-        return Pagination.newBuilder(combinedPagination)
-                .setCurrentPage(Page.newBuilder(requested).setPageNumber(pageNumber))
-                .setCursor(cursor)
-                .setCursorPosition(firstItemPosition + lastItemOffset - 1)
-                .setHasMore(combinedPagination.getHasMore() || lastItemOffset < allJobsSize)
-                .build();
-    }
-
-    private Observable<JobQueryResult> findJobsInCell(JobManagementServiceStub client, JobQuery request) {
-        return GrpcUtil.<JobQueryResult>createRequestObservable(emitter -> {
-            final StreamObserver<JobQueryResult> streamObserver = GrpcUtil.createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, sessionContext, grpcConfiguration.getRequestTimeoutMs()).findJobs(request, streamObserver);
-        });
+        }).orElseThrow(() -> TitusServiceException.unexpected("no results from any Cells"));
     }
 
     @Override
@@ -257,9 +222,57 @@ public class AggregatingJobManagementService implements JobManagementService {
     }
 
     @Override
-    public Observable<TaskQueryResult> findTasks(TaskQuery taskQuery) {
-        return Observable.error(TitusServiceException.unimplemented());
+    public Observable<TaskQueryResult> findTasks(TaskQuery request) {
+        if (request.getPage().getPageSize() <= 0) {
+            return Observable.just(TaskQueryResult.newBuilder()
+                    .setPagination(emptyGrpcPagination(request.getPage()))
+                    .build());
+        }
+        if (StringExt.isNotEmpty(request.getPage().getCursor()) || request.getPage().getPageNumber() == 0) {
+            return findTasksWithCursorPagination(request);
+        }
+        // TODO: page number pagination
+        return Observable.error(TitusServiceException.invalidArgument("pageNumbers are not supported, please use cursors"));
     }
+
+    private Observable<TaskQueryResult> findTasksWithCursorPagination(TaskQuery request) {
+        BiConsumer<JobManagementServiceStub, StreamObserver<TaskQueryResult>> findTasks =
+                (client, streamObserver) -> wrap(client).findTasks(request, streamObserver);
+
+        List<Observable<TaskQueryResult>> requests = callToAllCells(connector, JobManagementServiceGrpc::newStub, findTasks)
+                .stream()
+                .map(observable -> observable.map(CellResponse::getResult))
+                .collect(Collectors.toList());
+
+        return Observable.combineLatest(requests, (rawResults) -> {
+            TaskQueryResult[] results = Arrays.copyOf(rawResults, rawResults.length, TaskQueryResult[].class);
+            TaskQueryResult combinedResults = combineTaskResults(results);
+            Pair<List<Task>, Pagination> combinedPage = takeCombinedPage(
+                    request.getPage(),
+                    combinedResults.getItemsList(),
+                    combinedResults.getPagination(),
+                    this::addStackName,
+                    JobManagerCursors.taskCursorOrderComparator(),
+                    JobManagerCursors::newCursorFrom
+            );
+            return TaskQueryResult.newBuilder()
+                    .addAllItems(combinedPage.getLeft())
+                    .setPagination(combinedPage.getRight())
+                    .build();
+        });
+    }
+
+    private static TaskQueryResult combineTaskResults(TaskQueryResult[] results) {
+        return Arrays.stream(results).reduce((one, other) -> {
+            Pagination pagination = combinePagination(one.getPagination(), other.getPagination());
+            return TaskQueryResult.newBuilder()
+                    .setPagination(pagination)
+                    .addAllItems(one.getItemsList())
+                    .addAllItems(other.getItemsList())
+                    .build();
+        }).orElseThrow(() -> TitusServiceException.unexpected("no results from any Cells"));
+    }
+
 
     @Override
     public Completable killTask(TaskKillRequest taskKillRequest) {
@@ -297,6 +310,11 @@ public class AggregatingJobManagementService implements JobManagementService {
     private static JobChangeNotification buildJobSnapshotEndMarker() {
         final JobChangeNotification.SnapshotEnd marker = JobChangeNotification.SnapshotEnd.newBuilder().build();
         return JobChangeNotification.newBuilder().setSnapshotEnd(marker).build();
+    }
+
+    private JobManagementServiceStub wrap(JobManagementServiceStub client) {
+        return createWrappedStub(client, sessionContext, grpcConfiguration.getRequestTimeoutMs());
+
     }
 }
 

--- a/titus-server-federation/src/main/java/io/netflix/titus/federation/service/CellResponse.java
+++ b/titus-server-federation/src/main/java/io/netflix/titus/federation/service/CellResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netflix.titus.federation.service;
+
+import io.grpc.stub.AbstractStub;
+import io.netflix.titus.api.federation.model.Cell;
+
+class CellResponse<STUB extends AbstractStub<STUB>, T> {
+    private final Cell cell;
+    private final STUB client;
+    private final T result;
+
+    CellResponse(Cell cell, STUB client, T result) {
+        this.cell = cell;
+        this.client = client;
+        this.result = result;
+    }
+
+    public Cell getCell() {
+        return cell;
+    }
+
+    public STUB getClient() {
+        return client;
+    }
+
+    public T getResult() {
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CellResponse{" +
+                "cell=" + cell +
+                ", client=" + client +
+                ", result=" + result +
+                '}';
+    }
+}

--- a/titus-server-federation/src/main/java/io/netflix/titus/federation/service/PageAggregationUtil.java
+++ b/titus-server-federation/src/main/java/io/netflix/titus/federation/service/PageAggregationUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netflix.titus.federation.service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.netflix.titus.grpc.protogen.Page;
+import com.netflix.titus.grpc.protogen.Pagination;
+import io.netflix.titus.common.util.tuple.Pair;
+
+final class PageAggregationUtil {
+    private PageAggregationUtil() {
+    }
+
+    static <T> Pair<List<T>, Pagination> takeCombinedPage(Page requested,
+                                                          List<T> combinedItems,
+                                                          Pagination combinedPagination,
+                                                          Function<T, T> stackNameDecorator,
+                                                          Comparator<T> cursorComparator,
+                                                          Function<T, String> cursorFactory) {
+        List<T> sorted = combinedItems.stream()
+                .map(stackNameDecorator)
+                .sorted(cursorComparator)
+                .collect(Collectors.toList());
+
+        int lastItemOffset = Math.min(sorted.size(), requested.getPageSize());
+        List<T> pageItems = sorted.subList(0, lastItemOffset);
+        String cursor = sorted.isEmpty() ? "" : cursorFactory.apply(pageItems.get(pageItems.size() - 1));
+
+        // first item position relative to totalItems from all Cells
+        int firstItemPosition = Math.max(0, combinedPagination.getCursorPosition() - (sorted.size() - 1));
+        int pageNumber = firstItemPosition / requested.getPageSize();
+        Pagination finalPagination = Pagination.newBuilder(combinedPagination)
+                .setCurrentPage(Page.newBuilder(requested).setPageNumber(pageNumber))
+                .setCursor(cursor)
+                .setCursorPosition(firstItemPosition + lastItemOffset - 1)
+                .setHasMore(combinedPagination.getHasMore() || lastItemOffset < sorted.size())
+                .build();
+
+        return Pair.of(pageItems, finalPagination);
+    }
+
+    static Pagination combinePagination(Pagination one, Pagination other) {
+        int cursorPosition = one.getCursorPosition() + other.getCursorPosition();
+        if (one.getTotalItems() > 0 && other.getTotalItems() > 0) {
+            // the cursorPosition on each cell always points to (totalItemsReturned - 1), when merging two cells
+            // with items, we need to compensate two deductions on the total number of items, so the final (merged)
+            // cursorPosition is still (totalItemsBeingReturned - 1).
+            // Note that when either one of the cells is empty, the cursorPosition from the empty cell will be 0 and
+            // there is nothing to compensate since there are no items in that cell.
+            cursorPosition++;
+        }
+        return Pagination.newBuilder()
+                // combined currentPage.pageNumber and cursor will be computed later
+                .setHasMore(one.getHasMore() || other.getHasMore())
+                .setTotalPages(one.getTotalPages() + other.getTotalPages())
+                .setTotalItems(one.getTotalItems() + other.getTotalItems())
+                .setCursorPosition(cursorPosition)
+                .build();
+    }
+}

--- a/titus-server-federation/src/test/java/io/netflix/titus/federation/service/AggregatingAutoScalingServiceTest.java
+++ b/titus-server-federation/src/test/java/io/netflix/titus/federation/service/AggregatingAutoScalingServiceTest.java
@@ -35,7 +35,6 @@ import rx.observers.AssertableSubscriber;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-
 public class AggregatingAutoScalingServiceTest extends AggregatingAutoScalingTestBase {
 
     @Test
@@ -125,7 +124,7 @@ public class AggregatingAutoScalingServiceTest extends AggregatingAutoScalingTes
 
         AssertableSubscriber<ScalingPolicyID> testSubscriber = service.setAutoScalingPolicy(PutPolicyRequest.newBuilder().setJobId(JOB_2).build()).test();
         testSubscriber.awaitValueCount(1, 1, TimeUnit.SECONDS);
-        assertThat(testSubscriber.getOnErrorEvents().isEmpty()).isTrue();
+        testSubscriber.assertNoErrors();
 
         List<ScalingPolicyID> onNextEvents = testSubscriber.getOnNextEvents();
         assertThat(onNextEvents).isNotNull();

--- a/titus-server-federation/src/test/java/io/netflix/titus/federation/service/AggregatingAutoScalingTestBase.java
+++ b/titus-server-federation/src/test/java/io/netflix/titus/federation/service/AggregatingAutoScalingTestBase.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,7 @@ import org.junit.Rule;
 
 import static com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc.AutoScalingServiceImplBase;
 import static com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceImplBase;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,7 +58,6 @@ public class AggregatingAutoScalingTestBase {
     @Rule
     public final GrpcServerRule cellOne = new GrpcServerRule().directExecutor();
 
-
     @Rule
     public final GrpcServerRule cellTwo = new GrpcServerRule().directExecutor();
 
@@ -69,6 +70,9 @@ public class AggregatingAutoScalingTestBase {
         cellMap.put(new Cell("one", "1"), cellOne.getChannel());
         cellMap.put(new Cell("two", "2"), cellTwo.getChannel());
         when(connector.getChannels()).thenReturn(cellMap);
+        when(connector.getChannelForCell(any())).then(invocation ->
+                Optional.ofNullable(cellMap.get(invocation.getArgument(0)))
+        );
 
         GrpcConfiguration grpcConfiguration = mock(GrpcConfiguration.class);
         when(grpcConfiguration.getRequestTimeoutMs()).thenReturn(1000L);


### PR DESCRIPTION
First pass at extracting some common federated pagination logic, and grpc call to cells. This is a moving target and I expect more iterations as things evolve.

Other than the new federated `findTasks` using the common logic, changes here are a pure refactoring, and they shouldn't change any of the current behavior.

Tests and the endpoints (grpc and rest) for `findTasks` will come in a followup patch. I wanted to get this PR out quickly before @corindwyer starts renaming packages, and avoid a big merge conflict.