### PR TITLE
let the federation proxy set titus.stack for jobs and tasks

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -25,7 +25,7 @@ public final class JobAttributes {
     // Job Descriptor Attributes
 
     /**
-     * Stack name that can be replaced in a federated deployment, where all Cells have the same Stack name.
+     * Federated stack name. All cells under the same federated stack must share the same value.
      */
     public static final String JOB_ATTRIBUTES_STACK = "titus.stack";
 

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementServiceTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementServiceTest.java
@@ -72,6 +72,7 @@ import rx.observers.AssertableSubscriber;
 import rx.subjects.PublishSubject;
 
 import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_CELL;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_STACK;
 import static com.netflix.titus.federation.service.ServiceTests.walkAllPages;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.toGrpcPage;
 import static io.grpc.Status.DEADLINE_EXCEEDED;
@@ -100,6 +101,7 @@ public class AggregatingJobManagementServiceTest {
 
     private String stackName;
     private AggregatingJobManagementService service;
+    private List<Cell> cells;
     private Map<Cell, GrpcServerRule> cellToServiceMap;
     private TestClock clock;
     private ServiceDataGenerator dataGenerator;
@@ -118,7 +120,7 @@ public class AggregatingJobManagementServiceTest {
 
         CellInfoResolver cellInfoResolver = new DefaultCellInfoResolver(titusFederationConfiguration);
         DefaultCellRouter cellRouter = new DefaultCellRouter(cellInfoResolver, titusFederationConfiguration);
-        List<Cell> cells = cellInfoResolver.resolve();
+        cells = cellInfoResolver.resolve();
         cellToServiceMap = ImmutableMap.of(
                 cells.get(0), cellOne,
                 cells.get(1), cellTwo
@@ -773,6 +775,23 @@ public class AggregatingJobManagementServiceTest {
                 assertThat(job.getJobDescriptor().getAttributesOrThrow(JOB_ATTRIBUTES_CELL).equals(expectedCellName));
             }).doesNotThrowAnyException();
         });
+    }
+
+    @Test
+    public void createJobInjectsFederatedStackName() {
+        Cell firstCell = cells.get(0);
+        CellWithCachedJobsService cachedJobsService = new CellWithCachedJobsService(firstCell.getName());
+        cellToServiceMap.get(firstCell).getServiceRegistry().addService(cachedJobsService);
+
+        // Create the job and let it get routed
+        JobDescriptor jobDescriptor = JobDescriptor.newBuilder()
+                .setApplicationName("app1")
+                .setCapacityGroup("app1CapGroup")
+                .build();
+        String jobId = service.createJob(jobDescriptor).toBlocking().first();
+        Optional<JobDescriptor> createdJob = cachedJobsService.getCachedJob(jobId);
+        assertThat(createdJob).isPresent();
+        assertThat(createdJob.get().getAttributesMap()).containsEntry(JOB_ATTRIBUTES_STACK, stackName);
     }
 
     private List<Job> walkAllFindJobsPages(int pageWalkSize) {

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithCachedJobsService.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithCachedJobsService.java
@@ -2,13 +2,14 @@ package com.netflix.titus.federation.service;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
-import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
 import com.netflix.titus.grpc.protogen.JobId;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import io.grpc.stub.StreamObserver;
 import rx.Observable;
 import rx.Subscription;
@@ -21,6 +22,10 @@ class CellWithCachedJobsService extends JobManagementServiceGrpc.JobManagementSe
 
     CellWithCachedJobsService(String name) {
         this.cellName = name;
+    }
+
+    Optional<JobDescriptor> getCachedJob(String jobId) {
+        return Optional.ofNullable(jobDescriptorMap.get(JobId.newBuilder().setId(jobId).build()));
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/common/CellDecorator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/common/CellDecorator.java
@@ -33,27 +33,25 @@ public class CellDecorator {
     }
 
     /**
-     * Adds {@link JobAttributes#JOB_ATTRIBUTES_CELL "titus.cell"} and {@link JobAttributes#JOB_ATTRIBUTES_STACK "titus.stack"}
-     * labels to a {@link TitusJobSpec V2 job spec}, replacing existing values if they are already present.
+     * Adds a {@link JobAttributes#JOB_ATTRIBUTES_CELL "titus.cell"} label to a {@link TitusJobSpec V2 job spec},
+     * replacing the existing value if it is already present.
      */
     public TitusJobSpec ensureCellInfo(TitusJobSpec jobSpec) {
         final Map<String, String> originalLabels = jobSpec.getLabels();
         final Map<String, String> labels = originalLabels == null ? new HashMap<>() : new HashMap<>(originalLabels);
         final String cellName = cellNameSupplier.get();
         labels.put(JobAttributes.JOB_ATTRIBUTES_CELL, cellName);
-        labels.put(JobAttributes.JOB_ATTRIBUTES_STACK, cellName);
         return new TitusJobSpec.Builder(jobSpec).labels(labels).build();
     }
 
     /**
-     * Adds {@link JobAttributes#JOB_ATTRIBUTES_CELL "titus.cell"} and {@link JobAttributes#JOB_ATTRIBUTES_STACK "titus.stack"}
-     * attributes to a {@link JobDescriptor V3 job spec}, replacing existing values if they are already present.
+     * Adds a {@link JobAttributes#JOB_ATTRIBUTES_CELL "titus.cell"} attribute to a {@link JobDescriptor V3 job spec},
+     * replacing the existing value if it is already present.
      */
     public JobDescriptor ensureCellInfo(JobDescriptor jobDescriptor) {
         final String cellName = cellNameSupplier.get();
         return jobDescriptor.toBuilder()
                 .putAttributes(JobAttributes.JOB_ATTRIBUTES_CELL, cellName)
-                .putAttributes(JobAttributes.JOB_ATTRIBUTES_STACK, cellName)
                 .build();
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/JobSchedulingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/JobSchedulingTest.java
@@ -287,7 +287,6 @@ public class JobSchedulingTest extends BaseIntegrationTest {
         List<Parameter> parameters = job.getParameters();
         final Map<String, String> labels = Parameters.getLabels(parameters);
         assertThat(labels).containsEntry(JobAttributes.JOB_ATTRIBUTES_CELL, EmbeddedTitusMaster.CELL_NAME);
-        assertThat(labels).containsEntry(JobAttributes.JOB_ATTRIBUTES_STACK, EmbeddedTitusMaster.CELL_NAME);
 
         Collection<V2WorkerMetadata> tasksMetadata = job.getStageMetadata(1).getAllWorkers();
         tasksMetadata.forEach(workerMetadata ->

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/CellAssertions.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/CellAssertions.java
@@ -26,7 +26,6 @@ public class CellAssertions {
 
     public static void assertCellInfo(JobDescriptor jobDescriptor, String cellName) {
         assertThat(jobDescriptor.getAttributesMap()).containsEntry("titus.cell", cellName);
-        assertThat(jobDescriptor.getAttributesMap()).containsEntry("titus.stack", cellName);
     }
 
     public static void assertCellInfo(Job job, String cellName) {
@@ -35,7 +34,6 @@ public class CellAssertions {
 
     public static void assertCellInfo(Task task, String cellName) {
         assertThat(task.getTaskContextMap()).containsEntry("titus.cell", cellName);
-        assertThat(task.getTaskContextMap()).containsEntry("titus.stack", cellName);
     }
 
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
@@ -542,7 +542,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
         jobs1.getItemsList().forEach(job -> assertCellInfo(job, EmbeddedTitusMaster.CELL_NAME));
 
         JobQueryResult jobs2 = client.findJobs(JobQuery.newBuilder()
-                .putFilteringCriteria("attributes", "titus.cell,titus.stack")
+                .putFilteringCriteria("attributes", "titus.cell")
                 .putFilteringCriteria("attributes.op", "and")
                 .setPage(PAGE)
                 .build()
@@ -562,7 +562,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
 
         JobQueryResult jobs4 = client.findJobs(JobQuery.newBuilder()
                 .putFilteringCriteria("attributes",
-                        String.format("titus.cell:%1$s,titus.stack:%1$s", EmbeddedTitusMaster.CELL_NAME))
+                        String.format("titus.cell:%1$s", EmbeddedTitusMaster.CELL_NAME))
                 .putFilteringCriteria("attributes.op", "and")
                 .setPage(PAGE)
                 .build()
@@ -581,7 +581,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
         tasks1.getItemsList().forEach(task -> assertCellInfo(task, EmbeddedTitusMaster.CELL_NAME));
 
         TaskQueryResult tasks2 = client.findTasks(TaskQuery.newBuilder()
-                .putFilteringCriteria("attributes", "titus.cell,titus.stack")
+                .putFilteringCriteria("attributes", "titus.cell")
                 .putFilteringCriteria("attributes.op", "and")
                 .setPage(PAGE)
                 .build()
@@ -600,7 +600,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
 
         final TaskQueryResult tasks4 = client.findTasks(TaskQuery.newBuilder()
                 .putFilteringCriteria("attributes",
-                        String.format("titus.cell:%1$s,titus.stack:%1$s", EmbeddedTitusMaster.CELL_NAME))
+                        String.format("titus.cell:%1$s", EmbeddedTitusMaster.CELL_NAME))
                 .putFilteringCriteria("attributes.op", "and")
                 .setPage(PAGE).build()
         );


### PR DESCRIPTION
This makes it so jobs and tasks are always persisted with `titus.stack`
being the federated stack name. The caveat is that jobs created not
through the federation proxy (including legacy V2 API calls that don't
go through federation) will not have the attribute persisted with them.
With it, the persisted state should more accurately reflect what jobs
and tasks were created in a federated context, and what is their
federated stack name.

All jobs and tasks queried through a federation proxy continue to have
`titus.stack` automatically decorated into them, regardless if the
records from each cell have it or not.