### PR TITLE
Fix status code

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
@@ -147,7 +147,7 @@ public final class ErrorResponses {
                 case V2EngineTurnedOff:
                     return Status.PERMISSION_DENIED;
                 case JobCreateLimited:
-                    return Status.RESOURCE_EXHAUSTED;
+                    return Status.INVALID_ARGUMENT;
                 case JobNotFound:
                 case TaskNotFound:
                     return Status.NOT_FOUND;


### PR DESCRIPTION
### Description of the Change
The job create limited exception happens when the requestor submits a job that already has a given app-stack-detail-sequence and should translate to invalid argument/bad request instead of resource exhausted.