### PR TITLE
Read Tier from AWS ASG tags

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/connector/cloud/InstanceGroup.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/connector/cloud/InstanceGroup.java
@@ -30,6 +30,7 @@ public class InstanceGroup {
     private final boolean isTerminateSuspended;
     private final Map<String, String> attributes;
     private final List<String> instanceIds;
+    private final Map<String, String> tags;
 
     public InstanceGroup(String id,
                          String launchConfigurationName,
@@ -39,7 +40,8 @@ public class InstanceGroup {
                          boolean isLaunchSuspended,
                          boolean isTerminateSuspended,
                          Map<String, String> attributes,
-                         List<String> instanceIds) {
+                         List<String> instanceIds,
+                         Map<String, String> tags) {
         this.id = id;
         this.launchConfigurationName = launchConfigurationName;
         this.min = min;
@@ -49,6 +51,7 @@ public class InstanceGroup {
         this.isTerminateSuspended = isTerminateSuspended;
         this.attributes = attributes;
         this.instanceIds = instanceIds;
+        this.tags = tags;
     }
 
     public String getId() {
@@ -87,6 +90,10 @@ public class InstanceGroup {
         return instanceIds;
     }
 
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -122,6 +129,9 @@ public class InstanceGroup {
         if (attributes != null ? !attributes.equals(that.attributes) : that.attributes != null) {
             return false;
         }
+        if (tags != null ? !tags.equals(that.tags) : that.tags != null) {
+            return false;
+        }
         return instanceIds != null ? instanceIds.equals(that.instanceIds) : that.instanceIds == null;
     }
 
@@ -136,6 +146,7 @@ public class InstanceGroup {
         result = 31 * result + (isTerminateSuspended ? 1 : 0);
         result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
         result = 31 * result + (instanceIds != null ? instanceIds.hashCode() : 0);
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
         return result;
     }
 
@@ -151,6 +162,7 @@ public class InstanceGroup {
                 ", isTerminateSuspended=" + isTerminateSuspended +
                 ", attributes=" + attributes +
                 ", instanceIds=" + instanceIds +
+                ", tags=" + tags +
                 '}';
     }
 
@@ -164,7 +176,8 @@ public class InstanceGroup {
                 .withIsLaunchSuspended(isLaunchSuspended)
                 .withIsTerminateSuspended(isTerminateSuspended)
                 .withAttributes(attributes)
-                .withInstanceIds(instanceIds);
+                .withInstanceIds(instanceIds)
+                .withTags(tags);
     }
 
     public static Builder newBuilder() {
@@ -181,6 +194,7 @@ public class InstanceGroup {
         private boolean isTerminateSuspended;
         private List<String> instanceIds;
         private Map<String, String> attributes;
+        private Map<String, String> tags;
 
         private Builder() {
         }
@@ -230,6 +244,11 @@ public class InstanceGroup {
             return this;
         }
 
+        public Builder withTags(Map<String, String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
         public Builder but() {
             return newBuilder()
                     .withId(id)
@@ -240,11 +259,12 @@ public class InstanceGroup {
                     .withIsLaunchSuspended(isLaunchSuspended)
                     .withIsTerminateSuspended(isTerminateSuspended)
                     .withAttributes(attributes)
-                    .withInstanceIds(instanceIds);
+                    .withInstanceIds(instanceIds)
+                    .withTags(tags);
         }
 
         public InstanceGroup build() {
-            InstanceGroup instanceGroup = new InstanceGroup(id, launchConfigurationName, min, desired, max, isLaunchSuspended, isTerminateSuspended, attributes, instanceIds);
+            InstanceGroup instanceGroup = new InstanceGroup(id, launchConfigurationName, min, desired, max, isLaunchSuspended, isTerminateSuspended, attributes, instanceIds, tags);
             return instanceGroup;
         }
     }

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/AwsInstanceCloudConnector.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/AwsInstanceCloudConnector.java
@@ -49,15 +49,8 @@ import com.amazonaws.services.autoscaling.model.SuspendedProcess;
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest;
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupResult;
 import com.amazonaws.services.ec2.AmazonEC2Async;
-import com.amazonaws.services.ec2.model.CreateTagsRequest;
-import com.amazonaws.services.ec2.model.CreateTagsResult;
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
-import com.amazonaws.services.ec2.model.DescribeInstancesResult;
-import com.amazonaws.services.ec2.model.Filter;
-import com.amazonaws.services.ec2.model.Reservation;
-import com.amazonaws.services.ec2.model.Tag;
-import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
-import com.amazonaws.services.ec2.model.TerminateInstancesResult;
+import com.amazonaws.services.autoscaling.model.TagDescription;
+import com.amazonaws.services.ec2.model.*;
 import com.google.common.base.Strings;
 import com.netflix.titus.api.connector.cloud.CloudConnectorException;
 import com.netflix.titus.api.connector.cloud.Instance;
@@ -451,7 +444,8 @@ public class AwsInstanceCloudConnector implements InstanceCloudConnector {
                 isLaunchSuspended,
                 isTerminateSuspended,
                 Collections.emptyMap(),
-                awsScalingGroup.getInstances().stream().map(com.amazonaws.services.autoscaling.model.Instance::getInstanceId).collect(Collectors.toList())
+                awsScalingGroup.getInstances().stream().map(com.amazonaws.services.autoscaling.model.Instance::getInstanceId).collect(Collectors.toList()),
+                awsScalingGroup.getTags().stream().collect(Collectors.toMap(TagDescription::getKey, TagDescription::getValue))
         );
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DefaultAgentCache.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DefaultAgentCache.java
@@ -37,6 +37,7 @@ import com.netflix.titus.api.connector.cloud.Instance;
 import com.netflix.titus.api.connector.cloud.InstanceCloudConnector;
 import com.netflix.titus.api.connector.cloud.InstanceGroup;
 import com.netflix.titus.api.model.ResourceDimension;
+import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.rx.ObservableExt;
 import com.netflix.titus.master.agent.service.AgentManagementConfiguration;
@@ -310,7 +311,8 @@ public class DefaultAgentCache implements AgentCache {
             agentInstanceGroup = DataConverters.toAgentInstanceGroup(
                     instanceGroup,
                     instanceResourceDimension,
-                    defaultAutoScaleRule
+                    defaultAutoScaleRule,
+                    Tier.Flex
             );
             agentInstances = instanceGroup.getInstanceIds().stream()
                     .map(instanceCache::getAgentInstance)

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/stub/connector/cloud/InstanceGenerators.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/stub/connector/cloud/InstanceGenerators.java
@@ -40,6 +40,7 @@ public final class InstanceGenerators {
                 .withDesired(desiredSize)
                 .withMax(desiredSize)
                 .withAttributes(Collections.singletonMap(ATTR_SUBNET, idx + ".0.0.0/8"))
+                .withTags(Collections.emptyMap())
                 .withInstanceIds(Collections.emptyList())
                 .build()
         );


### PR DESCRIPTION
If the AWS ASG has a special tag on it, and we recognize that as a tier, use that
when we initially see the the ASG, rather than default into flex tier.
