### PR TITLE
do not start a gradle daemon during docker builds

### DIFF
--- a/titus-ext/runner/Dockerfile.gateway
+++ b/titus-ext/runner/Dockerfile.gateway
@@ -1,4 +1,5 @@
 FROM openjdk:8 as builder
+ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 ## install gradle
 COPY gradlew gradle.properties /usr/src/titus-control-plane/
 COPY gradle /usr/src/titus-control-plane/gradle/

--- a/titus-ext/runner/Dockerfile.master
+++ b/titus-ext/runner/Dockerfile.master
@@ -1,4 +1,5 @@
 FROM openjdk:8 as builder
+ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 ## install gradle
 COPY gradlew gradle.properties /usr/src/titus-control-plane/
 COPY gradle /usr/src/titus-control-plane/gradle/


### PR DESCRIPTION
### Description of the Change

See GoogleContainerTools/kaniko#247