### PR TITLE
Federation: ensure fields required for cursors are always present

### DIFF
--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobManagementService.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobManagementService.java
@@ -16,9 +16,12 @@
 
 package com.netflix.titus.federation.service;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -28,11 +31,11 @@ import javax.inject.Singleton;
 import com.google.protobuf.Empty;
 import com.netflix.titus.api.federation.model.Cell;
 import com.netflix.titus.api.service.TitusServiceException;
-import com.netflix.titus.common.util.rx.EmitterWithMultipleSubscriptions;
-import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
-import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.common.util.ProtobufCopy;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.concurrency.CallbackCountDownLatch;
+import com.netflix.titus.common.util.rx.EmitterWithMultipleSubscriptions;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.federation.startup.GrpcConfiguration;
 import com.netflix.titus.federation.startup.TitusFederationConfiguration;
@@ -55,6 +58,8 @@ import com.netflix.titus.grpc.protogen.TaskId;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.jobmanager.JobManagerCursors;
 import com.netflix.titus.runtime.service.JobManagementService;
 import io.grpc.stub.StreamObserver;
@@ -66,16 +71,21 @@ import rx.Observable;
 
 import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_STACK;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_STACK;
-import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createRequestObservable;
-import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
 import static com.netflix.titus.federation.service.CellConnectorUtil.callToCell;
 import static com.netflix.titus.federation.service.PageAggregationUtil.combinePagination;
 import static com.netflix.titus.federation.service.PageAggregationUtil.takeCombinedPage;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.emptyGrpcPagination;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createRequestObservable;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
 
 @Singleton
 public class AggregatingJobManagementService implements JobManagementService {
     private static final Logger logger = LoggerFactory.getLogger(AggregatingJobManagementService.class);
+
+    // some fields are required from each cell, so pagination cursors can be generated
+    private static final Set<String> JOB_FEDERATION_MINIMUM_FIELD_SET = CollectionsExt.asSet("id", "status", "statusHistory");
+    private static final Set<String> TASK_FEDERATION_MINIMUM_FIELD_SET = CollectionsExt.asSet("id", "status", "statusHistory");
+
     private final GrpcConfiguration grpcConfiguration;
     private final TitusFederationConfiguration federationConfiguration;
     private final CellConnector connector;
@@ -164,14 +174,25 @@ public class AggregatingJobManagementService implements JobManagementService {
                     .setPagination(emptyGrpcPagination(request.getPage()))
                     .build());
         }
+
+        Set<String> fieldsFilter = Collections.emptySet();
+        if (request.getFieldsCount() > 0) {
+            fieldsFilter = new HashSet<>(request.getFieldsList());
+            fieldsFilter.addAll(JOB_MINIMUM_FIELD_SET);
+            request = request.toBuilder()
+                    .addAllFields(fieldsFilter)
+                    .addAllFields(JOB_FEDERATION_MINIMUM_FIELD_SET)
+                    .build();
+        }
+
         if (StringExt.isNotEmpty(request.getPage().getCursor()) || request.getPage().getPageNumber() == 0) {
-            return findJobsWithCursorPagination(request);
+            return findJobsWithCursorPagination(request, fieldsFilter);
         }
         // TODO: page number pagination
         return Observable.error(TitusServiceException.invalidArgument("pageNumbers are not supported, please use cursors"));
     }
 
