### PR TITLE
Back pressure error handling 

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerConfiguration.java
@@ -30,4 +30,7 @@ public interface AppScaleManagerConfiguration {
 
     @DefaultValue("120")
     long getStoreInitTimeoutSeconds();
+
+    @DefaultValue("30")
+    long getReconcileAllPendingAndDeletingRequestsIntervalMins();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerMetrics.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/AppScaleManagerMetrics.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.titus.api.appscale.model.AutoScalingPolicy;
@@ -32,6 +33,7 @@ public class AppScaleManagerMetrics {
     private final Id errorMetricId;
     private Registry registry;
     private final AtomicInteger numTargets;
+    private final Counter droppedRequestsCount;
 
 
     private volatile Map<String, SpectatorExt.FsmMetrics<PolicyStatus>> fsmMetricsMap;
@@ -41,11 +43,13 @@ public class AppScaleManagerMetrics {
         fsmMetricsMap = new ConcurrentHashMap<>();
         numTargets = registry.gauge(METRIC_TITUS_APPSCALE_NUM_TARGETS, new AtomicInteger(0));
         this.registry = registry;
+        droppedRequestsCount = registry.counter(METRIC_BACK_PRESSURE_DROP_COUNT);
     }
 
-    public static final String METRIC_APPSCALE_ERRORS = "titus.appscale.errors";
-    public static final String METRIC_TITUS_APPSCALE_NUM_TARGETS = "titus.appScale.numTargets";
-    public static final String METRIC_TITUS_APPSCALE_POLICY = "titus.appScale.policy.";
+    private static final String METRIC_APPSCALE_ERRORS = "titus.appScale.errors";
+    private static final String METRIC_TITUS_APPSCALE_NUM_TARGETS = "titus.appScale.numTargets";
+    private static final String METRIC_TITUS_APPSCALE_POLICY = "titus.appScale.policy.";
+    private static final String METRIC_BACK_PRESSURE_DROP_COUNT = "titus.appScale.droppedRequests";
 
     private Id stateIdOf(AutoScalingPolicy autoScalingPolicy) {
         return registry.createId(METRIC_TITUS_APPSCALE_POLICY, "t.jobId", autoScalingPolicy.getJobId());
@@ -74,5 +78,9 @@ public class AppScaleManagerMetrics {
 
     public void reportErrorForException(AutoScalePolicyException autoScalePolicyException) {
         registry.counter(errorMetricId.withTag("errorCode", autoScalePolicyException.getErrorCode().name())).increment();
+    }
+
+    public void reportDroppedRequest() {
+        droppedRequestsCount.increment();
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
@@ -58,6 +58,7 @@ import com.netflix.titus.api.model.v2.parameter.Parameters;
 import com.netflix.titus.common.util.ExecutorsExt;
 import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.rx.ObservableExt;
+import com.netflix.titus.common.util.rx.RetryHandlerBuilder;
 import com.netflix.titus.common.util.rx.eventbus.RxEventBus;
 import com.netflix.titus.master.job.V2JobMgrIntf;
 import com.netflix.titus.master.job.V2JobOperations;
@@ -76,6 +77,8 @@ import rx.subjects.SerializedSubject;
 
 @Singleton
 public class DefaultAppScaleManager implements AppScaleManager {
+    public static final long INITIAL_RETRY_DELAY_SEC = 5;
+    public static final long MAX_RETRY_DELAY_SEC = 30;
     private static Logger logger = LoggerFactory.getLogger(DefaultAppScaleManager.class);
 
     private static final long SHUTDOWN_TIMEOUT_MS = 5_000;
@@ -154,7 +157,13 @@ public class DefaultAppScaleManager implements AppScaleManager {
                 })
                 .observeOn(awsInteractionScheduler, ASYNC_HANDLER_BUFFER_CAPACITY)
                 .doOnError(e -> logger.error("Exception in appScaleActionsSubject ", e))
-                .retry()
+                .retryWhen(RetryHandlerBuilder.retryHandler()
+                        .withUnlimitedRetries()
+                        .withScheduler(awsInteractionScheduler)
+                        .withDelay(INITIAL_RETRY_DELAY_SEC, MAX_RETRY_DELAY_SEC, TimeUnit.SECONDS)
+                        .withTitle("Auto-retry for appScaleActionsSubject")
+                        .buildExponentialBackoff()
+                )
                 .subscribe(new AppScaleActionHandler());
     }
 
@@ -178,8 +187,9 @@ public class DefaultAppScaleManager implements AppScaleManager {
         checkForScalingPolicyActions().toCompletable().await(appScaleManagerConfiguration.getStoreInitTimeoutSeconds(),
                 TimeUnit.SECONDS);
 
-        reconcileAllPendingRequests = Observable.interval(appScaleManagerConfiguration.getReconcileAllPendingAndDeletingRequestsIntervalMins(), TimeUnit.MINUTES)
-                .observeOn(Schedulers.io())
+        reconcileAllPendingRequests = Observable.interval(
+                appScaleManagerConfiguration.getReconcileAllPendingAndDeletingRequestsIntervalMins(), TimeUnit.MINUTES,
+                Schedulers.io())
                 .flatMap(ignored -> checkForScalingPolicyActions())
                 .subscribe(policy -> logger.info("Reconciliation - policy request processed : {}.", policy.getPolicyId()),
                         e -> logger.error("error in reconciliation (ReconcileAllPendingRequests) stream", e),

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
@@ -708,6 +708,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
                                 return appAutoScalingClient.deleteScalableTarget(autoScalingPolicy.getJobId())
                                         .doOnError(e -> saveStatusOnError(AutoScalePolicyException.errorDeletingTarget(autoScalingPolicy.getPolicyId(),
                                                 autoScalingPolicy.getJobId(), e.getMessage())))
+                                        .onErrorResumeNext(e -> Completable.complete())
                                         .andThen(Observable.just(autoScalingPolicy));
                             } else {
                                 return Observable.just(autoScalingPolicy);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
@@ -708,7 +708,6 @@ public class DefaultAppScaleManager implements AppScaleManager {
                                 return appAutoScalingClient.deleteScalableTarget(autoScalingPolicy.getJobId())
                                         .doOnError(e -> saveStatusOnError(AutoScalePolicyException.errorDeletingTarget(autoScalingPolicy.getPolicyId(),
                                                 autoScalingPolicy.getJobId(), e.getMessage())))
-                                        .onErrorResumeNext(e -> Completable.complete())
                                         .andThen(Observable.just(autoScalingPolicy));
                             } else {
                                 return Observable.just(autoScalingPolicy);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManager.java
@@ -80,6 +80,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
 
     private static final long SHUTDOWN_TIMEOUT_MS = 5_000;
     private static final String DEFAULT_JOB_GROUP_SEQ = "v000";
+    private static final int ASYNC_HANDLER_BUFFER_CAPACITY = 10_000;
 
     private final AppScaleManagerMetrics metrics;
     private final SerializedSubject<AppScaleAction, AppScaleAction> appScaleActionsSubject;
@@ -93,6 +94,7 @@ public class DefaultAppScaleManager implements AppScaleManager {
 
     private volatile Map<String, AutoScalableTarget> scalableTargets;
     private volatile Subscription reconcileFinishedJobsSub;
+    private volatile Subscription reconcileAllPendingRequests;
     private volatile Subscription reconcileScalableTargetsSub;
 
     private volatile ExecutorService awsInteractionExecutor;
@@ -144,7 +146,16 @@ public class DefaultAppScaleManager implements AppScaleManager {
         this.scalableTargets = new ConcurrentHashMap<>();
         this.metrics = new AppScaleManagerMetrics(registry);
         this.appScaleActionsSubject = PublishSubject.<AppScaleAction>create().toSerialized();
-        this.appScaleActionsSub = appScaleActionsSubject.observeOn(awsInteractionScheduler).subscribe(new AppScaleActionHandler());
+
+        this.appScaleActionsSub = appScaleActionsSubject
+                .onBackpressureDrop(appScaleAction -> {
+                    logger.warn("Dropping {}", appScaleAction);
+                    metrics.reportDroppedRequest();
+                })
+                .observeOn(awsInteractionScheduler, ASYNC_HANDLER_BUFFER_CAPACITY)
+                .doOnError(e -> logger.error("Exception in appScaleActionsSubject ", e))
+                .retry()
+                .subscribe(new AppScaleActionHandler());
     }
 
     @Activator
@@ -167,6 +178,12 @@ public class DefaultAppScaleManager implements AppScaleManager {
         checkForScalingPolicyActions().toCompletable().await(appScaleManagerConfiguration.getStoreInitTimeoutSeconds(),
                 TimeUnit.SECONDS);
 
+        reconcileAllPendingRequests = Observable.interval(appScaleManagerConfiguration.getReconcileAllPendingAndDeletingRequestsIntervalMins(), TimeUnit.MINUTES)
+                .observeOn(Schedulers.io())
+                .flatMap(ignored -> checkForScalingPolicyActions())
+                .subscribe(policy -> logger.info("Reconciliation - policy request processed : {}.", policy.getPolicyId()),
+                        e -> logger.error("error in reconciliation (ReconcileAllPendingRequests) stream", e),
+                        () -> logger.info("reconciliation (ReconcileAllPendingRequests) stream closed"));
 
         reconcileFinishedJobsSub = Observable.interval(appScaleManagerConfiguration.getReconcileFinishedJobsIntervalMins(), TimeUnit.MINUTES)
                 .observeOn(Schedulers.io())
@@ -208,9 +225,8 @@ public class DefaultAppScaleManager implements AppScaleManager {
 
     @PreDestroy
     public void shutdown() {
-        ObservableExt.safeUnsubscribe(reconcileFinishedJobsSub);
-        ObservableExt.safeUnsubscribe(reconcileScalableTargetsSub);
-        ObservableExt.safeUnsubscribe(appScaleActionsSub);
+        ObservableExt.safeUnsubscribe(reconcileFinishedJobsSub, reconcileScalableTargetsSub,
+                reconcileAllPendingRequests, appScaleActionsSub);
         if (awsInteractionExecutor == null) {
             return; // nothing else to do
         }


### PR DESCRIPTION
new branch from v0.1.0-rc.78

Back-pressure handling for policy creation and deletion by providing ring buffer size for observeOn.
Bulk creation test to verify this behavior.