### PR TITLE
mark jobs with spaces in their entrypoint binaries as noncompliant

### DIFF
--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/ContainersGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/ContainersGenerator.java
@@ -117,7 +117,7 @@ public final class ContainersGenerator {
 
     private static DataGenerator<Triple<List<String>, List<String>, Map<String, String>>> executable() {
         DataGenerator<Pair<List<String>, List<String>>> entryPointAndCommands = DataGenerator.zip(
-                items(asList("sleep 100"), asList("echo 'Hello'")),
+                items(asList("/bin/sh", "-c"), asList("echo 'Hello'")),
                 items(Collections.<String>emptyList(), Collections.<String>emptyList())
         );
         DataGenerator<Map<String, String>> envs = items(


### PR DESCRIPTION
These jobs are likely relying on legacy shell parsing being done by the executor, which is going away.

Internal: TITUS-1574