-    private Observable<JobQueryResult> findJobsWithCursorPagination(JobQuery request) {
+    private Observable<JobQueryResult> findJobsWithCursorPagination(JobQuery request, Set<String> fields) {
         return aggregatingClient.call(JobManagementServiceGrpc::newStub, findJobsInCell(request))
                 .map(CellResponse::getResult)
                 .reduce(this::combineJobResults)
@@ -183,6 +204,13 @@ public class AggregatingJobManagementService implements JobManagementService {
                             JobManagerCursors.jobCursorOrderComparator(),
                             JobManagerCursors::newCursorFrom
                     );
+
+                    if (!CollectionsExt.isNullOrEmpty(fields)) {
+                        combinedPage = combinedPage.mapLeft(jobs -> jobs.stream()
+                                .map(job -> ProtobufCopy.copy(job, fields))
+                                .collect(Collectors.toList())
+                        );
+                    }
 
                     return JobQueryResult.newBuilder()
                             .addAllItems(combinedPage.getLeft())
@@ -271,14 +299,25 @@ public class AggregatingJobManagementService implements JobManagementService {
                     .setPagination(emptyGrpcPagination(request.getPage()))
                     .build());
         }
+
+        Set<String> fieldsFilter = Collections.emptySet();
+        if (request.getFieldsCount() > 0) {
+            fieldsFilter = new HashSet<>(request.getFieldsList());
+            fieldsFilter.addAll(TASK_MINIMUM_FIELD_SET);
+            request = request.toBuilder()
+                    .addAllFields(fieldsFilter)
+                    .addAllFields(TASK_FEDERATION_MINIMUM_FIELD_SET)
+                    .build();
+        }
+
         if (StringExt.isNotEmpty(request.getPage().getCursor()) || request.getPage().getPageNumber() == 0) {
-            return findTasksWithCursorPagination(request);
+            return findTasksWithCursorPagination(request, fieldsFilter);
         }
         // TODO: page number pagination
         return Observable.error(TitusServiceException.invalidArgument("pageNumbers are not supported, please use cursors"));
     }
 
