### PR TITLE
Agent quality tracker

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -100,6 +100,13 @@ public final class JobFunctions {
         return task instanceof ServiceJobTask;
     }
 
+    /**
+     * @return true if the task is or was at some point in time in the started state.
+     */
+    public static boolean everStarted(Task task) {
+        return findTaskStatus(task, TaskState.Started).isPresent();
+    }
+
     public static Job changeJobStatus(Job job, JobState jobState, String reasonCode) {
         JobStatus newStatus = JobModel.newJobStatus()
                 .withState(jobState)

--- a/titus-common/src/main/java/com/netflix/titus/common/util/TimeSeriesData.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/TimeSeriesData.java
@@ -1,0 +1,118 @@
+package com.netflix.titus.common.util;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+
+import com.netflix.titus.common.util.time.Clock;
+import com.netflix.titus.common.util.tuple.Pair;
+
+/**
+ * Simple, concurrent time series data collector.
+ */
+public class TimeSeriesData {
+
+    private static final Pair<Double, Long> CLEANUP_MARKER = Pair.of(0.0, 0L);
+
+    private final long retentionMs;
+    private final long stepMs;
+
+    private final BiFunction<Double, Long, Double> adjuster;
+    private final Clock clock;
+
+    private final Queue<Pair<Double, Long>> offers = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedDeque<Pair<Double, Long>> data = new ConcurrentLinkedDeque<>();
+    private final AtomicReference<Pair<Double, Long>> lastAggregate;
+
+    private final Pair<Double, Long> nothing;
+    private final AtomicInteger wipMarker = new AtomicInteger();
+
+    public TimeSeriesData(long retentionMs,
+                          long stepMs,
+                          BiFunction<Double, Long, Double> adjuster,
+                          Clock clock) {
+        this.retentionMs = retentionMs;
+        this.stepMs = stepMs;
+        this.adjuster = adjuster;
+        this.clock = clock;
+
+        this.nothing = Pair.of(0.0, 0L);
+        this.lastAggregate = new AtomicReference<>(nothing);
+    }
+
+    public void add(double value, long timestamp) {
+        long now = clock.wallTime();
+        if (now - retentionMs < timestamp) {
+            offers.add(Pair.of(value, timestamp));
+            process(now);
+        }
+    }
+
+    public void clear() {
+        if (!data.isEmpty()) {
+            offers.add(CLEANUP_MARKER);
+            process(clock.wallTime());
+        }
+    }
+
+    public double getAggregatedValue() {
+        if (data.isEmpty()) {
+            return 0.0;
+        }
+
+        long now = clock.wallTime();
+        if (now - lastAggregate.get().getRight() >= stepMs) {
+            process(now);
+        }
+        return lastAggregate.get().getLeft();
+    }
+
+    private void process(long now) {
+        if (wipMarker.getAndIncrement() == 0) {
+            do {
+                boolean changed = false;
+
+                // Remove expired entries
+                long expiredTimestamp = now - retentionMs;
+                for (Pair<Double, Long> next; (next = data.peek()) != null && next.getRight() <= expiredTimestamp; ) {
+                    data.poll();
+                    changed = true;
+                }
+
+                // Add new entries
+                Pair<Double, Long> offer;
+                while ((offer = offers.poll()) != null) {
+                    long latest = data.isEmpty() ? 0 : data.getLast().getRight();
+                    if (offer == CLEANUP_MARKER) {
+                        data.clear();
+                        changed = true;
+                    } else if (offer.getRight() >= latest) {
+                        data.add(offer);
+                        changed = true;
+                    }
+                }
+
+                // Recompute the aggregated value if needed
+                if (changed || now - lastAggregate.get().getRight() >= stepMs) {
+                    lastAggregate.set(computeAggregatedValue(now));
+                }
+            } while (wipMarker.decrementAndGet() != 0);
+        }
+    }
+
+    private Pair<Double, Long> computeAggregatedValue(long now) {
+        if (data.isEmpty()) {
+            return nothing;
+        }
+
+        double sum = 0;
+        for (Pair<Double, Long> next : data) {
+            sum += adjuster.apply(next.getLeft(), now - next.getRight());
+        }
+
+        return Pair.of(sum, now);
+    }
+}

--- a/titus-common/src/test/java/com/netflix/titus/common/util/TimeSeriesDataTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/TimeSeriesDataTest.java
@@ -1,0 +1,47 @@
+package com.netflix.titus.common.util;
+
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.titus.common.util.time.Clocks;
+import com.netflix.titus.common.util.time.TestClock;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeSeriesDataTest {
+
+    private static final long RETENTION_MS = 60_000;
+    private static final long STEP_MS = 1_000;
+
+    private final TestClock testClock = Clocks.test();
+
+    private final TimeSeriesData timeSeriesData = new TimeSeriesData(
+            RETENTION_MS,
+            STEP_MS,
+            (value, delayMs) -> value / (1 + delayMs / 1_000),
+            testClock
+    );
+
+    @Test
+    public void testAggregate() {
+        timeSeriesData.add(30, testClock.wallTime());
+        testClock.advanceTime(2_000, TimeUnit.MILLISECONDS);
+        timeSeriesData.add(20, testClock.wallTime());
+        assertThat(timeSeriesData.getAggregatedValue()).isEqualTo(30);
+    }
+
+    @Test
+    public void testDataExpiry() {
+        timeSeriesData.add(10, testClock.wallTime());
+        testClock.advanceTime(60_000, TimeUnit.MILLISECONDS);
+        timeSeriesData.add(10, testClock.wallTime());
+        assertThat(timeSeriesData.getAggregatedValue()).isEqualTo(10);
+    }
+
+    @Test
+    public void testClear() {
+        timeSeriesData.add(10, testClock.wallTime());
+        timeSeriesData.clear();
+        assertThat(timeSeriesData.getAggregatedValue()).isEqualTo(0);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/cluster/DefaultLeaderActivator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/cluster/DefaultLeaderActivator.java
@@ -33,6 +33,8 @@ import com.netflix.titus.common.util.guice.ContainerEventBus.ContainerEventListe
 import com.netflix.titus.common.util.guice.ContainerEventBus.ContainerStartedEvent;
 import com.netflix.titus.common.util.time.Clock;
 import com.netflix.titus.master.MetricConstants;
+import com.netflix.titus.master.scheduler.AgentQualityTracker;
+import com.netflix.titus.master.scheduler.ContainerFailureBasedAgentQualityTracker;
 import com.netflix.titus.master.scheduler.SchedulingService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -197,6 +199,9 @@ public class DefaultLeaderActivator implements LeaderActivator, ContainerEventLi
         try {
             try {
                 activationLifecycle.activate();
+
+                // FIXME Circular dependencies forces are to postpone the activation process.
+                ((ContainerFailureBasedAgentQualityTracker)injector.getInstance(AgentQualityTracker.class)).start();
                 injector.getInstance(SchedulingService.class).startScheduling();
             } catch (Exception e) {
                 stopBeingLeader();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/AgentQualityTracker.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/AgentQualityTracker.java
@@ -1,0 +1,12 @@
+package com.netflix.titus.master.scheduler;
+
+public interface AgentQualityTracker {
+
+    /**
+     * Evaluates quality of an agent with the given id from 0 to 1 (0 == do not use it, 1 == perfect).
+     *
+     * @param agentHostName an agent host name
+     * @return the agent's quality score from 0 to 1, or -1 if there is no agent with the given id
+     */
+    double qualityOf(String agentHostName);
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
@@ -50,17 +50,17 @@ public class ContainerFailureBasedAgentQualityTracker implements AgentQualityTra
     private static final double LOST_AFTER_STARTED_WEIGHT = 0.1;
 
     /**
-     * A container starting error due to an agent local problems. We give it a highest score.
+     * A container starting error due to agent local problems. We give it a highest score.
      */
     private static final double LOCAL_STARTING_ERROR_WEIGHT = 0.5;
 
     /**
-     * Not agent related issue us not counted as an error.
+     * Issue not related to agent; not counted as error.
      */
     private static final double SYSTEM_STARTING_ERROR_WEIGHT = 0;
 
     /**
-     * A container crash may indicate the underlying agent degradation. We give it a middle score value.
+     * A container crash may indicate underlying agent degradation. We give it a middle score value.
      */
     private static final double CONTAINER_CRASH_WEIGHT = 0.3;
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
@@ -220,6 +220,7 @@ public class ContainerFailureBasedAgentQualityTracker implements AgentQualityTra
                 return null;
             }
             placement = agentManagementService.findAgentInstance(instanceId).map(PlacementHistory::new).orElse(null);
+            agentsPlacementHistory.put(hostname, placement);
         }
 
         return placement;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
@@ -1,0 +1,262 @@
+package com.netflix.titus.master.scheduler;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.api.agent.model.AgentInstance;
+import com.netflix.titus.api.agent.model.event.AgentEvent;
+import com.netflix.titus.api.agent.model.event.AgentInstanceRemovedEvent;
+import com.netflix.titus.api.agent.model.event.AgentInstanceUpdateEvent;
+import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.api.jobmanager.TaskAttributes;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
+import com.netflix.titus.api.jobmanager.model.job.event.JobManagerEvent;
+import com.netflix.titus.api.jobmanager.model.job.event.TaskUpdateEvent;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.TimeSeriesData;
+import com.netflix.titus.common.util.code.CodeInvariants;
+import com.netflix.titus.common.util.rx.ObservableExt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Subscription;
+
+@Singleton
+public class ContainerFailureBasedAgentQualityTracker implements AgentQualityTracker {
+
+    private static final Logger logger = LoggerFactory.getLogger(ContainerFailureBasedAgentQualityTracker.class);
+
+    private final ConcurrentMap<String, PlacementHistory> agentsPlacementHistory = new ConcurrentHashMap<>();
+
+    private final SchedulerConfiguration configuration;
+    private final AgentManagementService agentManagementService;
+    private final V3JobOperations v3JobOperations;
+    private final TitusRuntime titusRuntime;
+    private final CodeInvariants invariants;
+
+    private Subscription agentStreamSubscription;
+    private Subscription jobStreamSubscription;
+
+    @Inject
+    public ContainerFailureBasedAgentQualityTracker(SchedulerConfiguration configuration,
+                                                    AgentManagementService agentManagementService,
+                                                    V3JobOperations v3JobOperations,
+                                                    TitusRuntime titusRuntime) {
+        this.configuration = configuration;
+        this.agentManagementService = agentManagementService;
+        this.v3JobOperations = v3JobOperations;
+        this.titusRuntime = titusRuntime;
+        this.invariants = titusRuntime.getCodeInvariants();
+    }
+
+    /**
+     * FIXME Due to circular dependency between components, we cannot use the activation framework here.
+     */
+    public void start() {
+        this.agentStreamSubscription = titusRuntime.persistentStream(agentManagementService.events(true)).subscribe(
+                this::handleAgentEvent,
+                e -> logger.error("Agent event stream terminated with an error", e),
+                () -> logger.info("Agent event stream onCompleted")
+        );
+        this.jobStreamSubscription = titusRuntime.persistentStream(v3JobOperations.observeJobs()).subscribe(
+                this::handleJobEvent,
+                e -> logger.error("Job event stream terminated with an error", e),
+                () -> logger.info("Job event stream onCompleted")
+        );
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        ObservableExt.safeUnsubscribe(agentStreamSubscription, jobStreamSubscription);
+    }
+
+    @Override
+    public double qualityOf(String agentHostName) {
+        PlacementHistory history = agentsPlacementHistory.get(agentHostName);
+        if (history == null) {
+            return -1;
+        }
+        return history.quality();
+    }
+
+    private void handleAgentEvent(AgentEvent event) {
+        try {
+            tryHandleAgentEvent(event);
+        } catch (Exception e) {
+            logger.warn("Unexpected exception during handling agent event: event={}", event, e);
+        }
+    }
+
+    private void tryHandleAgentEvent(AgentEvent event) {
+        if (event instanceof AgentInstanceUpdateEvent) {
+            AgentInstanceUpdateEvent agentEvent = (AgentInstanceUpdateEvent) event;
+            String hostname = agentEvent.getAgentInstance().getHostname();
+            if (agentsPlacementHistory.get(hostname) == null) {
+                agentsPlacementHistory.put(hostname, new PlacementHistory(agentEvent.getAgentInstance()));
+            }
+        } else if (event instanceof AgentInstanceRemovedEvent) {
+            String instanceId = ((AgentInstanceRemovedEvent) event).getAgentInstanceId();
+            agentsPlacementHistory.values().removeIf(i -> i.getInstance().getId().equals(instanceId));
+        }
+    }
+
+    private void handleJobEvent(JobManagerEvent<?> event) {
+        try {
+            tryHandleJobEvent(event);
+        } catch (Exception e) {
+            logger.warn("Unexpected exception during handling job event: event={}", event, e);
+        }
+    }
+
+    private void tryHandleJobEvent(JobManagerEvent<?> event) {
+        if (!(event instanceof TaskUpdateEvent)) {
+            return;
+        }
+
+        TaskUpdateEvent taskEvent = (TaskUpdateEvent) event;
+        Task task = taskEvent.getCurrentTask();
+
+        if (task.getStatus().getState() == TaskState.Started) {
+            handleTaskStartedEvent(task);
+        } else if (task.getStatus().getState() == TaskState.Finished) {
+            handleTaskFinishedEvent(task);
+        }
+    }
+
+    private void handleTaskStartedEvent(Task task) {
+        PlacementHistory placement = tryGetOrCreatePlacementHistory(task);
+        if (placement != null) {
+            placement.onTaskStarted();
+        }
+    }
+
+    private void handleTaskFinishedEvent(Task task) {
+        String reasonCode = task.getStatus().getReasonCode();
+        if (reasonCode == null) {
+            invariants.inconsistent("Task with status without reason code: taskId={}, status={}", task.getId(), task.getStatus());
+            return;
+        }
+
+        ErrorKind errorKind;
+        switch (reasonCode) {
+            case TaskStatus.REASON_NORMAL:
+            case TaskStatus.REASON_TASK_KILLED:
+            case TaskStatus.REASON_FAILED:
+            case TaskStatus.REASON_STUCK_IN_KILLING_STATE:
+            default:
+                return;
+            case TaskStatus.REASON_CRASHED:
+                errorKind = ErrorKind.ContainerCrash;
+                break;
+            case TaskStatus.REASON_TASK_LOST:
+                errorKind = isStartedTask(task) ? ErrorKind.LostAfterStarted : ErrorKind.LostBeforeStarted;
+                break;
+            case TaskStatus.REASON_STUCK_IN_STATE:
+            case TaskStatus.REASON_LOCAL_SYSTEM_ERROR:
+                errorKind = ErrorKind.LocalStartingError;
+                break;
+            case TaskStatus.REASON_TRANSIENT_SYSTEM_ERROR:
+            case TaskStatus.REASON_UNKNOWN_SYSTEM_ERROR:
+                errorKind = ErrorKind.SystemStartingError;
+                break;
+        }
+
+        PlacementHistory placement = tryGetOrCreatePlacementHistory(task);
+        if (placement != null) {
+            placement.onTaskFailure(errorKind);
+        }
+    }
+
+    private PlacementHistory tryGetOrCreatePlacementHistory(Task task) {
+        String hostId = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST);
+        if (hostId == null) {
+            invariants.inconsistent("Task without host name assigned: taskId=%s", task.getId());
+            return null;
+        }
+
+        PlacementHistory placement = agentsPlacementHistory.get(hostId);
+        if (placement == null) {
+            String instanceId = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID);
+            if (instanceId == null) {
+                invariants.inconsistent("Task without agent id assigned: taskId=%s", task.getId());
+                return null;
+            }
+            placement = agentManagementService.findAgentInstance(instanceId).map(PlacementHistory::new).orElse(null);
+        }
+
+        return placement;
+    }
+
+    private boolean isStartedTask(Task task) {
+        return JobFunctions.findTaskStatus(task, TaskState.Started).isPresent();
+    }
+
+    private enum ErrorKind {
+        LostAfterStarted,
+        LostBeforeStarted,
+        LocalStartingError,
+        SystemStartingError,
+        ContainerCrash
+    }
+
+    private class PlacementHistory {
+
+        private final AgentInstance instance;
+        private final TimeSeriesData errorTimeSeries = new TimeSeriesData(
+                configuration.getContainerFailureTrackingRetentionMs(),
+                1_000,
+                (value, delayMs) -> {
+                    long delayMin = 1 + delayMs / 60_000;
+                    return value / delayMin;
+                },
+                titusRuntime.getClock()
+        );
+
+        private PlacementHistory(AgentInstance instance) {
+            this.instance = instance;
+        }
+
+        private AgentInstance getInstance() {
+            return instance;
+        }
+
+        private double quality() {
+            double failureLevel = errorTimeSeries.getAggregatedValue();
+            return Math.max(0, Math.min(1, 1 - failureLevel));
+        }
+
+        private void onTaskStarted() {
+            errorTimeSeries.clear();
+        }
+
+        private void onTaskFailure(ErrorKind errorKind) {
+            double weight;
+            switch (errorKind) {
+                case LostAfterStarted:
+                    weight = 0.1;
+                    break;
+                case LostBeforeStarted:
+                    weight = 0.3;
+                    break;
+                case LocalStartingError:
+                    weight = 0.5;
+                    break;
+                case SystemStartingError:
+                    weight = 0.2;
+                    break;
+                case ContainerCrash:
+                    weight = 0.3;
+                    break;
+                default:
+                    return;
+            }
+            errorTimeSeries.add(weight, titusRuntime.getClock().wallTime());
+        }
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -98,6 +98,7 @@ import com.netflix.titus.master.scheduler.constraint.ConstraintEvaluatorTransfor
 import com.netflix.titus.master.scheduler.constraint.SystemHardConstraint;
 import com.netflix.titus.master.scheduler.constraint.SystemSoftConstraint;
 import com.netflix.titus.master.scheduler.constraint.TaskCache;
+import com.netflix.titus.master.scheduler.fitness.AgentManagementFitnessCalculator;
 import com.netflix.titus.master.scheduler.fitness.TitusFitnessCalculator;
 import com.netflix.titus.master.scheduler.resourcecache.AgentResourceCache;
 import com.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheUpdater;
@@ -215,6 +216,7 @@ public class DefaultSchedulingService implements SchedulingService {
                                     ScaleDownOrderEvaluator scaleDownOrderEvaluator,
                                     Map<ScaleDownConstraintEvaluator, Double> weightedScaleDownConstraintEvaluators,
                                     PreferentialNamedConsumableResourceEvaluator preferentialNamedConsumableResourceEvaluator,
+                                    AgentManagementFitnessCalculator agentManagementFitnessCalculator,
                                     TaskMigrator taskMigrator,
                                     TitusRuntime titusRuntime,
                                     RxEventBus rxEventBus,
@@ -225,7 +227,7 @@ public class DefaultSchedulingService implements SchedulingService {
                 systemSoftConstraint, systemHardConstraint, taskCache, v2ConstraintEvaluatorTransformer,
                 Schedulers.computation(),
                 tierSlaUpdater, registry, scaleDownOrderEvaluator, weightedScaleDownConstraintEvaluators,
-                preferentialNamedConsumableResourceEvaluator,
+                preferentialNamedConsumableResourceEvaluator, agentManagementFitnessCalculator,
                 taskMigrator, titusRuntime, rxEventBus, agentResourceCache, config
         );
     }
@@ -249,6 +251,7 @@ public class DefaultSchedulingService implements SchedulingService {
                                     ScaleDownOrderEvaluator scaleDownOrderEvaluator,
                                     Map<ScaleDownConstraintEvaluator, Double> weightedScaleDownConstraintEvaluators,
                                     PreferentialNamedConsumableResourceEvaluator preferentialNamedConsumableResourceEvaluator,
+                                    AgentManagementFitnessCalculator agentManagementFitnessCalculator,
                                     TaskMigrator taskMigrator,
                                     TitusRuntime titusRuntime,
                                     RxEventBus rxEventBus,
@@ -287,7 +290,7 @@ public class DefaultSchedulingService implements SchedulingService {
         TaskScheduler.Builder schedulerBuilder = new TaskScheduler.Builder()
                 .withLeaseRejectAction(virtualMachineService::rejectLease)
                 .withLeaseOfferExpirySecs(masterConfiguration.getMesosLeaseOfferExpirySecs())
-                .withFitnessCalculator(new TitusFitnessCalculator(schedulerConfiguration, agentResourceCache))
+                .withFitnessCalculator(new TitusFitnessCalculator(schedulerConfiguration, agentManagementFitnessCalculator, agentResourceCache))
                 .withFitnessGoodEnoughFunction(TitusFitnessCalculator.fitnessGoodEnoughFunction)
                 .withAutoScaleByAttributeName(masterConfiguration.getAutoscaleByAttributeName())
                 .withScaleDownOrderEvaluator(scaleDownOrderEvaluator)
@@ -688,7 +691,7 @@ public class DefaultSchedulingService implements SchedulingService {
 
     @Override
     public void initRunningTask(QueuableTask task, String hostname) {
-        logger.info("Initializing Fenzo with the task: taskId={}, qAttributes={}, host={}",task.getId(), task.getQAttributes(), hostname);
+        logger.info("Initializing Fenzo with the task: taskId={}, qAttributes={}, host={}", task.getId(), task.getQAttributes(), hostname);
         schedulingService.initializeRunningTask(task, hostname);
         agentResourceCacheUpdater.createOrUpdateAgentResourceCacheForTask(task, hostname);
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerConfiguration.java
@@ -129,4 +129,10 @@ public interface SchedulerConfiguration {
      */
     @DefaultValue("300000")
     long getPreferredNetworkInterfaceDelayMs();
+
+    /**
+     * Amount of time to keep information about task execution failures on an agent.
+     */
+    @DefaultValue("300000")
+    long getContainerFailureTrackingRetentionMs();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerModule.java
@@ -72,6 +72,7 @@ public final class SchedulerModule extends AbstractModule {
         bind(SystemSoftConstraint.class).to(DefaultSystemSoftConstraint.class);
         bind(SystemHardConstraint.class).to(DefaultSystemHardConstraint.class);
 
+        bind(AgentQualityTracker.class).to(ContainerFailureBasedAgentQualityTracker.class);
         bind(V2_CONSTRAINT_EVALUATOR_TRANSFORMER_TYPE).to(V2ConstraintEvaluatorTransformer.class);
         bind(V3_CONSTRAINT_EVALUATOR_TRANSFORMER_TYPE).to(V3ConstraintEvaluatorTransformer.class);
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/DefaultSystemSoftConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/DefaultSystemSoftConstraint.java
@@ -25,7 +25,6 @@ import com.netflix.fenzo.TaskTrackerState;
 import com.netflix.fenzo.VirtualMachineCurrentState;
 import com.netflix.fenzo.plugins.WeightedAverageFitnessCalculator;
 import com.netflix.fenzo.plugins.WeightedAverageFitnessCalculator.WeightedFitnessCalculator;
-import com.netflix.titus.master.scheduler.fitness.AgentManagementFitnessCalculator;
 import com.netflix.titus.master.scheduler.systemselector.SystemSelectorFitnessCalculator;
 
 import static java.util.Arrays.asList;
@@ -35,11 +34,9 @@ public class DefaultSystemSoftConstraint implements SystemSoftConstraint {
     private final WeightedAverageFitnessCalculator delegate;
 
     @Inject
-    public DefaultSystemSoftConstraint(AgentManagementFitnessCalculator agentManagementFitnessCalculator,
-                                       SystemSelectorFitnessCalculator systemSelectorFitnessCalculator) {
+    public DefaultSystemSoftConstraint(SystemSelectorFitnessCalculator systemSelectorFitnessCalculator) {
         List<WeightedFitnessCalculator> calculators = asList(
-                new WeightedFitnessCalculator(agentManagementFitnessCalculator, 0.6),
-                new WeightedFitnessCalculator(systemSelectorFitnessCalculator, 0.4)
+                new WeightedFitnessCalculator(systemSelectorFitnessCalculator, 1.0)
         );
         delegate = new WeightedAverageFitnessCalculator(calculators);
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/fitness/AgentManagementFitnessCalculator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/fitness/AgentManagementFitnessCalculator.java
@@ -38,9 +38,12 @@ import org.slf4j.LoggerFactory;
 public class AgentManagementFitnessCalculator implements VMTaskFitnessCalculator {
 
     private static final Logger logger = LoggerFactory.getLogger(AgentManagementFitnessCalculator.class);
+
     private static final double ACTIVE_INSTANCE_GROUP_SCORE = 1.0;
     private static final double PHASED_OUT_INSTANCE_GROUP_SCORE = 0.5;
     private static final double NOT_ACTIVE_INSTANCE_GROUP_SCORE = 0.01;
+
+    private static final double QUALITY_OF_UNKNOWN_AGENT = 0.5;
 
     private final SchedulerConfiguration schedulerConfiguration;
     private final AgentManagementService agentManagementService;
@@ -73,7 +76,7 @@ public class AgentManagementFitnessCalculator implements VMTaskFitnessCalculator
             double quality = Math.min(1.0, agentQualityTracker.qualityOf(targetVM.getHostname()));
             if (quality <= 0) {
                 // If we have no information about the agent, we have to assume something.
-                quality = 0.5;
+                quality = QUALITY_OF_UNKNOWN_AGENT;
             }
 
             if (instanceGroup.getLifecycleStatus().getState() == InstanceGroupLifecycleState.Active) {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/player/ContainerPlayersManager.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/player/ContainerPlayersManager.java
@@ -66,7 +66,7 @@ public class ContainerPlayersManager {
     public boolean play(TaskExecutorHolder taskHolder) {
         JobPlayer jobPlayer = jobPlayers.get(taskHolder.getJobId());
         if (jobPlayer == null) {
-            List<Pair<ContainerSelector, ContainerRules>> parseResult = PlayerParser.parse(taskHolder.getEnv());
+            List<Pair<RuleSelector, ContainerRules>> parseResult = PlayerParser.parse(taskHolder.getEnv());
             if (parseResult.isEmpty()) {
                 return false;
             }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/player/RuleSelector.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/player/RuleSelector.java
@@ -16,18 +16,22 @@
 
 package com.netflix.titus.testkit.embedded.cloud.agent.player;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import com.netflix.titus.common.util.NumberSequence;
 
-class ContainerSelector {
+class RuleSelector {
 
     private final NumberSequence slots;
     private final NumberSequence resubmits;
+    private final Set<String> instanceIds;
 
-    ContainerSelector(NumberSequence slots, NumberSequence resubmits) {
+    RuleSelector(NumberSequence slots, NumberSequence resubmits, Set<String> instanceIds) {
         this.slots = slots;
         this.resubmits = resubmits;
+        this.instanceIds = instanceIds;
     }
 
     public NumberSequence getSlots() {
@@ -38,6 +42,10 @@ class ContainerSelector {
         return resubmits;
     }
 
+    public Set<String> getInstanceIds() {
+        return instanceIds;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -46,22 +54,23 @@ class ContainerSelector {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ContainerSelector selector = (ContainerSelector) o;
-        return Objects.equals(slots, selector.slots) &&
-                Objects.equals(resubmits, selector.resubmits);
+        RuleSelector that = (RuleSelector) o;
+        return Objects.equals(slots, that.slots) &&
+                Objects.equals(resubmits, that.resubmits) &&
+                Objects.equals(instanceIds, that.instanceIds);
     }
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(slots, resubmits);
+        return Objects.hash(slots, resubmits, instanceIds);
     }
 
     @Override
     public String toString() {
-        return "ContainerSelector{" +
+        return "RuleSelector{" +
                 "slots=" + slots +
                 ", resubmits=" + resubmits +
+                ", instanceIds=" + instanceIds +
                 '}';
     }
 
@@ -69,8 +78,8 @@ class ContainerSelector {
         return new Builder();
     }
 
-    public static ContainerSelector everything() {
-        return ContainerSelector.newBuilder().build();
+    public static RuleSelector everything() {
+        return RuleSelector.newBuilder().build();
     }
 
     public static final class Builder {
@@ -79,6 +88,8 @@ class ContainerSelector {
 
         private NumberSequence resubmits;
         private int resubmitStep = 1;
+
+        private Set<String> instanceIds = new HashSet<>();
 
         private Builder() {
         }
@@ -103,14 +114,21 @@ class ContainerSelector {
             return this;
         }
 
-        public ContainerSelector build() {
+        public Builder withInstances(String... instanceIds) {
+            for (String instanceId : instanceIds) {
+                this.instanceIds.add(instanceId);
+            }
+            return this;
+        }
+
+        public RuleSelector build() {
             if (slots == null) {
                 slots = NumberSequence.from(0);
             }
             if (resubmits == null) {
                 resubmits = NumberSequence.from(0);
             }
-            return new ContainerSelector(slots.step(slotStep), resubmits.step(resubmitStep));
+            return new RuleSelector(slots.step(slotStep), resubmits.step(resubmitStep), instanceIds);
         }
     }
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/endpoint/rest/SimulatedAgentsServiceResource.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/endpoint/rest/SimulatedAgentsServiceResource.java
@@ -16,6 +16,9 @@
 
 package com.netflix.titus.testkit.embedded.cloud.endpoint.rest;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,10 +33,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.netflix.titus.common.aws.AwsInstanceType;
+import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedInstance;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedInstanceGroup;
 import com.netflix.titus.simulator.TitusCloudSimulator.SimulatedTask;
@@ -56,11 +61,50 @@ public class SimulatedAgentsServiceResource {
 
     @GET
     @Path("/instanceGroups")
-    public List<SimulatedInstanceGroup> getAllInstanceGroups(@QueryParam("ids") List<String> ids) {
+    public List<SimulatedInstanceGroup> getInstanceGroups(@QueryParam("ids") List<String> ids) {
         if (ids.isEmpty()) {
             return gateway.getAllInstanceGroups();
         }
         return gateway.getInstanceGroups(new HashSet<>(ids));
+    }
+
+    @GET
+    @Path("/instanceGroups/{id}")
+    public SimulatedInstanceGroup getInstanceGroup(@PathParam("id") String id) {
+        return getInstanceGroupOrThrowNotFound(id);
+    }
+
+    @GET
+    @Path("/instanceGroups/{id}/allocations")
+    public List<String> getInstanceGroupAllocations(@PathParam("id") String id) {
+        SimulatedInstanceGroup instanceGroup = getInstanceGroupOrThrowNotFound(id);
+
+        List<String> result = new ArrayList<>();
+        for (SimulatedInstance instance : gateway.getInstances(id)) {
+            List<SimulatedTask> tasks = gateway.getSimulatedTasksOnInstance(instance.getId());
+
+            // We could improve this by summing dominant resources, but it is good enough to start.
+            int usedCpus = tasks.stream().mapToInt(t -> t.getComputeResources().getCpu()).sum();
+            int used = (64 * usedCpus) / instanceGroup.getComputeResources().getCpu();
+            String usage = String.format("%s%s", toCharSeq(used, '#'), toCharSeq(64 - used, '_'));
+            result.add(String.format("%30s: |%s|", instance.getId(), usage));
+        }
+
+        return result;
+    }
+
+    private String toCharSeq(int len, char c) {
+        char[] cbuf = new char[len];
+        Arrays.fill(cbuf, 0, len, c);
+        return new String(cbuf);
+    }
+
+    private SimulatedInstanceGroup getInstanceGroupOrThrowNotFound(@QueryParam("ids") String id) {
+        List<SimulatedInstanceGroup> instanceGroups = gateway.getInstanceGroups(Collections.singleton(id));
+        if (instanceGroups.isEmpty()) {
+            throw new WebApplicationException(Response.status(404).build());
+        }
+        return CollectionsExt.first(instanceGroups);
     }
 
     @POST

--- a/titus-testkit/src/test/java/com/netflix/titus/testkit/embedded/cloud/agent/player/PlayerParserTest.java
+++ b/titus-testkit/src/test/java/com/netflix/titus/testkit/embedded/cloud/agent/player/PlayerParserTest.java
@@ -32,14 +32,15 @@ public class PlayerParserTest {
 
     @Test
     public void testSingleRule() {
-        Either<List<Pair<ContainerSelector, ContainerRules>>, String> parsed = PlayerParser.parseInternal(ImmutableMap.of(
-                "TASK_LIFECYCLE_1", "selector: slots=5.. slotStep=2 resubmits=1..10 resubmitStep=3; launched: delay=2s; startInitiated: delay=3s; started: delay=60s; killInitiated: delay=5s"
+        Either<List<Pair<RuleSelector, ContainerRules>>, String> parsed = PlayerParser.parseInternal(ImmutableMap.of(
+                "TASK_LIFECYCLE_1", "selector: slots=5.. slotStep=2 resubmits=1..10 resubmitStep=3 instances=flex1,flex2; launched: delay=2s; startInitiated: delay=3s; started: delay=60s; killInitiated: delay=5s"
         ));
         assertThat(parsed.hasValue()).isTrue();
 
-        ContainerSelector selector = parsed.getValue().get(0).getLeft();
+        RuleSelector selector = parsed.getValue().get(0).getLeft();
         expectSequenceStartingWith(selector.getSlots(), 5L, 7L);
         expectSequenceStartingWith(selector.getResubmits(), 1L, 4L, 7L);
+        assertThat(selector.getInstanceIds()).contains("flex1", "flex2");
 
         ContainerRules containerRules = parsed.getValue().get(0).getRight();
         assertThat(containerRules.getTaskStateRules()).hasSize(4);


### PR DESCRIPTION
### Description of the Change

To prevent scheduling tasks on agent nodes where there were recent failures,
we need to track all recent errors on each agent instance, and aggregate them into
a single number describing agents quality. This information is used by `AgentManagementFitnessCalculator` as a multiplier to adjust (lower), the computed fitness value.
