### PR TITLE
federated health endpoints

### DIFF
--- a/titus-common/build.gradle
+++ b/titus-common/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     // gRPC dependencies
     compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
+    compile "io.grpc:grpc-protobuf:${grpcVersion}"
 
     testCompile project(':titus-testkit')
     testCompile "com.squareup.okhttp3:mockwebserver:${okHttpVersion}"

--- a/titus-common/src/main/java/com/netflix/titus/common/util/DateTimeExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/DateTimeExt.java
@@ -20,6 +20,9 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
+
 /**
  * Data and time supplementary functions.
  */
@@ -42,7 +45,15 @@ public final class DateTimeExt {
     }
 
     /**
-     * Given time in milliseconds, format it using time units. For example 3600,000 is formatted as 1h.
+     * Given a duration with milliseconds resolution, format it using time units.
+     * For example 3600,000 is formatted as 1h.
+     */
+    public static String toTimeUnitString(Duration duration) {
+        return toTimeUnitString(Durations.toMillis(duration));
+    }
+
+    /**
+     * Given a duration in milliseconds, format it using time units. For example 3600,000 is formatted as 1h.
      */
     public static String toTimeUnitString(long timeMs) {
         StringBuilder sb = new StringBuilder();

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/GrpcModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/GrpcModule.java
@@ -18,11 +18,13 @@ package com.netflix.titus.federation.endpoint.grpc;
 
 import com.google.inject.AbstractModule;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.metadata.SimpleCallMetadataResolverProvider;
 import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultAutoScalingServiceGrpc;
+import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultHealthServiceGrpc;
 import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultJobManagementServiceGrpc;
 import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultLoadBalancerServiceGrpc;
 
@@ -32,6 +34,7 @@ public class GrpcModule extends AbstractModule {
     protected void configure() {
         bind(TitusFederationGrpcServer.class).asEagerSingleton();
         bind(CallMetadataResolver.class).toProvider(SimpleCallMetadataResolverProvider.class);
+        bind(HealthGrpc.HealthImplBase.class).to(DefaultHealthServiceGrpc.class);
         bind(JobManagementServiceGrpc.JobManagementServiceImplBase.class).to(DefaultJobManagementServiceGrpc.class);
         bind(AutoScalingServiceGrpc.AutoScalingServiceImplBase.class).to(DefaultAutoScalingServiceGrpc.class);
         bind(LoadBalancerServiceGrpc.LoadBalancerServiceImplBase.class).to(DefaultLoadBalancerServiceGrpc.class);

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/JerseyModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/JerseyModule.java
@@ -31,6 +31,7 @@ import com.netflix.titus.runtime.endpoint.common.rest.filter.CallerContextFilter
 import com.netflix.titus.runtime.endpoint.common.rest.provider.InstrumentedResourceMethodDispatchAdapter;
 import com.netflix.titus.runtime.endpoint.metadata.SimpleHttpCallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.v3.rest.AutoScalingResource;
+import com.netflix.titus.runtime.endpoint.v3.rest.HealthResource;
 import com.netflix.titus.runtime.endpoint.v3.rest.JobManagementResource;
 import com.sun.jersey.api.core.DefaultResourceConfig;
 import com.sun.jersey.guice.JerseyServletModule;
@@ -68,6 +69,7 @@ public final class JerseyModule extends JerseyServletModule {
             config.getClasses().add(InstrumentedResourceMethodDispatchAdapter.class);
 
             // resources
+            config.getClasses().add(HealthResource.class);
             config.getClasses().add(JobManagementResource.class);
             config.getClasses().add(AutoScalingResource.class);
             return config;

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingHealthService.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingHealthService.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service;
+
+import java.util.function.BiConsumer;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.federation.startup.GrpcConfiguration;
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.Unknown;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import com.netflix.titus.runtime.service.HealthService;
+import io.grpc.Status;
+import io.grpc.stub.AbstractStub;
+import io.grpc.stub.StreamObserver;
+import rx.Observable;
+
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.NOT_SERVING;
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.SERVING;
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.UNKNOWN;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
+
+@Singleton
+public class AggregatingHealthService implements HealthService {
+    private final AggregatingCellClient client;
+    private final CallMetadataResolver callMetadataResolver;
+    private final GrpcConfiguration grpcConfiguration;
+
+    @Inject
+    public AggregatingHealthService(AggregatingCellClient client, CallMetadataResolver callMetadataResolver, GrpcConfiguration grpcConfiguration) {
+        this.client = client;
+        this.callMetadataResolver = callMetadataResolver;
+        this.grpcConfiguration = grpcConfiguration;
+    }
+
+    private ClientCall<HealthCheckResponse> check() {
+        return (client, responseObserver) -> wrap(client).check(HealthCheckRequest.newBuilder().build(), responseObserver);
+    }
+
+    @Override
+    public Observable<HealthCheckResponse> check(HealthCheckRequest request) {
+        return client.callExpectingErrors(HealthGrpc::newStub, check())
+                .map(resp -> resp.getResult().onErrorGet(e -> newErrorResponse(resp.getCell().getName(), e)))
+                .reduce((one, other) -> HealthCheckResponse.newBuilder()
+                        .setStatus(merge(one.getStatus(), other.getStatus()))
+                        .addAllDetails(one.getDetailsList())
+                        .addAllDetails(other.getDetailsList())
+                        .build())
+                .defaultIfEmpty(HealthCheckResponse.newBuilder()
+                        .setStatus(UNKNOWN)
+                        .build());
+    }
+
+    private static ServingStatus merge(ServingStatus oneStatus, ServingStatus otherStatus) {
+        if (oneStatus.equals(SERVING)) {
+            return otherStatus;
+        }
+        return oneStatus;
+    }
+
+    private static HealthCheckResponse newErrorResponse(String cellName, Throwable e) {
+        return HealthCheckResponse.newBuilder()
+                .setStatus(NOT_SERVING)
+                .addDetails(HealthCheckResponse.ServerStatus.newBuilder()
+                        .setError(Unknown.newBuilder()
+                                .setCell(cellName)
+                                .setErrorCode(statusCodeFromThrowable(e))
+                                .setMessage(e.getMessage())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static String statusCodeFromThrowable(Throwable e) {
+        Status status = Status.fromThrowable(e);
+        if (status.getCode().equals(Status.Code.UNKNOWN)) {
+            return e.getClass().getSimpleName();
+        }
+        return status.getCode().toString();
+    }
+
+    private <STUB extends AbstractStub<STUB>> STUB wrap(STUB stub) {
+        return createWrappedStub(stub, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
+    }
+
+    private interface ClientCall<T> extends BiConsumer<HealthGrpc.HealthStub, StreamObserver<T>> {
+        // generics sanity
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/ServiceModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/ServiceModule.java
@@ -18,12 +18,14 @@ package com.netflix.titus.federation.service;
 
 import com.google.inject.AbstractModule;
 import com.netflix.titus.runtime.service.AutoScalingService;
+import com.netflix.titus.runtime.service.HealthService;
 import com.netflix.titus.runtime.service.JobManagementService;
 import com.netflix.titus.runtime.service.LoadBalancerService;
 
 public class ServiceModule extends AbstractModule {
     @Override
     protected void configure() {
+        bind(HealthService.class).to(AggregatingHealthService.class);
         bind(JobManagementService.class).to(AggregatingJobManagementService.class);
         bind(AutoScalingService.class).to(AggregatingAutoScalingService.class);
         bind(LoadBalancerService.class).to(AggregatingLoadbalancerService.class);

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingHealthServiceTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingHealthServiceTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.util.Durations;
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.common.util.time.Clocks;
+import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.federation.startup.GrpcConfiguration;
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.Details;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServerStatus;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.runtime.endpoint.metadata.AnonymousCallMetadataResolver;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcServerRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import rx.observers.AssertableSubscriber;
+
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.NOT_SERVING;
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.SERVING;
+import static io.grpc.Status.Code.DEADLINE_EXCEEDED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class AggregatingHealthServiceTest {
+
+    private final TestClock clock = Clocks.test();
+
+    @Rule
+    public final GrpcServerRule cellOne = new GrpcServerRule().directExecutor();
+
+    @Rule
+    public final GrpcServerRule cellTwo = new GrpcServerRule().directExecutor();
+
+    AggregatingHealthService service;
+    private final CellConnector connector = mock(CellConnector.class);
+
+    @Before
+    public void setup() {
+        Map<Cell, ManagedChannel> cellMap = new HashMap<>();
+        cellMap.put(new Cell("one", "1"), cellOne.getChannel());
+        cellMap.put(new Cell("two", "2"), cellTwo.getChannel());
+        when(connector.getChannels()).thenReturn(cellMap);
+        when(connector.getChannelForCell(any())).then(invocation ->
+                Optional.ofNullable(cellMap.get(invocation.getArgument(0)))
+        );
+
+        GrpcConfiguration grpcConfiguration = mock(GrpcConfiguration.class);
+        when(grpcConfiguration.getRequestTimeoutMs()).thenReturn(1000L);
+        AnonymousCallMetadataResolver anonymousCallMetadataResolver = new AnonymousCallMetadataResolver();
+        AggregatingCellClient aggregatingCellClient = new AggregatingCellClient(connector);
+        service = new AggregatingHealthService(aggregatingCellClient, anonymousCallMetadataResolver, grpcConfiguration);
+    }
+
+    @Test
+    public void allCellsOK() {
+        cellOne.getServiceRegistry().addService(new CellWithHealthStatus(ok("one")));
+        cellTwo.getServiceRegistry().addService(new CellWithHealthStatus(ok("two")));
+
+        AssertableSubscriber<HealthCheckResponse> subscriber = service.check(HealthCheckRequest.newBuilder().build()).test();
+        subscriber.awaitTerminalEvent(10, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(1);
+        HealthCheckResponse response = subscriber.getOnNextEvents().get(0);
+        assertThat(response.getStatus()).isEqualTo(SERVING);
+        assertThat(response.getDetailsCount()).isEqualTo(2);
+        assertThat(response.getDetails(0).hasDetails()).isTrue();
+        assertThat(response.getDetails(1).hasDetails()).isTrue();
+        Set<String> cellsSeen = response.getDetailsList().stream()
+                .map(s -> s.getDetails().getCell())
+                .collect(Collectors.toSet());
+        assertThat(cellsSeen).contains("one", "two");
+    }
+
+    @Test
+    public void singleCell() {
+        reset(connector);
+        when(connector.getChannels()).thenReturn(Collections.singletonMap(
+                new Cell("one", "1"), cellOne.getChannel()
+        ));
+        when(connector.getChannelForCell(any())).thenReturn(Optional.of(cellOne.getChannel()));
+
+        HealthCheckResponse one = HealthCheckResponse.newBuilder()
+                .setStatus(NOT_SERVING)
+                .addDetails(ServerStatus.newBuilder()
+                        .setDetails(Details.newBuilder()
+                                .setCell("one")
+                                .setLeader(false)
+                                .setActive(true)
+                                .setUptime(Durations.fromMillis(clock.wallTime()))
+                                .build())
+                        .build())
+                .build();
+        cellOne.getServiceRegistry().addService(new CellWithHealthStatus(one));
+
+        AssertableSubscriber<HealthCheckResponse> subscriber = service.check(HealthCheckRequest.newBuilder().build()).test();
+        subscriber.awaitTerminalEvent(10, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(1);
+        HealthCheckResponse response = subscriber.getOnNextEvents().get(0);
+        assertThat(response.getStatus()).isEqualTo(NOT_SERVING);
+        assertThat(response.getDetailsCount()).isEqualTo(1);
+        assertThat(response.getDetails(0).hasDetails()).isTrue();
+        assertThat(response.getDetails(0).getDetails().getCell()).isEqualTo("one");
+        assertThat(response.getDetails(0).getDetails().getLeader()).isFalse();
+    }
+
+    @Test
+    public void oneCellFailing() {
+        cellOne.getServiceRegistry().addService(new CellWithHealthStatus(ok("one")));
+        cellTwo.getServiceRegistry().addService(new CellWithHealthStatus(failing("two")));
+
+        AssertableSubscriber<HealthCheckResponse> subscriber = service.check(HealthCheckRequest.newBuilder().build()).test();
+        subscriber.awaitTerminalEvent(10, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(1);
+        HealthCheckResponse response = subscriber.getOnNextEvents().get(0);
+        assertThat(response.getStatus()).isEqualTo(NOT_SERVING);
+        assertThat(response.getDetailsCount()).isEqualTo(2);
+        assertThat(response.getDetails(0).hasDetails()).isTrue();
+        assertThat(response.getDetails(1).hasDetails()).isTrue();
+        Set<String> cellsSeen = response.getDetailsList().stream()
+                .map(s -> s.getDetails().getCell())
+                .collect(Collectors.toSet());
+        assertThat(cellsSeen).contains("one", "two");
+    }
+
+    @Test
+    public void grpcErrors() {
+        cellOne.getServiceRegistry().addService(new CellWithHealthStatus(ok("one")));
+        cellTwo.getServiceRegistry().addService(new HealthGrpc.HealthImplBase() {
+            @Override
+            public void check(HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
+                responseObserver.onError(Status.DEADLINE_EXCEEDED.asRuntimeException());
+            }
+        });
+
+        AssertableSubscriber<HealthCheckResponse> subscriber = service.check(HealthCheckRequest.newBuilder().build()).test();
+        subscriber.awaitTerminalEvent(10, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(1);
+        HealthCheckResponse response = subscriber.getOnNextEvents().get(0);
+        assertThat(response.getStatus()).isEqualTo(NOT_SERVING);
+        assertThat(response.getDetailsCount()).isEqualTo(2);
+        List<ServerStatus> errors = response.getDetailsList().stream()
+                .filter(ServerStatus::hasError)
+                .collect(Collectors.toList());
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).getError().getCell()).isEqualTo("two");
+        assertThat(errors.get(0).getError().getErrorCode()).isEqualTo(DEADLINE_EXCEEDED.toString());
+    }
+
+    @Test
+    public void allCellsFailing() {
+        cellOne.getServiceRegistry().addService(new CellWithHealthStatus(failing("one")));
+        cellTwo.getServiceRegistry().addService(new CellWithHealthStatus(failing("two")));
+
+        AssertableSubscriber<HealthCheckResponse> subscriber = service.check(HealthCheckRequest.newBuilder().build()).test();
+        subscriber.awaitTerminalEvent(10, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(1);
+        HealthCheckResponse response = subscriber.getOnNextEvents().get(0);
+        assertThat(response.getStatus()).isEqualTo(NOT_SERVING);
+        assertThat(response.getDetailsCount()).isEqualTo(2);
+        assertThat(response.getDetails(0).hasDetails()).isTrue();
+        assertThat(response.getDetails(1).hasDetails()).isTrue();
+        Set<String> cellsSeen = response.getDetailsList().stream()
+                .map(s -> s.getDetails().getCell())
+                .collect(Collectors.toSet());
+        assertThat(cellsSeen).contains("one", "two");
+    }
+
+    private HealthCheckResponse ok(String cellName) {
+        return HealthCheckResponse.newBuilder()
+                .setStatus(SERVING)
+                .addDetails(ServerStatus.newBuilder()
+                        .setDetails(Details.newBuilder()
+                                .setCell(cellName)
+                                .setLeader(true)
+                                .setActive(true)
+                                .setUptime(Durations.fromMillis(clock.wallTime()))
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private HealthCheckResponse failing(String cellName) {
+        return HealthCheckResponse.newBuilder()
+                .setStatus(NOT_SERVING)
+                .addDetails(ServerStatus.newBuilder()
+                        .setDetails(Details.newBuilder()
+                                .setCell(cellName)
+                                .setLeader(true)
+                                .setActive(false)
+                                .setUptime(Durations.fromMillis(clock.wallTime()))
+                                .build())
+                        .build())
+                .build();
+    }
+}

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithHealthStatus.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithHealthStatus.java
@@ -14,36 +14,23 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.health.endpoint.grpc;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
+package com.netflix.titus.federation.service;
 
 import com.netflix.titus.grpc.protogen.HealthCheckRequest;
 import com.netflix.titus.grpc.protogen.HealthCheckResponse;
-import com.netflix.titus.grpc.protogen.HealthCheckResponse.Details;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
-import com.netflix.titus.master.health.service.HealthService;
 import io.grpc.stub.StreamObserver;
 
-@Singleton
-public class DefaultHealthServiceGrpc extends HealthGrpc.HealthImplBase {
-    private final HealthService healthService;
+class CellWithHealthStatus extends HealthGrpc.HealthImplBase {
+    private final HealthCheckResponse response;
 
-    @Inject
-    public DefaultHealthServiceGrpc(HealthService healthService) {
-        this.healthService = healthService;
+    CellWithHealthStatus(HealthCheckResponse response) {
+        this.response = response;
     }
 
     @Override
     public void check(HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
-        Details details = healthService.getServerStatus();
-        responseObserver.onNext(HealthCheckResponse.newBuilder()
-                .setStatus(details.getStatus())
-                .addDetails(HealthCheckResponse.ServerStatus.newBuilder()
-                        .setDetails(details)
-                        .build())
-                .build());
+        responseObserver.onNext(response);
         responseObserver.onCompleted();
     }
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/connector/titusmaster/TitusMasterConnectorModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/connector/titusmaster/TitusMasterConnectorModule.java
@@ -41,6 +41,8 @@ import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc.AgentManagementServiceStub;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc.AutoScalingServiceStub;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc.HealthStub;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceStub;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
@@ -102,6 +104,12 @@ public class TitusMasterConnectorModule extends AbstractModule {
                 .usePlaintext(true)
                 .maxHeaderListSize(65536)
                 .build();
+    }
+
+    @Provides
+    @Singleton
+    HealthStub healthClient(final @Named(MANAGED_CHANNEL_NAME) Channel channel) {
+        return HealthGrpc.newStub(channel);
     }
 
     @Provides

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GrpcModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GrpcModule.java
@@ -22,7 +22,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.titus.gateway.endpoint.v3.grpc.DefaultAgentManagementServiceGrpc;
-import com.netflix.titus.gateway.endpoint.v3.grpc.DefaultHealthServiceGrpc;
+import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultHealthServiceGrpc;
 import com.netflix.titus.gateway.endpoint.v3.grpc.DefaultSchedulerServiceGrpc;
 import com.netflix.titus.gateway.endpoint.v3.grpc.GrpcEndpointConfiguration;
 import com.netflix.titus.gateway.endpoint.v3.grpc.TitusGatewayGrpcServer;

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GrpcModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GrpcModule.java
@@ -22,11 +22,13 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.titus.gateway.endpoint.v3.grpc.DefaultAgentManagementServiceGrpc;
+import com.netflix.titus.gateway.endpoint.v3.grpc.DefaultHealthServiceGrpc;
 import com.netflix.titus.gateway.endpoint.v3.grpc.DefaultSchedulerServiceGrpc;
 import com.netflix.titus.gateway.endpoint.v3.grpc.GrpcEndpointConfiguration;
 import com.netflix.titus.gateway.endpoint.v3.grpc.TitusGatewayGrpcServer;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc.AgentManagementServiceImplBase;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
@@ -40,6 +42,7 @@ public class GrpcModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(HealthGrpc.HealthImplBase.class).to(DefaultHealthServiceGrpc.class);
         bind(JobManagementServiceGrpc.JobManagementServiceImplBase.class).to(DefaultJobManagementServiceGrpc.class);
         bind(AgentManagementServiceImplBase.class).to(DefaultAgentManagementServiceGrpc.class);
         bind(AutoScalingServiceGrpc.AutoScalingServiceImplBase.class).to(DefaultAutoScalingServiceGrpc.class);

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/JerseyModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/JerseyModule.java
@@ -27,6 +27,7 @@ import com.netflix.governator.providers.Advises;
 import com.netflix.titus.gateway.endpoint.v2.rest.ApiRewriteFilter;
 import com.netflix.titus.gateway.endpoint.v2.rest.TitusMasterProxyServlet;
 import com.netflix.titus.gateway.endpoint.v3.rest.AgentManagementResource;
+import com.netflix.titus.gateway.endpoint.v3.rest.HealthResource;
 import com.netflix.titus.gateway.endpoint.v3.rest.SchedulerResource;
 import com.netflix.titus.runtime.endpoint.common.rest.JsonMessageReaderWriter;
 import com.netflix.titus.runtime.endpoint.common.rest.RestServerConfiguration;
@@ -78,6 +79,7 @@ public final class JerseyModule extends JerseyServletModule {
             config.getClasses().add(InstrumentedResourceMethodDispatchAdapter.class);
 
             // resources
+            config.getClasses().add(HealthResource.class);
             config.getClasses().add(AgentManagementResource.class);
             config.getClasses().add(JobManagementResource.class);
             config.getClasses().add(AutoScalingResource.class);

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/JerseyModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/JerseyModule.java
@@ -27,7 +27,7 @@ import com.netflix.governator.providers.Advises;
 import com.netflix.titus.gateway.endpoint.v2.rest.ApiRewriteFilter;
 import com.netflix.titus.gateway.endpoint.v2.rest.TitusMasterProxyServlet;
 import com.netflix.titus.gateway.endpoint.v3.rest.AgentManagementResource;
-import com.netflix.titus.gateway.endpoint.v3.rest.HealthResource;
+import com.netflix.titus.runtime.endpoint.v3.rest.HealthResource;
 import com.netflix.titus.gateway.endpoint.v3.rest.SchedulerResource;
 import com.netflix.titus.runtime.endpoint.common.rest.JsonMessageReaderWriter;
 import com.netflix.titus.runtime.endpoint.common.rest.RestServerConfiguration;

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/grpc/DefaultHealthServiceGrpc.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/grpc/DefaultHealthServiceGrpc.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.gateway.endpoint.v3.grpc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.runtime.service.HealthService;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Subscription;
+
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.attachCancellingCallback;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.safeOnError;
+
+@Singleton
+public class DefaultHealthServiceGrpc extends HealthGrpc.HealthImplBase {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultHealthServiceGrpc.class);
+
+    private final HealthService healthService;
+
+    @Inject
+    public DefaultHealthServiceGrpc(HealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    @Override
+    public void check(HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
+        Subscription subscription = healthService.check(request).subscribe(
+                responseObserver::onNext,
+                e -> safeOnError(logger, e, responseObserver),
+                responseObserver::onCompleted
+        );
+        attachCancellingCallback(responseObserver, subscription);
+    }
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/rest/HealthResource.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/rest/HealthResource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.gateway.endpoint.v3.rest;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.runtime.endpoint.common.rest.Responses;
+import com.netflix.titus.runtime.service.HealthService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(tags = "Health")
+@Path("/v3/status")
+@Singleton
+public class HealthResource {
+    private final HealthService healthService;
+
+    @Inject
+    public HealthResource(HealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    @GET
+    @ApiOperation("Get the health status")
+    public HealthCheckResponse check() {
+        return Responses.fromSingleValueObservable(healthService.check(HealthCheckRequest.newBuilder().build()));
+    }
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/V3ServiceModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/V3ServiceModule.java
@@ -23,17 +23,20 @@ import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.titus.gateway.service.v3.internal.DefaultAgentManagementService;
 import com.netflix.titus.gateway.service.v3.internal.DefaultAutoScalingService;
+import com.netflix.titus.gateway.service.v3.internal.DefaultHealthService;
 import com.netflix.titus.gateway.service.v3.internal.DefaultJobManagementService;
 import com.netflix.titus.gateway.service.v3.internal.DefaultLoadBalancerService;
 import com.netflix.titus.gateway.service.v3.internal.DefaultSchedulerService;
 import com.netflix.titus.gateway.service.v3.internal.DefaultTitusManagementService;
 import com.netflix.titus.runtime.service.AutoScalingService;
+import com.netflix.titus.runtime.service.HealthService;
 import com.netflix.titus.runtime.service.JobManagementService;
 import com.netflix.titus.runtime.service.LoadBalancerService;
 
 public class V3ServiceModule extends AbstractModule {
     @Override
     protected void configure() {
+        bind(HealthService.class).to(DefaultHealthService.class);
         bind(JobManagementService.class).to(DefaultJobManagementService.class);
         bind(AutoScalingService.class).to(DefaultAutoScalingService.class);
         bind(LoadBalancerService.class).to(DefaultLoadBalancerService.class);

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultHealthService.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultHealthService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.gateway.service.v3.internal;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.gateway.service.v3.GrpcClientConfiguration;
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import com.netflix.titus.runtime.service.HealthService;
+import io.grpc.stub.StreamObserver;
+import rx.Observable;
+
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createRequestObservable;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createSimpleClientResponseObserver;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
+
+@Singleton
+public class DefaultHealthService implements HealthService {
+    private final GrpcClientConfiguration configuration;
+    private final CallMetadataResolver callMetadataResolver;
+    private final HealthGrpc.HealthStub client;
+
+    @Inject
+    public DefaultHealthService(GrpcClientConfiguration configuration, CallMetadataResolver callMetadataResolver, HealthGrpc.HealthStub client) {
+        this.configuration = configuration;
+        this.callMetadataResolver = callMetadataResolver;
+        this.client = client;
+    }
+
+    @Override
+    public Observable<HealthCheckResponse> check(HealthCheckRequest request) {
+        return createRequestObservable(emitter -> {
+            StreamObserver<HealthCheckResponse> streamObserver = createSimpleClientResponseObserver(emitter);
+            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).check(request, streamObserver);
+        }, configuration.getRequestTimeout());
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/TitusMasterModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/TitusMasterModule.java
@@ -38,6 +38,7 @@ import com.netflix.titus.master.endpoint.common.ContextResolver;
 import com.netflix.titus.master.endpoint.common.EmptyContextResolver;
 import com.netflix.titus.master.endpoint.v2.rest.JerseyModule;
 import com.netflix.titus.master.endpoint.v2.validator.ValidatorConfiguration;
+import com.netflix.titus.master.health.HealthModule;
 import com.netflix.titus.master.job.JobModule;
 import com.netflix.titus.master.jobmanager.endpoint.v3.V3EndpointModule;
 import com.netflix.titus.master.jobmanager.service.V3JobManagerModule;
@@ -118,6 +119,7 @@ public class TitusMasterModule extends AbstractModule {
         }
 
         install(new EndpointModule());
+        install(new HealthModule());
         install(new V3EndpointModule());
         install(new AgentEndpointModule());
         install(new AutoScalingModule());

--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/v2/rest/ServerStatusResource.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/v2/rest/ServerStatusResource.java
@@ -32,7 +32,7 @@ import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import com.netflix.titus.api.endpoint.v2.rest.representation.ServerStatusRepresentation;
 import com.netflix.titus.common.util.DateTimeExt;
-import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServerStatus;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.Details;
 import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus;
 import com.netflix.titus.grpc.protogen.ServiceActivation;
 import com.netflix.titus.master.health.service.HealthService;
@@ -57,7 +57,7 @@ public class ServerStatusResource {
 
     @GET
     public ServerStatusRepresentation getServerStatus() {
-        ServerStatus details = healthService.getServerStatus();
+        Details details = healthService.getServerStatus();
 
         if (details.getStatus() != ServingStatus.SERVING) {
             return new ServerStatusRepresentation(

--- a/titus-server-master/src/main/java/com/netflix/titus/master/health/HealthModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/health/HealthModule.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.health;
+
+import com.google.inject.AbstractModule;
+import com.netflix.titus.grpc.protogen.HealthGrpc.HealthImplBase;
+import com.netflix.titus.master.health.endpoint.grpc.DefaultHealthServiceGrpc;
+import com.netflix.titus.master.health.service.DefaultHealthService;
+import com.netflix.titus.master.health.service.HealthService;
+
+public class HealthModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(HealthImplBase.class).to(DefaultHealthServiceGrpc.class);
+        bind(HealthService.class).to(DefaultHealthService.class);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/health/endpoint/grpc/DefaultHealthServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/health/endpoint/grpc/DefaultHealthServiceGrpc.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.health.endpoint.grpc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServerStatus;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.master.health.service.HealthService;
+import io.grpc.stub.StreamObserver;
+
+@Singleton
+public class DefaultHealthServiceGrpc extends HealthGrpc.HealthImplBase {
+    private final HealthService healthService;
+
+    @Inject
+    public DefaultHealthServiceGrpc(HealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    @Override
+    public void check(HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
+        ServerStatus serverStatus = healthService.getServerStatus();
+        responseObserver.onNext(HealthCheckResponse.newBuilder()
+                .setStatus(serverStatus.getStatus())
+                .addDetails(serverStatus)
+                .build());
+        responseObserver.onCompleted();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/health/service/DefaultHealthService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/health/service/DefaultHealthService.java
@@ -29,7 +29,7 @@ import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import com.netflix.titus.common.util.guice.ActivationLifecycle;
 import com.netflix.titus.common.util.tuple.Pair;
-import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServerStatus;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.Details;
 import com.netflix.titus.grpc.protogen.ServiceActivation;
 import com.netflix.titus.master.cluster.LeaderActivator;
 import com.netflix.titus.master.config.CellInfoResolver;
@@ -52,12 +52,12 @@ public class DefaultHealthService implements HealthService {
         this.leaderActivator = leaderActivator;
     }
 
-    public ServerStatus getServerStatus() {
+    public Details getServerStatus() {
         RuntimeMXBean rb = ManagementFactory.getRuntimeMXBean();
         Duration uptime = Durations.fromMillis(rb.getUptime());
 
         if (!leaderActivator.isLeader()) {
-            return ServerStatus.newBuilder()
+            return Details.newBuilder()
                     .setStatus(NOT_SERVING)
                     .setLeader(false)
                     .setActive(false)
@@ -75,7 +75,7 @@ public class DefaultHealthService implements HealthService {
                         .build())
                 .collect(Collectors.toList());
 
-        ServerStatus.Builder details = ServerStatus.newBuilder()
+        Details.Builder details = Details.newBuilder()
                 .setStatus(SERVING)
                 .setCell(cellInfoResolver.getCellName())
                 .setLeader(true)

--- a/titus-server-master/src/main/java/com/netflix/titus/master/health/service/DefaultHealthService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/health/service/DefaultHealthService.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.health.service;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
+import com.google.protobuf.util.Timestamps;
+import com.netflix.titus.common.util.guice.ActivationLifecycle;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServerStatus;
+import com.netflix.titus.grpc.protogen.ServiceActivation;
+import com.netflix.titus.master.cluster.LeaderActivator;
+import com.netflix.titus.master.config.CellInfoResolver;
+
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.NOT_SERVING;
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.SERVING;
+
+@Singleton
+public class DefaultHealthService implements HealthService {
+    private final CellInfoResolver cellInfoResolver;
+    private final ActivationLifecycle activationLifecycle;
+    private final LeaderActivator leaderActivator;
+
+    @Inject
+    public DefaultHealthService(CellInfoResolver cellInfoResolver,
+                                ActivationLifecycle activationLifecycle,
+                                LeaderActivator leaderActivator) {
+        this.cellInfoResolver = cellInfoResolver;
+        this.activationLifecycle = activationLifecycle;
+        this.leaderActivator = leaderActivator;
+    }
+
+    public ServerStatus getServerStatus() {
+        RuntimeMXBean rb = ManagementFactory.getRuntimeMXBean();
+        Duration uptime = Durations.fromMillis(rb.getUptime());
+
+        if (!leaderActivator.isLeader()) {
+            return ServerStatus.newBuilder()
+                    .setStatus(NOT_SERVING)
+                    .setLeader(false)
+                    .setActive(false)
+                    .setUptime(uptime)
+                    .build();
+        }
+
+        boolean active = leaderActivator.isActivated();
+
+        List<ServiceActivation> serviceActivations = activationLifecycle.getServiceActionTimesMs().stream()
+                .sorted(Comparator.comparing(Pair::getRight))
+                .map(pair -> ServiceActivation.newBuilder()
+                        .setName(pair.getLeft())
+                        .setActivationTime(Durations.fromMillis(pair.getRight()))
+                        .build())
+                .collect(Collectors.toList());
+
+        ServerStatus.Builder details = ServerStatus.newBuilder()
+                .setStatus(SERVING)
+                .setCell(cellInfoResolver.getCellName())
+                .setLeader(true)
+                .setActive(active)
+                .setUptime(uptime)
+                .setElectionTimestamp(Timestamps.fromMillis(leaderActivator.getElectionTimestamp()))
+                .setActivationTimestamp(Timestamps.fromMillis(leaderActivator.getActivationEndTimestamp()))
+                .addAllServiceActivationTimes(serviceActivations);
+
+        if (active) {
+            details.setActivationTime(Durations.fromMillis(leaderActivator.getActivationTime()));
+        }
+
+        return details.build();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/health/service/HealthService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/health/service/HealthService.java
@@ -19,5 +19,5 @@ package com.netflix.titus.master.health.service;
 import com.netflix.titus.grpc.protogen.HealthCheckResponse;
 
 public interface HealthService {
-    public HealthCheckResponse.ServerStatus getServerStatus();
+    public HealthCheckResponse.Details getServerStatus();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/health/service/HealthService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/health/service/HealthService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.health.service;
+
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+
+public interface HealthService {
+    public HealthCheckResponse.ServerStatus getServerStatus();
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ServerStatusResourceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ServerStatusResourceTest.java
@@ -22,6 +22,8 @@ import com.netflix.titus.api.endpoint.v2.rest.representation.ServerStatusReprese
 import com.netflix.titus.common.util.guice.ActivationLifecycle;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.cluster.LeaderActivator;
+import com.netflix.titus.master.config.CellInfoResolver;
+import com.netflix.titus.master.health.service.DefaultHealthService;
 import com.netflix.titus.runtime.endpoint.common.rest.JsonMessageReaderWriter;
 import com.netflix.titus.runtime.endpoint.common.rest.TitusExceptionMapper;
 import com.netflix.titus.testkit.junit.jaxrs.HttpTestClient;
@@ -39,11 +41,15 @@ import static org.mockito.Mockito.when;
 
 public class ServerStatusResourceTest {
 
+    private static final CellInfoResolver cellInfoResolver = mock(CellInfoResolver.class);
+
     private static final ActivationLifecycle activationLifecycle = mock(ActivationLifecycle.class);
 
     private static final LeaderActivator leaderActivator = mock(LeaderActivator.class);
 
-    private static final ServerStatusResource restService = new ServerStatusResource(activationLifecycle, leaderActivator);
+    private static final ServerStatusResource restService = new ServerStatusResource(
+            new DefaultHealthService(cellInfoResolver, activationLifecycle, leaderActivator)
+    );
 
     @ClassRule
     public static final JaxRsServerResource<ServerStatusResource> jaxRsServer = JaxRsServerResource.newBuilder(restService)
@@ -59,7 +65,8 @@ public class ServerStatusResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        reset(activationLifecycle, leaderActivator);
+        reset(cellInfoResolver, activationLifecycle, leaderActivator);
+        when(cellInfoResolver.getCellName()).thenReturn("cellN");
     }
 
     @Test

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/HealthTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/HealthTest.java
@@ -41,7 +41,7 @@ public class HealthTest extends BaseIntegrationTest {
             EmbeddedTitusCell.aTitusCell()
                     .withMaster(basicMaster(new SimulatedCloud()))
                     .withDefaultGateway()
-                    .build(), true
+                    .build()
     );
 
     @Rule
@@ -56,10 +56,12 @@ public class HealthTest extends BaseIntegrationTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(SERVING);
         assertThat(response.getDetailsCount()).isGreaterThan(0);
-        assertThat(response.getDetails(0).getStatus()).isEqualTo(SERVING);
-        assertThat(response.getDetails(0).hasUptime()).isTrue();
-        assertThat(response.getDetails(0).hasElectionTimestamp()).isTrue();
-        assertThat(response.getDetails(0).hasActivationTime()).isTrue();
-        assertThat(response.getDetails(0).hasActivationTimestamp()).isTrue();
+        assertThat(response.getDetails(0).hasDetails()).isTrue();
+        HealthCheckResponse.Details details = response.getDetails(0).getDetails();
+        assertThat(details.getStatus()).isEqualTo(SERVING);
+        assertThat(details.hasUptime()).isTrue();
+        assertThat(details.hasElectionTimestamp()).isTrue();
+        assertThat(details.hasActivationTime()).isTrue();
+        assertThat(details.hasActivationTimestamp()).isTrue();
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/HealthTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/HealthTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.integration.v3;
+
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.master.integration.BaseIntegrationTest;
+import com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCell;
+import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
+import com.netflix.titus.testkit.grpc.TestStreamObserver;
+import com.netflix.titus.testkit.junit.category.IntegrationTest;
+import com.netflix.titus.testkit.junit.master.TitusStackResource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+
+import static com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus.SERVING;
+import static com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMasters.basicMaster;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(IntegrationTest.class)
+public class HealthTest extends BaseIntegrationTest {
+    public static final TitusStackResource titusStackResource = new TitusStackResource(
+            EmbeddedTitusCell.aTitusCell()
+                    .withMaster(basicMaster(new SimulatedCloud()))
+                    .withDefaultGateway()
+                    .build(), true
+    );
+
+    @Rule
+    public final RuleChain ruleChain = RuleChain.outerRule(titusStackResource);
+
+    @Test(timeout = 30_000L)
+    public void healthStatus() throws Exception {
+        TestStreamObserver<HealthCheckResponse> testStreamObserver = new TestStreamObserver<>();
+        titusStackResource.getOperations().getHealthClient().check(HealthCheckRequest.newBuilder().build(), testStreamObserver);
+        HealthCheckResponse response = testStreamObserver.takeNext(10, TimeUnit.SECONDS);
+        assertThat(testStreamObserver.hasError()).isFalse();
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(SERVING);
+        assertThat(response.getDetailsCount()).isGreaterThan(0);
+        assertThat(response.getDetails(0).getStatus()).isEqualTo(SERVING);
+        assertThat(response.getDetails(0).hasUptime()).isTrue();
+        assertThat(response.getDetails(0).hasElectionTimestamp()).isTrue();
+        assertThat(response.getDetails(0).hasActivationTime()).isTrue();
+        assertThat(response.getDetails(0).hasActivationTimestamp()).isTrue();
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/DefaultHealthServiceGrpc.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/DefaultHealthServiceGrpc.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.gateway.endpoint.v3.grpc;
+package com.netflix.titus.runtime.endpoint.v3.grpc;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/HealthResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/HealthResource.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.gateway.endpoint.v3.rest;
+package com.netflix.titus.runtime.endpoint.v3.rest;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/HealthService.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/HealthService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.service;
+
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import rx.Observable;
+
+public interface HealthService {
+    Observable<HealthCheckResponse> check(HealthCheckRequest request);
+}

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/cli/CLI.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/cli/CLI.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 
+import com.netflix.titus.testkit.cli.command.HealthCommand;
 import com.netflix.titus.testkit.cli.command.agent.AgentInstanceGetCommand;
 import com.netflix.titus.testkit.cli.command.agent.AgentLifecycleUpdateCommand;
 import com.netflix.titus.testkit.cli.command.agent.AgentObserveCommand;
@@ -67,6 +68,8 @@ public class CLI {
     }
 
     private static Map<String, CliCommand> COMMANDS = new TreeMap<String, CliCommand>() {{
+        put("health", new HealthCommand());
+
         // Agent management
         put("agentServerGroups", new AgentServerGroupGetCommand());
         put("agentInstances", new AgentInstanceGetCommand());

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/cli/command/HealthCommand.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/cli/command/HealthCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.testkit.cli.command;
+
+import com.netflix.titus.grpc.protogen.HealthCheckRequest;
+import com.netflix.titus.grpc.protogen.HealthCheckResponse;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.testkit.cli.CliCommand;
+import com.netflix.titus.testkit.cli.CommandContext;
+import com.netflix.titus.testkit.util.PrettyPrinters;
+import org.apache.commons.cli.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HealthCommand implements CliCommand {
+    private static final Logger logger = LoggerFactory.getLogger(HealthCommand.class);
+
+    @Override
+    public String getDescription() {
+        return "Get health status";
+    }
+
+    @Override
+    public boolean isRemote() {
+        return true;
+    }
+
+    @Override
+    public Options getOptions() {
+        return new Options();
+    }
+
+    @Override
+    public void execute(CommandContext context) {
+        HealthGrpc.HealthBlockingStub client = HealthGrpc.newBlockingStub(context.createChannel());
+        try {
+            HealthCheckResponse response = client.check(HealthCheckRequest.newBuilder().build());
+            logger.info(PrettyPrinters.print(response));
+        } catch (Exception e) {
+            ErrorReports.handleReplyError("Error querying status", e);
+        }
+    }
+}

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/EmbeddedTitusOperations.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/EmbeddedTitusOperations.java
@@ -2,6 +2,7 @@ package com.netflix.titus.testkit.embedded;
 
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
@@ -10,6 +11,8 @@ import rx.Observable;
 
 public interface EmbeddedTitusOperations {
     SimulatedCloud getSimulatedCloud();
+
+    HealthGrpc.HealthStub getHealthClient();
 
     JobManagementServiceGrpc.JobManagementServiceStub getV3GrpcClient();
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedCellTitusOperations.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedCellTitusOperations.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.testkit.embedded.EmbeddedTitusOperations;
@@ -48,6 +49,11 @@ public class EmbeddedCellTitusOperations implements EmbeddedTitusOperations {
     @Override
     public SimulatedCloud getSimulatedCloud() {
         return simulatedCloud;
+    }
+
+    @Override
+    public HealthGrpc.HealthStub getHealthClient() {
+        return gateway.map(EmbeddedTitusGateway::getHealthClient).orElse(master.getHealthClient());
     }
 
     @Override

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
@@ -30,6 +30,7 @@ import com.netflix.titus.api.jobmanager.store.JobStore;
 import com.netflix.titus.gateway.startup.TitusGatewayModule;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.master.TitusMaster;
@@ -135,6 +136,11 @@ public class EmbeddedTitusGateway {
             injector.close();
         }
         return this;
+    }
+
+    public HealthGrpc.HealthStub getHealthClient() {
+        HealthGrpc.HealthStub client = HealthGrpc.newStub(getOrCreateGrpcChannel());
+        return attachCallHeaders(client);
     }
 
     public JobManagementServiceGrpc.JobManagementServiceStub getV3GrpcClient() {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
@@ -61,6 +61,8 @@ import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.ext.cassandra.testkit.store.EmbeddedCassandraStoreFactory;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc.HealthStub;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceBlockingStub;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceStub;
@@ -308,6 +310,11 @@ public class EmbeddedTitusMaster {
 
     public TitusMasterClient getClient() {
         return new DefaultTitusMasterClient("127.0.0.1", apiPort);
+    }
+
+    public HealthStub getHealthClient() {
+        HealthStub client = HealthGrpc.newStub(getOrCreateGrpcChannel());
+        return attachCallHeaders(client);
     }
 
     public JobManagementServiceStub getV3GrpcClient() {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedFederationTitusOperations.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedFederationTitusOperations.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.testkit.embedded.EmbeddedTitusOperations;
@@ -26,6 +27,11 @@ class EmbeddedFederationTitusOperations implements EmbeddedTitusOperations {
     @Override
     public SimulatedCloud getSimulatedCloud() {
         return cloudSimulator;
+    }
+
+    @Override
+    public HealthGrpc.HealthStub getHealthClient() {
+        return federation.getHealthGrpcClient();
     }
 
     @Override

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedTitusFederation.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedTitusFederation.java
@@ -31,6 +31,7 @@ import com.netflix.governator.guice.jetty.Archaius2JettyModule;
 import com.netflix.titus.federation.startup.TitusFederationModule;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
+import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.master.TitusMaster;
@@ -137,6 +138,11 @@ public class EmbeddedTitusFederation {
 
     public EmbeddedTitusOperations getTitusOperations() {
         return titusOperations;
+    }
+
+    public HealthGrpc.HealthStub getHealthGrpcClient() {
+        HealthGrpc.HealthStub client = HealthGrpc.newStub(getOrCreateGrpcChannel());
+        return attachCallHeaders(client);
     }
 
     public JobManagementServiceGrpc.JobManagementServiceStub getV3GrpcClient() {


### PR DESCRIPTION
This adds a new v3 REST and GRPC health service, with per-cell details at the federated level.

It depends on Netflix/titus-api-definitions#49.