-    private Observable<TaskQueryResult> findTasksWithCursorPagination(TaskQuery request) {
+    private Observable<TaskQueryResult> findTasksWithCursorPagination(TaskQuery request, Set<String> fields) {
         return aggregatingClient.call(JobManagementServiceGrpc::newStub, findTasksInCell(request))
                 .map(CellResponse::getResult)
                 .reduce(this::combineTaskResults)
@@ -290,6 +329,14 @@ public class AggregatingJobManagementService implements JobManagementService {
                             JobManagerCursors.taskCursorOrderComparator(),
                             JobManagerCursors::newCursorFrom
                     );
+
+                    if (!CollectionsExt.isNullOrEmpty(fields)) {
+                        combinedPage = combinedPage.mapLeft(tasks -> tasks.stream()
+                                .map(task -> ProtobufCopy.copy(task, fields))
+                                .collect(Collectors.toList())
+                        );
+                    }
+
                     return TaskQueryResult.newBuilder()
                             .addAllItems(combinedPage.getLeft())
                             .setPagination(combinedPage.getRight())

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementServiceTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementServiceTest.java
@@ -33,10 +33,10 @@ import com.google.common.collect.Iterables;
 import com.netflix.titus.api.federation.model.Cell;
 import com.netflix.titus.api.model.Page;
 import com.netflix.titus.api.service.TitusServiceException;
-import com.netflix.titus.runtime.endpoint.metadata.AnonymousCallMetadataResolver;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.time.Clocks;
 import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.federation.startup.GrpcConfiguration;
 import com.netflix.titus.federation.startup.TitusFederationConfiguration;
 import com.netflix.titus.grpc.protogen.Capacity;
@@ -57,6 +57,7 @@ import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
+import com.netflix.titus.runtime.endpoint.metadata.AnonymousCallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.v3.grpc.V3GrpcModelConverters;
 import com.netflix.titus.runtime.jobmanager.JobManagerCursors;
 import com.netflix.titus.testkit.grpc.TestStreamObserver;
@@ -232,33 +233,13 @@ public class AggregatingJobManagementServiceTest {
 
     @Test
     public void findJobsWithCursorPagination() {
-        final List<Job> cellOneSnapshot = new ArrayList<>();
-        final List<Job> cellTwoSnapshot = new ArrayList<>();
-        // generate 5 groups of size 20 (10 service, 10 batch) with different timestamps
-        for (int i = 0; i < 5; i++) {
-            for (int j = 0; j < 5; j++) {
-                clock.advanceTime(1, TimeUnit.SECONDS);
-                cellOneSnapshot.add(dataGenerator.newBatchJob(V3GrpcModelConverters::toGrpcJob));
-
-                clock.advanceTime(1, TimeUnit.SECONDS);
-                cellTwoSnapshot.add(dataGenerator.newServiceJob(V3GrpcModelConverters::toGrpcJob));
-
-                clock.advanceTime(1, TimeUnit.SECONDS);
-                cellOneSnapshot.add(dataGenerator.newServiceJob(V3GrpcModelConverters::toGrpcJob));
-
-                clock.advanceTime(1, TimeUnit.SECONDS);
-                cellTwoSnapshot.add(dataGenerator.newBatchJob(V3GrpcModelConverters::toGrpcJob));
-            }
-            clock.advanceTime(9, TimeUnit.SECONDS);
-        }
-        cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(cellOneSnapshot, cellOneUpdates.serialize()));
-        cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(cellTwoSnapshot, cellTwoUpdates.serialize()));
+        Pair<List<Job>, List<Job>> cellSnapshots = generateTestJobs();
 
         List<Job> allJobs = walkAllFindJobsPages(10);
-        assertThat(allJobs).hasSize(cellOneSnapshot.size() + cellTwoSnapshot.size());
+        assertThat(allJobs).hasSize(cellSnapshots.getLeft().size() + cellSnapshots.getRight().size());
 
         // expect stackName to have changed
-        List<Job> expected = Stream.concat(cellOneSnapshot.stream(), cellTwoSnapshot.stream())
+        List<Job> expected = Stream.concat(cellSnapshots.getLeft().stream(), cellSnapshots.getRight().stream())
                 .sorted(JobManagerCursors.jobCursorOrderComparator())
                 .map(this::withStackName)
                 .collect(Collectors.toList());
@@ -351,6 +332,28 @@ public class AggregatingJobManagementServiceTest {
         testSubscriber.awaitTerminalEvent(1, TimeUnit.SECONDS);
         testSubscriber.assertError(Status.INTERNAL.asRuntimeException().getClass());
         testSubscriber.assertNoValues();
+    }
+
+    @Test
+    public void findJobsWithFieldFiltering() {
+        Pair<List<Job>, List<Job>> cellSnapshots = generateTestJobs();
+        List<Job> allJobs = walkAllPages(
+                10,
+                service::findJobs,
+                page -> JobQuery.newBuilder()
+                        .setPage(page)
+                        .addFields("jobDescriptor.owner")
+                        .build(),
+                JobQueryResult::getPagination,
+                JobQueryResult::getItemsList
+        );
+        assertThat(allJobs).hasSize(cellSnapshots.getLeft().size() + cellSnapshots.getRight().size());
+        for (Job job : allJobs) {
+            assertThat(job.getId()).isNotEmpty();
+            assertThat(job.getJobDescriptor().getOwner().getTeamEmail()).isNotEmpty();
+            assertThat(job.getStatus().getReasonMessage()).isEmpty();
+            assertThat(job.getStatusHistoryList()).isEmpty();
+        }
     }
 
     @Test
@@ -565,28 +568,38 @@ public class AggregatingJobManagementServiceTest {
 
     @Test
     public void findTasksMergesAllCellsIntoSingleResult() {
-        List<Task> cellOneSnapshot = new ArrayList<>();
-        List<Task> cellTwoSnapshot = new ArrayList<>();
-
-        // 10 jobs on each cell with TASKS_IN_GENERATED_JOBS tasks each
-        for (int i = 0; i < 5; i++) {
-            cellOneSnapshot.addAll(dataGenerator.newBatchJobWithTasks());
-            cellTwoSnapshot.addAll(dataGenerator.newBatchJobWithTasks());
-            cellOneSnapshot.addAll(dataGenerator.newServiceJobWithTasks());
-            cellTwoSnapshot.addAll(dataGenerator.newServiceJobWithTasks());
-            clock.advanceTime(1, TimeUnit.MINUTES);
-        }
-
-        cellOne.getServiceRegistry().addService(new CellWithFixedTasksService(cellOneSnapshot));
-        cellTwo.getServiceRegistry().addService(new CellWithFixedTasksService(cellTwoSnapshot));
+        Pair<List<Task>, List<Task>> cellSnapshots = generateTestJobsWithTasks();
 
         List<Task> tasks = walkAllFindTasksPages(7);
-        assertThat(tasks).hasSize(cellOneSnapshot.size() + cellTwoSnapshot.size());
-        List<Task> expected = Stream.concat(cellOneSnapshot.stream(), cellTwoSnapshot.stream())
+        assertThat(tasks).hasSize(cellSnapshots.getLeft().size() + cellSnapshots.getRight().size());
+        List<Task> expected = Stream.concat(cellSnapshots.getLeft().stream(), cellSnapshots.getRight().stream())
                 .sorted(JobManagerCursors.taskCursorOrderComparator())
                 .map(this::withStackName)
                 .collect(Collectors.toList());
         assertThat(tasks).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    public void findTasksWithFieldFiltering() {
+        Pair<List<Task>, List<Task>> cellSnapshots = generateTestJobsWithTasks();
+
+        List<Task> allTasks = walkAllPages(
+                6,
+                service::findTasks,
+                page -> TaskQuery.newBuilder()
+                        .setPage(page)
+                        .addFields("jobId")
+                        .build(),
+                TaskQueryResult::getPagination,
+                TaskQueryResult::getItemsList
+        );
+        assertThat(allTasks).hasSize(cellSnapshots.getLeft().size() + cellSnapshots.getRight().size());
+        for (Task task : allTasks) {
+            assertThat(task.getId()).isNotEmpty();
+            assertThat(task.getJobId()).isNotEmpty();
+            assertThat(task.getStatus().getReasonMessage()).isEmpty();
+            assertThat(task.getStatusHistoryList()).isEmpty();
+        }
     }
 
     @Test
@@ -817,6 +830,49 @@ public class AggregatingJobManagementServiceTest {
 
     private Optional<Cell> getCellWithName(String cellName) {
         return cellToServiceMap.keySet().stream().filter(cell -> cell.getName().equals(cellName)).findFirst();
+    }
+
+    private Pair<List<Job>, List<Job>> generateTestJobs() {
+        final List<Job> cellOneSnapshot = new ArrayList<>();
+        final List<Job> cellTwoSnapshot = new ArrayList<>();
+        // generate 5 groups of size 20 (10 service, 10 batch) with different timestamps
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                clock.advanceTime(1, TimeUnit.SECONDS);
+                cellOneSnapshot.add(dataGenerator.newBatchJob(V3GrpcModelConverters::toGrpcJob));
+
+                clock.advanceTime(1, TimeUnit.SECONDS);
+                cellTwoSnapshot.add(dataGenerator.newServiceJob(V3GrpcModelConverters::toGrpcJob));
+
+                clock.advanceTime(1, TimeUnit.SECONDS);
+                cellOneSnapshot.add(dataGenerator.newServiceJob(V3GrpcModelConverters::toGrpcJob));
+
+                clock.advanceTime(1, TimeUnit.SECONDS);
+                cellTwoSnapshot.add(dataGenerator.newBatchJob(V3GrpcModelConverters::toGrpcJob));
+            }
+            clock.advanceTime(9, TimeUnit.SECONDS);
+        }
+        cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(cellOneSnapshot, cellOneUpdates.serialize()));
+        cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(cellTwoSnapshot, cellTwoUpdates.serialize()));
+        return Pair.of(cellOneSnapshot, cellTwoSnapshot);
+    }
+
+    private Pair<List<Task>, List<Task>> generateTestJobsWithTasks() {
+        List<Task> cellOneSnapshot = new ArrayList<>();
+        List<Task> cellTwoSnapshot = new ArrayList<>();
+
+        // 10 jobs on each cell with TASKS_IN_GENERATED_JOBS tasks each
+        for (int i = 0; i < 5; i++) {
+            cellOneSnapshot.addAll(dataGenerator.newBatchJobWithTasks());
+            cellTwoSnapshot.addAll(dataGenerator.newBatchJobWithTasks());
+            cellOneSnapshot.addAll(dataGenerator.newServiceJobWithTasks());
+            cellTwoSnapshot.addAll(dataGenerator.newServiceJobWithTasks());
+            clock.advanceTime(1, TimeUnit.MINUTES);
+        }
+
+        cellOne.getServiceRegistry().addService(new CellWithFixedTasksService(cellOneSnapshot));
+        cellTwo.getServiceRegistry().addService(new CellWithFixedTasksService(cellTwoSnapshot));
+        return Pair.of(cellOneSnapshot, cellTwoSnapshot);
     }
 }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -64,20 +64,18 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Subscription;
 
