### PR TITLE
allow V3 jobs to specify a custom CMD 

### DIFF
--- a/codequality/Intellij_code_style.xml
+++ b/codequality/Intellij_code_style.xml
@@ -1,4 +1,4 @@
-<code_scheme name="Titus">
+<code_scheme name="Titus" version="173">
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
   <option name="IMPORT_LAYOUT_TABLE">
@@ -11,6 +11,21 @@
       <package name="" withSubpackages="true" static="true" />
     </value>
   </option>
+  <JavaCodeStyleSettings>
+    <option name="SPACE_BEFORE_COLON_IN_FOREACH" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="java" withSubpackages="true" static="false" />
+        <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="true" />
+      </value>
+    </option>
+  </JavaCodeStyleSettings>
   <codeStyleSettings language="JAVA">
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultCellRouter.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultCellRouter.java
@@ -46,7 +46,7 @@ public class DefaultCellRouter implements CellRouter {
         this.federationConfiguration = federationConfiguration;
 
         compileRoutingPatterns = new MemoizedFunction<>((spec, lastCompiledPatterns) -> {
-            logger.info("Detected new routing rules, compiling them");
+            logger.info("Detected new routing rules, compiling them: {}", spec);
             List<Cell> cells = cellInfoResolver.resolve();
             Map<Cell, String> cellRoutingRules = CellInfoUtil.extractCellRoutingFromCellSpecification(cells, spec);
             try {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.google.common.primitives.Ints;
-import com.netflix.archaius.api.Config;
 import com.netflix.fenzo.PreferentialNamedConsumableResourceSet;
 import com.netflix.fenzo.TaskRequest;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
@@ -38,12 +37,13 @@ import com.netflix.titus.api.jobmanager.model.job.JobGroupInfo;
 import com.netflix.titus.api.jobmanager.model.job.SecurityProfile;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.model.EfsMount;
+import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.master.config.MasterConfiguration;
 import com.netflix.titus.master.job.worker.WorkerRequest;
 import com.netflix.titus.master.model.job.TitusQueuableTask;
-import io.titanframework.messages.TitanProtos;
+import io.titanframework.messages.TitanProtos.ContainerInfo;
 import io.titanframework.messages.TitanProtos.ContainerInfo.EfsConfigInfo;
 import org.apache.mesos.Protos;
 
@@ -71,16 +71,13 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
 
     private final MasterConfiguration masterConfiguration;
     private final MesosConfiguration mesosConfiguration;
-    private final Config config;
     private final String iamArnPrefix;
 
     @Inject
     public DefaultV3TaskInfoFactory(MasterConfiguration masterConfiguration,
-                                    MesosConfiguration mesosConfiguration,
-                                    Config config) {
+                                    MesosConfiguration mesosConfiguration) {
         this.masterConfiguration = masterConfiguration;
         this.mesosConfiguration = mesosConfiguration;
-        this.config = config;
         // Get the AWS account ID to use for building IAM ARNs.
         String accountId = Evaluators.getOrDefault(System.getenv("EC2_OWNER_ID"), "default");
         this.iamArnPrefix = ARN_PREFIX + accountId + ARN_SUFFIX;
@@ -98,27 +95,25 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
         String taskId = task.getId();
         Protos.TaskID protoTaskId = Protos.TaskID.newBuilder().setValue(taskId).build();
         Protos.ExecutorInfo executorInfo = newExecutorInfo(task, attributesMap, executorUriOverrideOpt);
-        Protos.TaskInfo.Builder taskInfoBuilder = newTaskInfoBuilder(protoTaskId, executorInfo, slaveID);
-        taskInfoBuilder = setupPrimaryResources(taskInfoBuilder, fenzoTask);
-
-        TitanProtos.ContainerInfo.Builder containerInfoBuilder = newContainerInfoBuilder(job, task, fenzoTask);
+        Protos.TaskInfo.Builder taskInfoBuilder = newTaskInfoBuilder(protoTaskId, executorInfo, slaveID, fenzoTask);
+        ContainerInfo.Builder containerInfoBuilder = newContainerInfoBuilder(job, task, fenzoTask);
         taskInfoBuilder.setData(containerInfoBuilder.build().toByteString());
         return taskInfoBuilder.build();
     }
 
-    private TitanProtos.ContainerInfo.Builder newContainerInfoBuilder(Job job, Task task, TitusQueuableTask<Job, Task> fenzoTask) {
-        TitanProtos.ContainerInfo.Builder containerInfoBuilder = TitanProtos.ContainerInfo.newBuilder();
+    private ContainerInfo.Builder newContainerInfoBuilder(Job job, Task task, TitusQueuableTask<Job, Task> fenzoTask) {
+        ContainerInfo.Builder containerInfoBuilder = ContainerInfo.newBuilder();
         Container container = job.getJobDescriptor().getContainer();
         Map<String, String> containerAttributes = container.getAttributes();
         ContainerResources containerResources = container.getContainerResources();
         SecurityProfile v3SecurityProfile = container.getSecurityProfile();
 
-        // Docker Values (Image and Entrypoint)
+        // Docker Values (Image, entrypoint, and command)
         Image image = container.getImage();
         containerInfoBuilder.setImageName(image.getName());
         applyNotNull(image.getDigest(), containerInfoBuilder::setImageDigest);
         applyNotNull(image.getTag(), containerInfoBuilder::setVersion);
-        containerInfoBuilder.setEntrypointStr(StringExt.concatenate(container.getEntryPoint(), " "));
+        setEntryPointCommand(containerInfoBuilder, container);
 
         // Netflix Values
         // Configure Netflix Metadata
@@ -134,7 +129,7 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
         String metatronAppMetadata = v3SecurityProfile.getAttributes().get(WorkerRequest.V2_NETFLIX_APP_METADATA);
         String metatronAppSignature = v3SecurityProfile.getAttributes().get(WorkerRequest.V2_NETFLIX_APP_METADATA_SIG);
         if (metatronAppMetadata != null && metatronAppSignature != null) {
-            TitanProtos.ContainerInfo.MetatronCreds.Builder metatronBuilder = TitanProtos.ContainerInfo.MetatronCreds.newBuilder()
+            ContainerInfo.MetatronCreds.Builder metatronBuilder = ContainerInfo.MetatronCreds.newBuilder()
                     .setAppMetadata(metatronAppMetadata)
                     .setMetadataSig(metatronAppSignature);
             containerInfoBuilder.setMetatronCreds(metatronBuilder.build());
@@ -194,7 +189,7 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
         List<String> securityGroups = v3SecurityProfile.getSecurityGroups();
         final TaskRequest.AssignedResources assignedResources = fenzoTask.getAssignedResources();
         String eniLabel = assignedResources == null ? "0" : "" + assignedResources.getConsumedNamedResources().get(0).getIndex();
-        TitanProtos.ContainerInfo.NetworkConfigInfo.Builder networkConfigInfoBuilder = TitanProtos.ContainerInfo.NetworkConfigInfo.newBuilder()
+        ContainerInfo.NetworkConfigInfo.Builder networkConfigInfoBuilder = ContainerInfo.NetworkConfigInfo.newBuilder()
                 .setEniLabel(eniLabel)
                 .setEniLablel(eniLabel)
                 .addAllSecurityGroups(securityGroups)
@@ -211,16 +206,29 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
         return containerInfoBuilder;
     }
 
-    private Protos.TaskInfo.Builder newTaskInfoBuilder(Protos.TaskID taskId, Protos.ExecutorInfo executorInfo, Protos.SlaveID slaveID) {
-        return Protos.TaskInfo.newBuilder()
+    private void setEntryPointCommand(ContainerInfo.Builder containerInfoBuilder, Container container) {
+        if (CollectionsExt.isNullOrEmpty(container.getCommand())) {
+            // fallback to the old behavior when no command is set to avoid breaking existing jobs relying on shell
+            // parsing and word splitting being done by the executor for flat string entrypoints
+            containerInfoBuilder.setEntrypointStr(StringExt.concatenate(container.getEntryPoint(), " "));
+            return;
+        }
+        containerInfoBuilder.setProcess(ContainerInfo.Process.newBuilder()
+                .addAllEntrypoint(container.getEntryPoint())
+                .addAllCommand(container.getCommand())
+        );
+    }
+
+    private Protos.TaskInfo.Builder newTaskInfoBuilder(Protos.TaskID taskId,
+                                                       Protos.ExecutorInfo executorInfo,
+                                                       Protos.SlaveID slaveID,
+                                                       TitusQueuableTask<Job, Task> fenzoTask) {
+
+        Protos.TaskInfo.Builder builder = Protos.TaskInfo.newBuilder()
                 .setTaskId(taskId)
                 .setName(taskId.getValue())
                 .setExecutor(executorInfo)
-                .setSlaveId(slaveID);
-    }
-
-    private Protos.TaskInfo.Builder setupPrimaryResources(Protos.TaskInfo.Builder builder, TitusQueuableTask<Job, Task> fenzoTask) {
-        builder
+                .setSlaveId(slaveID)
                 .addResources(Protos.Resource.newBuilder()
                         .setName("cpus")
                         .setType(Protos.Value.Type.SCALAR)
@@ -241,7 +249,7 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
         // set scalars other than cpus, mem, disk
         final Map<String, Double> scalars = fenzoTask.getScalarRequests();
         if (scalars != null && !scalars.isEmpty()) {
-            for (Map.Entry<String, Double> entry : scalars.entrySet()) {
+            for (Map.Entry<String, Double> entry: scalars.entrySet()) {
                 if (!Container.PRIMARY_RESOURCES.contains(entry.getKey())) { // Already set above
                     builder.addResources(Protos.Resource.newBuilder()
                             .setName(entry.getKey())

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
@@ -249,7 +249,7 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
         // set scalars other than cpus, mem, disk
         final Map<String, Double> scalars = fenzoTask.getScalarRequests();
         if (scalars != null && !scalars.isEmpty()) {
-            for (Map.Entry<String, Double> entry: scalars.entrySet()) {
+            for (Map.Entry<String, Double> entry : scalars.entrySet()) {
                 if (!Container.PRIMARY_RESOURCES.contains(entry.getKey())) { // Already set above
                     builder.addResources(Protos.Resource.newBuilder()
                             .setName(entry.getKey())

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactoryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.netflix.fenzo.PreferentialNamedConsumableResourceSet;
+import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.api.model.Tier;
+import com.netflix.titus.common.data.generator.DataGenerator;
+import com.netflix.titus.master.config.MasterConfiguration;
+import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
+import com.netflix.titus.master.scheduler.constraint.SystemHardConstraint;
+import com.netflix.titus.master.scheduler.constraint.SystemSoftConstraint;
+import com.netflix.titus.master.scheduler.constraint.TaskCache;
+import com.netflix.titus.master.scheduler.constraint.V3ConstraintEvaluatorTransformer;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import io.titanframework.messages.TitanProtos;
+import org.apache.mesos.Protos;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultV3TaskInfoFactoryTest {
+
+    private MasterConfiguration masterConfiguration;
+
+    @Before
+    public void setUp() throws Exception {
+        masterConfiguration = mock(MasterConfiguration.class);
+        when(masterConfiguration.pathToTitusExecutor()).thenReturn("/usr/bin/titus-executor");
+    }
+
+    @Test
+    public void jobsWithNoCommandSendFlatEntrypointStringToAgents() throws InvalidProtocolBufferException {
+        DefaultV3TaskInfoFactory factory = new DefaultV3TaskInfoFactory(masterConfiguration, mock(MesosConfiguration.class));
+        JobDescriptor<BatchJobExt> jobDescriptor = JobDescriptorGenerator.oneTaskBatchJobDescriptor();
+        jobDescriptor = jobDescriptor.toBuilder().withContainer(jobDescriptor.getContainer().toBuilder()
+                .withEntryPoint(Arrays.asList("some", "entrypoint"))
+                .build()
+        ).build();
+
+        Protos.TaskInfo taskInfo = buildTaskInfo(factory, jobDescriptor);
+        TitanProtos.ContainerInfo containerInfo = TitanProtos.ContainerInfo.parseFrom(taskInfo.getData());
+        assertThat(containerInfo.getEntrypointStr()).isEqualTo("some entrypoint");
+        assertThat(containerInfo.hasProcess()).isFalse();
+    }
+
+    @Test
+    public void jobsWithCommandDoNotSendFlatStrings() throws InvalidProtocolBufferException {
+        DefaultV3TaskInfoFactory factory = new DefaultV3TaskInfoFactory(masterConfiguration, mock(MesosConfiguration.class));
+        JobDescriptor<BatchJobExt> jobDescriptor = JobDescriptorGenerator.oneTaskBatchJobDescriptor();
+        jobDescriptor = jobDescriptor.toBuilder().withContainer(jobDescriptor.getContainer().toBuilder()
+                .withEntryPoint(Arrays.asList("some", "entrypoint"))
+                .withCommand(Arrays.asList("some", "command"))
+                .build()
+        ).build();
+
+        Protos.TaskInfo taskInfo = buildTaskInfo(factory, jobDescriptor);
+        TitanProtos.ContainerInfo containerInfo = TitanProtos.ContainerInfo.parseFrom(taskInfo.getData());
+        assertThat(containerInfo.hasEntrypointStr()).isFalse();
+        assertThat(containerInfo.getProcess().getEntrypointList()).containsExactly("some", "entrypoint");
+        assertThat(containerInfo.getProcess().getCommandList()).containsExactly("some", "command");
+    }
+
+    private Protos.TaskInfo buildTaskInfo(DefaultV3TaskInfoFactory factory, JobDescriptor<BatchJobExt> jobDescriptor) {
+        DataGenerator<Job<BatchJobExt>> jobs = JobGenerator.batchJobs(jobDescriptor);
+        Job<BatchJobExt> job = jobs.getValue();
+        DataGenerator<BatchJobTask> tasks = JobGenerator.batchTasks(job);
+        BatchJobTask task = tasks.getValue();
+        V3ConstraintEvaluatorTransformer transformer = new V3ConstraintEvaluatorTransformer(masterConfiguration, new TaskCache(mock(V3JobOperations.class)));
+
+        V3QueueableTask fenzoTask = new V3QueueableTask(Tier.Flex, null, job, task,
+                () -> Collections.singleton(task.getId()),
+                transformer, mock(SystemSoftConstraint.class),
+                mock(SystemHardConstraint.class)
+        );
+        Protos.SlaveID agentId = Protos.SlaveID.newBuilder()
+                .setValue("someAgent")
+                .build();
+        PreferentialNamedConsumableResourceSet.ConsumeResult consumeResult = new PreferentialNamedConsumableResourceSet.ConsumeResult(
+                0, "someAgent", "someResource", 1.0
+        );
+        return factory.newTaskInfo(fenzoTask, job, task, "someHost", Collections.emptyMap(), agentId, consumeResult, Optional.empty());
+    }
+}


### PR DESCRIPTION
### Description of the Change

Jobs that specify a custom `CMD` will have their entrypoint and command sent to agents not as flat
strings anymore. The new code path on agents will not force any shell parsing. It is responsibility of API callers to break commands and entrypoints into valid lists, respecting the semantics of [the docker API](https://docs.docker.com/engine/api/v1.24/#create-a-container), and [`execvp`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html).

The old behavior of flattening entrypoint strings, and relying on agent code to do shell parsing is being retired. To avoid breaking existing jobs, and allow for a smooth transition, only jobs that specify a command (previously a noop) will be sent to the new code path.

Related to Netflix/titus-executor#152 and Netflix/titus-api-definitions#52 (also TITUS-1574)