### PR TITLE
Enforce Min Disk Size

### DIFF
--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/JobManagerConfiguration.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/JobManagerConfiguration.java
@@ -31,4 +31,10 @@ public interface JobManagerConfiguration {
 
     @DefaultValue("_none_")
     String getNoncompliantClientWhiteList();
+
+    /**
+     * @return the minimum disk size in megabytes that the disk resource dimension should be set to.
+     */
+    @DefaultValue("10000")
+    int getMinDiskSize();
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/JobManagerConfiguration.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/JobManagerConfiguration.java
@@ -36,5 +36,5 @@ public interface JobManagerConfiguration {
      * @return the minimum disk size in megabytes that the disk resource dimension should be set to.
      */
     @DefaultValue("10000")
-    int getMinDiskSize();
+    int getMinDiskSizeMB();
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizer.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizer.java
@@ -115,7 +115,7 @@ class ExtendedJobSanitizer implements EntitySanitizer {
 
     private com.netflix.titus.api.jobmanager.model.job.JobDescriptor checkResourceViolations(com.netflix.titus.api.jobmanager.model.job.JobDescriptor jobDescriptor) {
         ContainerResources containerResources = jobDescriptor.getContainer().getContainerResources();
-        int minDiskSize = jobManagerConfiguration.getMinDiskSize();
+        int minDiskSize = jobManagerConfiguration.getMinDiskSizeMB();
         if (containerResources.getDiskMB() >= minDiskSize) {
             return jobDescriptor;
         }

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizerTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.gateway.service.v3.internal;
+
+import java.util.Optional;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
+import com.netflix.titus.gateway.service.v3.JobManagerConfiguration;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExtendedJobSanitizerTest {
+
+    private static final int MIN_DISK_SIZE = 10_000;
+    private final JobManagerConfiguration configuration = mock(JobManagerConfiguration.class);
+    private final EntitySanitizer entitySanitizer = mock(EntitySanitizer.class);
+
+    @Before
+    public void setUp() {
+        when(configuration.getNoncompliantClientWhiteList()).thenReturn("_none_");
+    }
+
+    @Test
+    public void testDiskSizeIsChangedToMin() {
+        int diskSize = 100;
+        JobDescriptor jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
+                .map(jd -> jd.but(d -> d.getContainer().but(c -> c.getContainerResources().toBuilder().withDiskMB(diskSize))))
+                .cast(JobDescriptor.class).getValue();
+
+        when(configuration.getMinDiskSize()).thenReturn(MIN_DISK_SIZE);
+        when(entitySanitizer.sanitize(any())).thenReturn(Optional.of(jobDescriptor));
+
+        ExtendedJobSanitizer sanitizer = new ExtendedJobSanitizer(configuration, entitySanitizer);
+        Optional<JobDescriptor> sanitizedJobDescriptorOpt = sanitizer.sanitize(jobDescriptor);
+        JobDescriptor sanitizedJobDescriptor = sanitizedJobDescriptorOpt.get();
+        assertThat(sanitizedJobDescriptor).isNotNull();
+        assertThat(sanitizedJobDescriptor.getContainer().getContainerResources().getDiskMB()).isEqualTo(MIN_DISK_SIZE);
+        String nonCompliant = (String) sanitizedJobDescriptor.getAttributes().get("titus.noncompliant");
+        assertThat(nonCompliant).contains("diskSizeLessThanMin");
+    }
+
+    @Test
+    public void testDiskSizeIsNotChanged() {
+        int diskSize = 11_000;
+        JobDescriptor jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
+                .map(jd -> jd.but(d -> d.getContainer().but(c -> c.getContainerResources().toBuilder().withDiskMB(diskSize))))
+                .cast(JobDescriptor.class).getValue();
+
+        when(configuration.getMinDiskSize()).thenReturn(MIN_DISK_SIZE);
+        when(entitySanitizer.sanitize(any())).thenReturn(Optional.of(jobDescriptor));
+
+        ExtendedJobSanitizer sanitizer = new ExtendedJobSanitizer(configuration, entitySanitizer);
+        Optional<JobDescriptor> sanitizedJobDescriptorOpt = sanitizer.sanitize(jobDescriptor);
+        assertThat(sanitizedJobDescriptorOpt).isEmpty();
+    }
+}

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizerTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizerTest.java
@@ -48,7 +48,7 @@ public class ExtendedJobSanitizerTest {
                 .map(jd -> jd.but(d -> d.getContainer().but(c -> c.getContainerResources().toBuilder().withDiskMB(diskSize))))
                 .cast(JobDescriptor.class).getValue();
 
-        when(configuration.getMinDiskSize()).thenReturn(MIN_DISK_SIZE);
+        when(configuration.getMinDiskSizeMB()).thenReturn(MIN_DISK_SIZE);
         when(entitySanitizer.sanitize(any())).thenReturn(Optional.of(jobDescriptor));
 
         ExtendedJobSanitizer sanitizer = new ExtendedJobSanitizer(configuration, entitySanitizer);
@@ -67,7 +67,7 @@ public class ExtendedJobSanitizerTest {
                 .map(jd -> jd.but(d -> d.getContainer().but(c -> c.getContainerResources().toBuilder().withDiskMB(diskSize))))
                 .cast(JobDescriptor.class).getValue();
 
-        when(configuration.getMinDiskSize()).thenReturn(MIN_DISK_SIZE);
+        when(configuration.getMinDiskSizeMB()).thenReturn(MIN_DISK_SIZE);
         when(entitySanitizer.sanitize(any())).thenReturn(Optional.of(jobDescriptor));
 
         ExtendedJobSanitizer sanitizer = new ExtendedJobSanitizer(configuration, entitySanitizer);


### PR DESCRIPTION
Enforce that the disk size is always greater than or equal to the min disk size configuration. If the request is changed then `diskSizeLessThanMin` is appended to the `titus.noncompliant` job attribute.