-import static com.netflix.titus.common.util.CollectionsExt.asSet;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.toGrpcPagination;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.toJobQueryCriteria;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.toPage;
 import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.safeOnError;
 import static com.netflix.titus.runtime.endpoint.v3.grpc.TitusPaginationUtils.checkPageIsValid;
+import static com.netflix.titus.runtime.service.JobManagementService.JOB_MINIMUM_FIELD_SET;
+import static com.netflix.titus.runtime.service.JobManagementService.TASK_MINIMUM_FIELD_SET;
 
 @Singleton
 public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.JobManagementServiceImplBase {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultJobManagementServiceGrpc.class);
-
-    private static final Set<String> JOB_MINIMUM_FIELD_SET = asSet("id");
-    private static final Set<String> TASK_MINIMUM_FIELD_SET = asSet("id");
 
     private final TitusServiceGateway<String, JobDescriptor, JobSpecCase, Job, Task, TaskStatus.TaskState> serviceGateway;
     private final CallMetadataResolver callMetadataResolver;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
@@ -704,7 +704,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
         JobDescriptor<BatchJobExt> jobDescriptor = baseBatchJobDescriptor(false)
                 .withAttributes(ImmutableMap.of("keyA", "valueA", "keyB", "valueB"))
                 .build();
-        jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.jobAccepted()));
+        jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.startTasks()));
 
         // Check jobs
         List<Job> foundJobs = client.findJobs(JobQuery.newBuilder().setPage(PAGE)
@@ -720,10 +720,15 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
         assertThat(foundJobDescriptor.getAttributesMap()).containsEntry("keyA", "valueA");
 
         // Check tasks
-        List<Task> foundTasks = client.findTasks(TaskQuery.newBuilder().setPage(PAGE).addFields("status").build()).getItemsList();
+        List<Task> foundTasks = client.findTasks(TaskQuery.newBuilder().setPage(PAGE)
+                .addFields("status")
+                .addFields("statusHistory")
+                .build()
+        ).getItemsList();
         assertThat(foundTasks).hasSize(1);
         assertThat(foundTasks.get(0).getId()).isNotEmpty(); // Always present
         assertThat(foundTasks.get(0).getStatus().getReasonMessage()).isNotEmpty();
+        assertThat(foundTasks.get(0).getStatusHistoryList()).isNotEmpty();
         assertThat(foundTasks.get(0).getTaskContextMap()).isEmpty();
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/JobManagementService.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/JobManagementService.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.runtime.service;
 
+import java.util.Set;
+
 import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
@@ -31,10 +33,15 @@ import com.netflix.titus.grpc.protogen.TaskQueryResult;
 import rx.Completable;
 import rx.Observable;
 
+import static com.netflix.titus.common.util.CollectionsExt.asSet;
+
 /**
  * RxJava wrapper for the JobManagement gRPC service.
  */
 public interface JobManagementService {
+    Set<String> JOB_MINIMUM_FIELD_SET = asSet("id");
+    Set<String> TASK_MINIMUM_FIELD_SET = asSet("id");
+
     Observable<String> createJob(JobDescriptor jobDescriptor);
 
     Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate);


### PR DESCRIPTION
When fields are being filtered in a query, ensure all that is required by the federation proxy is included, and take out what the original API query didn't specify.