### PR TITLE
ObservableExt improvements

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/rx/ObservableExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/rx/ObservableExt.java
@@ -56,7 +56,7 @@ public class ObservableExt {
      * Wrap {@link Runnable} into observable.
      */
     public static <Void> Observable<Void> fromRunnable(Runnable runnable) {
-        return (Observable<Void>) Observable.fromCallable(() -> {
+        return Observable.<Void>fromCallable(() -> {
             runnable.run();
             return null;
         }).ignoreElements();

--- a/titus-common/src/main/java/com/netflix/titus/common/util/rx/ObservableExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/rx/ObservableExt.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.common.util.rx;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -36,7 +37,6 @@ import com.netflix.titus.common.util.rx.batch.RateLimitedBatcher;
 import com.netflix.titus.common.util.spectator.SpectatorExt;
 import com.netflix.titus.common.util.tuple.Either;
 import com.netflix.titus.common.util.tuple.Pair;
-import java.util.Iterator;
 import org.slf4j.Logger;
 import rx.BackpressureOverflow;
 import rx.Completable;

--- a/titus-common/src/test/java/com/netflix/titus/common/util/rx/ObservableExtTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/rx/ObservableExtTest.java
@@ -1,0 +1,109 @@
+package com.netflix.titus.common.util.rx;
+
+import com.netflix.titus.testkit.rx.ExtTestSubscriber;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import rx.Observable;
+import rx.schedulers.Schedulers;
+import rx.schedulers.TestScheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+public class ObservableExtTest {
+
+    private static final int DELAY_MS = 100;
+
+    private final TestScheduler testScheduler = Schedulers.test();
+
+    private final ExtTestSubscriber<Object> testSubscriber = new ExtTestSubscriber<>();
+
+    private final Object A = new Object(),
+            B = new Object(),
+            C = new Object(),
+            D = new Object(),
+            E = new Object(),
+            F = new Object();
+
+    @Test
+    public void testFromWithDelayEmpty() {
+        final List<Observable<Object>> chunks = Collections.emptyList();
+        Observable<Object> observable = ObservableExt.fromWithDelay(chunks, DELAY_MS, TimeUnit.MILLISECONDS, testScheduler);
+        observable = observable.defaultIfEmpty(B);
+
+        observable.subscribe(testSubscriber);
+
+        assertThat(testSubscriber.takeNext()).isSameAs(B);
+        assertThat(testSubscriber.takeNext()).isNull();
+    }
+
+    @Test
+    public void testFromWithDelaySingle() {
+        final List<Observable<Object>> chunks = Collections.singletonList(Observable.just(A));
+        Observable<Object> observable = ObservableExt.fromWithDelay(chunks, DELAY_MS, TimeUnit.MILLISECONDS, testScheduler);
+        observable = observable.defaultIfEmpty(B);
+
+        observable.subscribe(testSubscriber);
+
+        assertThat(testSubscriber.takeNext()).isSameAs(A);
+        assertThat(testSubscriber.takeNext()).isNull();
+    }
+
+    @Test
+    public void testFromWithDelayMultiple() {
+        final List<Observable<Object>> chunks = Arrays.asList(
+                Observable.just(A).delay(1, TimeUnit.MILLISECONDS, testScheduler),
+                Observable.just(B, C, D),
+                Observable.just(E));
+        Observable<Object> observable = ObservableExt.fromWithDelay(chunks, DELAY_MS, TimeUnit.MILLISECONDS, testScheduler);
+        observable = observable.defaultIfEmpty(B);
+
+        observable.subscribe(testSubscriber);
+
+        // Nothing is available yet. The first element arrives after 1 ms because
+        // of the delay on the just(A).
+        assertThat(testSubscriber.takeNext()).isNull();
+
+        assertThat(1).isLessThan(DELAY_MS);
+        testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+        // Now that we've waited the 1 ms delay, A should be available. Note
+        // that fromWithDelay() should not delay the first element by DELAY_MS.
+        assertThat(testSubscriber.takeNext()).isSameAs(A);
+        assertThat(testSubscriber.takeNext()).isNull();
+
+        testScheduler.advanceTimeBy(DELAY_MS, TimeUnit.MILLISECONDS);
+        assertThat(testSubscriber.takeNext()).isSameAs(B);
+        assertThat(testSubscriber.takeNext()).isSameAs(C);
+        assertThat(testSubscriber.takeNext()).isSameAs(D);
+        assertThat(testSubscriber.takeNext()).isNull();
+
+        testScheduler.advanceTimeBy(DELAY_MS, TimeUnit.MILLISECONDS);
+        assertThat(testSubscriber.takeNext()).isSameAs(E);
+        assertThat(testSubscriber.takeNext()).isNull();
+    }
+
+    @Test
+    public void testFromWithDelayHundreds() {
+        final int NUM_CHUNKS_TO_TEST = 300;
+        final List<Observable<Integer>> chunks = new ArrayList<>(NUM_CHUNKS_TO_TEST);
+        for (int i = 0; i < NUM_CHUNKS_TO_TEST; ++i) {
+            chunks.add(Observable.just(i).delay(1000, TimeUnit.MILLISECONDS, testScheduler));
+        }
+        Observable<Integer> observable = ObservableExt.fromWithDelay(chunks, DELAY_MS, TimeUnit.MILLISECONDS, testScheduler);
+        observable = observable.defaultIfEmpty(-1);
+
+        observable.subscribe(testSubscriber);
+
+        assertThat(testSubscriber.takeNext()).isNull();
+
+        for (int i = 0; i < NUM_CHUNKS_TO_TEST; ++i) {
+            if (i > 0) testScheduler.advanceTimeBy(DELAY_MS, TimeUnit.MILLISECONDS);
+            testScheduler.advanceTimeBy(1000, TimeUnit.MILLISECONDS);
+            assertThat(testSubscriber.takeNext()).isEqualTo(i);
+            assertThat(testSubscriber.takeNext()).isNull();
+        }
+    }
+}


### PR DESCRIPTION
 * Specify a type parameter in fromRunnable() to fix an "unchecked cast" warning in NetBeans.
 * Delete a technically unsound cast in fromWithDelay()