### PR TITLE
backpressure handling for autoscale policy creation/deletion

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerConfiguration.java
@@ -30,4 +30,7 @@ public interface AppScaleManagerConfiguration {
 
     @DefaultValue("120")
     long getStoreInitTimeoutSeconds();
+
+    @DefaultValue("30")
+    long getReconcileAllPendingRequests();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerConfiguration.java
@@ -32,5 +32,5 @@ public interface AppScaleManagerConfiguration {
     long getStoreInitTimeoutSeconds();
 
     @DefaultValue("30")
-    long getReconcileAllPendingRequests();
+    long getReconcileAllPendingAndDeletingRequestsIntervalMins();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerMetrics.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerMetrics.java
@@ -46,7 +46,7 @@ public class AppScaleManagerMetrics {
         droppedRequestsCount = registry.counter(METRIC_BACK_PRESSURE_DROP_COUNT);
     }
 
-    private static final String METRIC_APPSCALE_ERRORS = "titus.appscale.errors";
+    private static final String METRIC_APPSCALE_ERRORS = "titus.appScale.errors";
     private static final String METRIC_TITUS_APPSCALE_NUM_TARGETS = "titus.appScale.numTargets";
     private static final String METRIC_TITUS_APPSCALE_POLICY = "titus.appScale.policy.";
     private static final String METRIC_BACK_PRESSURE_DROP_COUNT = "titus.appScale.droppedRequests";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
@@ -149,7 +149,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
 
         this.appScaleActionsSub = appScaleActionsSubject
                 .onBackpressureDrop(appScaleAction -> {
-                    logger.info("Dropping {}",appScaleAction);
+                    logger.error("Dropping {}",appScaleAction);
                     metrics.reportDroppedRequest();
                 })
                 .observeOn(awsInteractionScheduler, ASYNC_HANDLER_BUFFER_CAPACITY)
@@ -176,7 +176,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
         checkForScalingPolicyActions().toCompletable().await(appScaleManagerConfiguration.getStoreInitTimeoutSeconds(),
                 TimeUnit.SECONDS);
 
-        reconcileAllPendingRequests = Observable.interval(appScaleManagerConfiguration.getReconcileAllPendingRequests(), TimeUnit.MINUTES)
+        reconcileAllPendingRequests = Observable.interval(appScaleManagerConfiguration.getReconcileAllPendingAndDeletingRequestsIntervalMins(), TimeUnit.MINUTES)
                 .observeOn(Schedulers.io())
                 .flatMap(ignored -> checkForScalingPolicyActions())
                 .subscribe(policy -> logger.info("Reconciliation - policy request processed : {}.", policy.getPolicyId()),

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
@@ -80,6 +80,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
 
     private static final long SHUTDOWN_TIMEOUT_MS = 5_000;
     private static final String DEFAULT_JOB_GROUP_SEQ = "v000";
+    private static final int ASYNC_HANDLER_BUFFER_CAPACITY = 10_000;
 
     private final AppScaleManagerMetrics metrics;
     private final SerializedSubject<AppScaleAction, AppScaleAction> appScaleActionsSubject;
@@ -93,6 +94,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
 
     private volatile Map<String, AutoScalableTarget> scalableTargets;
     private volatile Subscription reconcileFinishedJobsSub;
+    private volatile Subscription reconcileAllPendingRequests;
     private volatile Subscription reconcileScalableTargetsSub;
 
     private volatile ExecutorService awsInteractionExecutor;
@@ -144,7 +146,14 @@ public class DefaultAppScaleManager implements AppScaleManager {
         this.scalableTargets = new ConcurrentHashMap<>();
         this.metrics = new AppScaleManagerMetrics(registry);
         this.appScaleActionsSubject = PublishSubject.<AppScaleAction>create().toSerialized();
-        this.appScaleActionsSub = appScaleActionsSubject.observeOn(awsInteractionScheduler).subscribe(new AppScaleActionHandler());
+
+        this.appScaleActionsSub = appScaleActionsSubject
+                .onBackpressureDrop(appScaleAction -> {
+                    logger.info("Dropping {}",appScaleAction);
+                    metrics.reportDroppedRequest();
+                })
+                .observeOn(awsInteractionScheduler, ASYNC_HANDLER_BUFFER_CAPACITY)
+                .subscribe(new AppScaleActionHandler(), e -> logger.error("Exception in appScaleActionsSubject ", e));
     }
 
     @Activator
@@ -167,6 +176,12 @@ public class DefaultAppScaleManager implements AppScaleManager {
         checkForScalingPolicyActions().toCompletable().await(appScaleManagerConfiguration.getStoreInitTimeoutSeconds(),
                 TimeUnit.SECONDS);
 
+        reconcileAllPendingRequests = Observable.interval(appScaleManagerConfiguration.getReconcileAllPendingRequests(), TimeUnit.MINUTES)
+                .observeOn(Schedulers.io())
+                .flatMap(ignored -> checkForScalingPolicyActions())
+                .subscribe(policy -> logger.info("Reconciliation - policy request processed : {}.", policy.getPolicyId()),
+                        e -> logger.error("error in reconciliation (ReconcileAllPendingRequests) stream", e),
+                        () -> logger.info("reconciliation (ReconcileAllPendingRequests) stream closed"));
 
         reconcileFinishedJobsSub = Observable.interval(appScaleManagerConfiguration.getReconcileFinishedJobsIntervalMins(), TimeUnit.MINUTES)
                 .observeOn(Schedulers.io())
@@ -210,6 +225,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
     public void shutdown() {
         ObservableExt.safeUnsubscribe(reconcileFinishedJobsSub);
         ObservableExt.safeUnsubscribe(reconcileScalableTargetsSub);
+        ObservableExt.safeUnsubscribe(reconcileAllPendingRequests);
         ObservableExt.safeUnsubscribe(appScaleActionsSub);
         if (awsInteractionExecutor == null) {
             return; // nothing else to do


### PR DESCRIPTION
### Back-pressure fix

Back-pressure handling for policy creation and deletion by providing ring buffer size for observeOn.
Bulk creation test to verify this behavior