### PR TITLE
[TITUS-2281] Remove validation of routable IP on jobs

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/loadbalancer/model/sanitizer/DefaultLoadBalancerJobValidator.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/loadbalancer/model/sanitizer/DefaultLoadBalancerJobValidator.java
@@ -65,12 +65,6 @@ public class DefaultLoadBalancerJobValidator implements LoadBalancerJobValidator
             throw JobManagerException.notServiceJob(jobId);
         }
 
-        // Must have routable IP
-        ContainerResources containerResources = job.getJobDescriptor().getContainer().getContainerResources();
-        if (!containerResources.isAllocateIP()) {
-            throw LoadBalancerException.jobNotRoutableIp(jobId);
-        }
-
         // Job should have less than max current load balancer associations
         int maxLoadBalancers = loadBalancerValidationConfiguration.getMaxLoadBalancersPerJob();
         int numLoadBalancers = loadBalancerStore.getNumLoadBalancersForJob(jobId);

--- a/titus-api/src/main/java/com/netflix/titus/api/loadbalancer/service/LoadBalancerException.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/loadbalancer/service/LoadBalancerException.java
@@ -23,7 +23,6 @@ import static java.lang.String.format;
 public class LoadBalancerException extends RuntimeException {
 
     public enum ErrorCode {
-        JobNotRoutableIp,
         JobMaxLoadBalancers,
         TargetGroupNotFound
     }
@@ -37,10 +36,6 @@ public class LoadBalancerException extends RuntimeException {
 
     public ErrorCode getErrorCode() {
         return errorCode;
-    }
-
-    public static LoadBalancerException jobNotRoutableIp(String jobId) {
-        return new Builder(ErrorCode.JobNotRoutableIp, format("Job %s does not have a routable IP", jobId)).build();
     }
 
     public static LoadBalancerException jobMaxLoadBalancers(String jobId, int maxLoadBalancers, int curLoadBalancers) {

--- a/titus-api/src/test/java/com/netflix/titus/api/loadbalancer/model/sanitizer/DefaultLoadBalancerJobValidatorTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/loadbalancer/model/sanitizer/DefaultLoadBalancerJobValidatorTest.java
@@ -103,29 +103,6 @@ public class DefaultLoadBalancerJobValidatorTest {
     }
 
     @Test
-    public void testValidateJobAllocateIp() throws Exception {
-        when(jobOperations.getJob(JOB_ID)).thenReturn(Optional.of(Job.<ServiceJobExt>newBuilder()
-                .withId(JOB_ID)
-                .withStatus(JobStatus.newBuilder()
-                        .withState(JobState.Accepted)
-                        .build())
-                .withJobDescriptor(JobDescriptor.<ServiceJobExt>newBuilder()
-                        .withExtensions(ServiceJobExt.newBuilder().build())
-                        .withContainer(Container.newBuilder()
-                                .withImage(Image.newBuilder().build())
-                                .withContainerResources(ContainerResources.newBuilder()
-                                        .withAllocateIP(false)
-                                        .build())
-                                .build())
-
-                        .build())
-                .build()));
-        Throwable thrown = catchThrowable(() -> loadBalancerValidator.validateJobId(JOB_ID));
-        assertThat(thrown).isInstanceOf(LoadBalancerException.class);
-        assertThat(((LoadBalancerException) thrown).getErrorCode()).isEqualTo(LoadBalancerException.ErrorCode.JobNotRoutableIp);
-    }
-
-    @Test
     public void testValidateMaxLoadBalancers() throws Exception {
         when(jobOperations.getJob(JOB_ID)).thenReturn(Optional.of(Job.<ServiceJobExt>newBuilder()
                 .withId(JOB_ID)

--- a/titus-api/src/test/java/com/netflix/titus/api/loadbalancer/service/LoadBalancerExceptionTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/loadbalancer/service/LoadBalancerExceptionTest.java
@@ -16,7 +16,10 @@ public class LoadBalancerExceptionTest {
 
     @Test
     public void getDefaultLoadBalancerExceptionLogLevelTest() {
-        assertEquals(Level.ERROR, LoadBalancerException.getLogLevel(LoadBalancerException.jobNotRoutableIp("job-id")));
+        assertEquals(
+                Level.ERROR,
+                LoadBalancerException.getLogLevel(
+                        LoadBalancerException.jobMaxLoadBalancers("job-id", 1, 1)));
     }
 
     @Test


### PR DESCRIPTION
### Description of the Change

Validation of a routable IP address for a job is no longer necessary as all jobs have IPs.