### PR TITLE
Reduce scheduling time

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
@@ -53,11 +53,9 @@ import rx.Completable;
 import rx.Observable;
 
 import static com.netflix.titus.common.util.guice.ProxyType.ActiveGuard;
-import static com.netflix.titus.common.util.guice.ProxyType.Logging;
-import static com.netflix.titus.common.util.guice.ProxyType.Spectator;
 
 @Singleton
-@ProxyConfiguration(types = {Logging, Spectator, ActiveGuard})
+@ProxyConfiguration(types = {ActiveGuard})
 public class DefaultAgentManagementService implements AgentManagementService {
 
     private final AgentManagementConfiguration configuration;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
@@ -24,17 +24,17 @@ import com.netflix.archaius.api.annotations.DefaultValue;
 @Configuration(prefix = "titusMaster.jobManager")
 public interface JobManagerConfiguration {
 
-    @DefaultValue("1000")
+    @DefaultValue("100")
     long getReconcilerIdleTimeoutMs();
 
-    @DefaultValue("50")
+    @DefaultValue("1")
     long getReconcilerActiveTimeoutMs();
 
     /**
      * How many active tasks in the transient state (in other words not Started and not Finished) are allowed in a job.
      * If the number of active tasks in the transient state goes above this limit, no new tasks are created.
      */
-    @DefaultValue("100")
+    @DefaultValue("300")
     int getActiveNotStartedTasksLimit();
 
     @DefaultValue("60000")

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerConfiguration.java
@@ -26,7 +26,7 @@ public interface SchedulerConfiguration {
     /**
      * @return Sleep interval between consecutive scheduler iterations
      */
-    @DefaultValue("500")
+    @DefaultValue("1000")
     long getSchedulerIterationIntervalMs();
 
     @DefaultValue("true")

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/DefaultSystemHardConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/DefaultSystemHardConstraint.java
@@ -75,6 +75,11 @@ public class DefaultSystemHardConstraint implements SystemHardConstraint {
     }
 
     @Override
+    public String getName() {
+        return "Default System Hard Constraint";
+    }
+
+    @Override
     public Result evaluate(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
         Preconditions.checkNotNull(delegate, "System activation not finished yet");
         return delegate.evaluate(taskRequest, targetVM, taskTrackerState);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/DefaultSystemSoftConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/DefaultSystemSoftConstraint.java
@@ -46,7 +46,7 @@ public class DefaultSystemSoftConstraint implements SystemSoftConstraint {
 
     @Override
     public String getName() {
-        return "System Soft Constraint";
+        return "Default System Soft Constraint";
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalAgentClusterConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalAgentClusterConstraint.java
@@ -66,7 +66,7 @@ public class GlobalAgentClusterConstraint implements GlobalConstraintEvaluator {
 
     @Override
     public String getName() {
-        return GlobalAgentClusterConstraint.class.getSimpleName();
+        return "Global Agent Cluster Constraint";
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalConstraintEvaluator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalConstraintEvaluator.java
@@ -22,12 +22,6 @@ import com.netflix.fenzo.ConstraintEvaluator;
  * Defines behavior for global constraint evaluators
  */
 public interface GlobalConstraintEvaluator extends ConstraintEvaluator {
-
-    @Override
-    default String getName() {
-        return getClass().getSimpleName();
-    }
-
     default void prepare() {
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalInactiveClusterConstraintEvaluator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalInactiveClusterConstraintEvaluator.java
@@ -51,6 +51,11 @@ public class GlobalInactiveClusterConstraintEvaluator implements GlobalConstrain
     }
 
     @Override
+    public String getName() {
+        return "Global Inactive Cluster Constraint Evaluator";
+    }
+
+    @Override
     public Result evaluate(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
         String serverGroupName = LeaseAttributes.getOrDefault(targetVM.getCurrAvailableResources(), serverGroupAttrName, null);
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalTaskLaunchingConstraintEvaluator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalTaskLaunchingConstraintEvaluator.java
@@ -48,6 +48,11 @@ public class GlobalTaskLaunchingConstraintEvaluator implements GlobalConstraintE
     }
 
     @Override
+    public String getName() {
+        return "Global Task Launching Constraint Evaluator";
+    }
+
+    @Override
     public Result evaluate(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
         if (schedulerConfiguration.isGlobalTaskLaunchingConstraintEvaluatorEnabled()) {
             int totalLaunchingTasks = (int) targetVM.getRunningTasks().stream().filter(this::isTaskLaunching).count();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalTaskResubmitConstraintEvaluator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/GlobalTaskResubmitConstraintEvaluator.java
@@ -42,6 +42,11 @@ public class GlobalTaskResubmitConstraintEvaluator implements GlobalConstraintEv
     }
 
     @Override
+    public String getName() {
+        return "Global Task Resubmit Constraint Evaluator";
+    }
+
+    @Override
     public Result evaluate(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
         if (!(taskRequest instanceof ScheduledRequest)) {
             return OK_RESULT;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
@@ -36,8 +36,6 @@ import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import com.netflix.titus.common.model.sanitizer.VerifierMode;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
-import com.netflix.titus.common.util.time.Clocks;
-import com.netflix.titus.common.util.time.TestClock;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.jobmanager.service.DefaultV3JobOperations;
 import com.netflix.titus.master.jobmanager.service.JobManagerConfiguration;
@@ -100,8 +98,6 @@ public class JobsScenarioBuilder {
 
         jobStore.events().subscribe(storeEvents);
 
-        TestClock clock = Clocks.testScheduler(testScheduler);
-
         SystemSoftConstraint systemSoftConstraint = new SystemSoftConstraint() {
             @Override
             public String getName() {
@@ -113,7 +109,17 @@ public class JobsScenarioBuilder {
                 return 1.0;
             }
         };
-        SystemHardConstraint systemHardConstraint = (taskRequest, targetVM, taskTrackerState) -> new ConstraintEvaluator.Result(true, "");
+        SystemHardConstraint systemHardConstraint = new SystemHardConstraint() {
+            @Override
+            public String getName() {
+                return "Test System Hard Constraint";
+            }
+
+            @Override
+            public Result evaluate(TaskRequest taskRequest, VirtualMachineCurrentState targetVM, TaskTrackerState taskTrackerState) {
+                return new ConstraintEvaluator.Result(true, "");
+            }
+        };
 
         BatchDifferenceResolver batchDifferenceResolver = new BatchDifferenceResolver(
                 configuration,


### PR DESCRIPTION
* Remove logging and spectator proxies from agent management to reduce cpu time
* Add more instrumentation to the various sections of the scheduling process
* Use constant string names in the evaluators