### PR TITLE
Dependencies updated and locked

### DIFF
--- a/titus-ext/zookeeper/dependencies.lock
+++ b/titus-ext/zookeeper/dependencies.lock
@@ -6,61 +6,43 @@
                 "com.google.inject:guice"
             ]
         },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
+        "c3p0:c3p0": {
+            "locked": "0.9.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
+                "org.quartz-scheduler:quartz"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.8.0",
+            "locked": "2.8.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.fenzo:fenzo-triggers",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.netflix.titus:titus-common"
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-common",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs"
             ]
         },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.4",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "io.swagger:swagger-core"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -81,10 +63,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "com.google.api.grpc:proto-google-common-protos": {
             "locked": "1.0.0",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.code.findbugs:annotations": {
+            "locked": "2.0.1",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -115,7 +109,11 @@
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
-                "io.opencensus:opencensus-api"
+                "io.opencensus:opencensus-api",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs",
+                "org.apache.curator:curator-client",
+                "org.reflections:reflections"
             ]
         },
         "com.google.inject.extensions:guice-assistedinject": {
@@ -134,7 +132,16 @@
             "locked": "4.1.0",
             "transitive": [
                 "com.google.inject.extensions:guice-grapher",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-core"
+            ]
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.1.0",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.inject:guice": {
@@ -143,7 +150,12 @@
                 "com.google.inject.extensions:guice-assistedinject",
                 "com.google.inject.extensions:guice-grapher",
                 "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.governator:governator-core"
+                "com.google.inject.extensions:guice-servlet",
+                "com.netflix.archaius:archaius2-guice",
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -151,7 +163,10 @@
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
                 "com.netflix.titus:titus-common",
-                "io.grpc:grpc-protobuf"
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "io.grpc:grpc-protobuf",
+                "org.apache.mesos:mesos"
             ]
         },
         "com.google.protobuf:protobuf-java-util": {
@@ -169,40 +184,133 @@
         "com.netflix.archaius:archaius2-core": {
             "locked": "2.3.13",
             "transitive": [
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.netflix.archaius:archaius2-guice": {
+            "locked": "2.3.13",
+            "transitive": [
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-core": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-triggers": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.governator:governator-api": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.runtime:health-core"
             ]
         },
         "com.netflix.governator:governator-core": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jersey": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jetty": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-providers": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.netflix.governator:governator-servlet": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "com.netflix.numerus:numerus": {
             "locked": "1.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.runtime:health-api": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-core"
+            ]
+        },
+        "com.netflix.runtime:health-core": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-guice"
+            ]
+        },
+        "com.netflix.runtime:health-guice": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.59.0",
             "transitive": [
+                "com.netflix.runtime:health-core",
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.netflix.titus:titus-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
         },
         "com.netflix.titus:titus-common": {
             "project": true,
             "transitive": [
-                "com.netflix.titus:titus-api"
+                "com.netflix.titus:titus-api",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-grpc-api": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-server-master": {
+            "project": true
+        },
+        "com.netflix.titus:titus-server-runtime": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -217,17 +325,34 @@
                 "com.squareup.okhttp3:okhttp"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
+        "com.sun.jersey.contribs:jersey-guice": {
+            "locked": "1.19",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.sun.jersey:jersey-core": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey:jersey-server"
+            ]
+        },
+        "com.sun.jersey:jersey-server": {
+            "locked": "1.19",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.sun.jersey:jersey-servlet"
+            ]
+        },
+        "com.sun.jersey:jersey-servlet": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -249,13 +374,15 @@
         "io.grpc:grpc-netty-shaded": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "io.grpc:grpc-protobuf": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
             ]
         },
         "io.grpc:grpc-protobuf-lite": {
@@ -267,7 +394,14 @@
         "io.grpc:grpc-stub": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.7.0.Final",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "io.netty:netty-buffer": {
@@ -341,6 +475,7 @@
         "io.reactivex:rxjava": {
             "locked": "1.3.8",
             "transitive": [
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.titus:titus-common",
                 "io.reactivex:rxnetty"
             ]
@@ -348,7 +483,33 @@
         "io.reactivex:rxnetty": {
             "locked": "0.4.20",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "io.swagger:swagger-annotations": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-models"
+            ]
+        },
+        "io.swagger:swagger-core": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "io.swagger:swagger-jaxrs": {
+            "locked": "1.5.12",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "io.swagger:swagger-models": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-core"
             ]
         },
         "javax.el:javax.el-api": {
@@ -362,44 +523,146 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.netflix.archaius:archaius2-api",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.runtime:health-core",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
+            ]
+        },
+        "javax.servlet:javax.servlet-api": {
+            "locked": "3.1.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-server"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
+                "io.swagger:swagger-core",
                 "org.hibernate:hibernate-validator"
             ]
         },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
+        "javax.ws.rs:jsr311-api": {
+            "locked": "1.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.sun.jersey:jersey-core",
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.9",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
             ]
         },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
-                "com.netflix.archaius:archaius2-core"
+                "com.netflix.archaius:archaius2-core",
+                "io.swagger:swagger-core"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
+        "org.apache.curator:curator-client": {
+            "locked": "2.11.0",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "org.apache.curator:curator-framework"
             ]
         },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
+        "org.apache.curator:curator-framework": {
+            "locked": "2.11.0",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.titus:titus-server-master",
+                "org.apache.curator:curator-recipes"
+            ]
+        },
+        "org.apache.curator:curator-recipes": {
+            "locked": "2.11.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.mesos:mesos": {
+            "locked": "1.3.2",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.zookeeper:zookeeper": {
+            "locked": "3.4.6",
+            "transitive": [
+                "org.apache.curator:curator-client"
+            ]
+        },
+        "org.eclipse.jetty:jetty-http": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-io": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-security": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-servlet"
+            ]
+        },
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-security"
+            ]
+        },
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-webapp"
+            ]
+        },
+        "org.eclipse.jetty:jetty-util": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-http",
+                "org.eclipse.jetty:jetty-io",
+                "org.eclipse.jetty:jetty-xml"
+            ]
+        },
+        "org.eclipse.jetty:jetty-webapp": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.eclipse.jetty:jetty-xml": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-webapp"
             ]
         },
         "org.glassfish:javax.el": {
@@ -417,7 +680,14 @@
         "org.hibernate:hibernate-validator": {
             "locked": "5.4.2.Final",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.javassist:javassist": {
+            "locked": "3.18.2-GA",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "org.jboss.logging:jboss-logging": {
@@ -426,16 +696,45 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.json:json": {
+            "locked": "20140107",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.quartz-scheduler:quartz": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
+            ]
+        },
+        "org.reflections:reflections": {
+            "locked": "0.9.10",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.archaius:archaius2-core",
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.governator:governator-core",
                 "com.netflix.spectator:spectator-api",
                 "com.netflix.titus:titus-api",
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
                 "io.reactivex:rxnetty",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models",
+                "org.apache.curator:curator-client",
+                "org.apache.zookeeper:zookeeper",
+                "org.quartz-scheduler:quartz",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -443,7 +742,10 @@
             "locked": "1.7.0",
             "transitive": [
                 "com.netflix.titus:titus-api",
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "org.springframework:spring-core": {
@@ -458,16 +760,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "org.webjars:swagger-ui": {
+            "locked": "2.1.4",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "org.xerial.snappy:snappy-java": {
             "locked": "1.1.7.2",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
             ]
         }
     },
@@ -478,61 +786,43 @@
                 "com.google.inject:guice"
             ]
         },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
+        "c3p0:c3p0": {
+            "locked": "0.9.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
+                "org.quartz-scheduler:quartz"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.8.0",
+            "locked": "2.8.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.fenzo:fenzo-triggers",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.netflix.titus:titus-common"
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-common",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs"
             ]
         },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.4",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "io.swagger:swagger-core"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -553,10 +843,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "com.google.api.grpc:proto-google-common-protos": {
             "locked": "1.0.0",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.code.findbugs:annotations": {
+            "locked": "2.0.1",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -587,7 +889,11 @@
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
-                "io.opencensus:opencensus-api"
+                "io.opencensus:opencensus-api",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs",
+                "org.apache.curator:curator-client",
+                "org.reflections:reflections"
             ]
         },
         "com.google.inject.extensions:guice-assistedinject": {
@@ -606,7 +912,16 @@
             "locked": "4.1.0",
             "transitive": [
                 "com.google.inject.extensions:guice-grapher",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-core"
+            ]
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.1.0",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.inject:guice": {
@@ -615,7 +930,12 @@
                 "com.google.inject.extensions:guice-assistedinject",
                 "com.google.inject.extensions:guice-grapher",
                 "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.governator:governator-core"
+                "com.google.inject.extensions:guice-servlet",
+                "com.netflix.archaius:archaius2-guice",
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -623,7 +943,10 @@
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
                 "com.netflix.titus:titus-common",
-                "io.grpc:grpc-protobuf"
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "io.grpc:grpc-protobuf",
+                "org.apache.mesos:mesos"
             ]
         },
         "com.google.protobuf:protobuf-java-util": {
@@ -641,40 +964,133 @@
         "com.netflix.archaius:archaius2-core": {
             "locked": "2.3.13",
             "transitive": [
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.netflix.archaius:archaius2-guice": {
+            "locked": "2.3.13",
+            "transitive": [
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-core": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-triggers": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.governator:governator-api": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.runtime:health-core"
             ]
         },
         "com.netflix.governator:governator-core": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jersey": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jetty": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-providers": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.netflix.governator:governator-servlet": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "com.netflix.numerus:numerus": {
             "locked": "1.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.runtime:health-api": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-core"
+            ]
+        },
+        "com.netflix.runtime:health-core": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-guice"
+            ]
+        },
+        "com.netflix.runtime:health-guice": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.59.0",
             "transitive": [
+                "com.netflix.runtime:health-core",
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.netflix.titus:titus-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
         },
         "com.netflix.titus:titus-common": {
             "project": true,
             "transitive": [
-                "com.netflix.titus:titus-api"
+                "com.netflix.titus:titus-api",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-grpc-api": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-server-master": {
+            "project": true
+        },
+        "com.netflix.titus:titus-server-runtime": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -689,17 +1105,34 @@
                 "com.squareup.okhttp3:okhttp"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
+        "com.sun.jersey.contribs:jersey-guice": {
+            "locked": "1.19",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.sun.jersey:jersey-core": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey:jersey-server"
+            ]
+        },
+        "com.sun.jersey:jersey-server": {
+            "locked": "1.19",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.sun.jersey:jersey-servlet"
+            ]
+        },
+        "com.sun.jersey:jersey-servlet": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -721,13 +1154,15 @@
         "io.grpc:grpc-netty-shaded": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "io.grpc:grpc-protobuf": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
             ]
         },
         "io.grpc:grpc-protobuf-lite": {
@@ -739,7 +1174,14 @@
         "io.grpc:grpc-stub": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.7.0.Final",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "io.netty:netty-buffer": {
@@ -813,6 +1255,7 @@
         "io.reactivex:rxjava": {
             "locked": "1.3.8",
             "transitive": [
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.titus:titus-common",
                 "io.reactivex:rxnetty"
             ]
@@ -820,7 +1263,33 @@
         "io.reactivex:rxnetty": {
             "locked": "0.4.20",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "io.swagger:swagger-annotations": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-models"
+            ]
+        },
+        "io.swagger:swagger-core": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "io.swagger:swagger-jaxrs": {
+            "locked": "1.5.12",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "io.swagger:swagger-models": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-core"
             ]
         },
         "javax.el:javax.el-api": {
@@ -834,44 +1303,146 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.netflix.archaius:archaius2-api",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.runtime:health-core",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
+            ]
+        },
+        "javax.servlet:javax.servlet-api": {
+            "locked": "3.1.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-server"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
+                "io.swagger:swagger-core",
                 "org.hibernate:hibernate-validator"
             ]
         },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
+        "javax.ws.rs:jsr311-api": {
+            "locked": "1.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.sun.jersey:jersey-core",
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.9",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
             ]
         },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
-                "com.netflix.archaius:archaius2-core"
+                "com.netflix.archaius:archaius2-core",
+                "io.swagger:swagger-core"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
+        "org.apache.curator:curator-client": {
+            "locked": "2.11.0",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "org.apache.curator:curator-framework"
             ]
         },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
+        "org.apache.curator:curator-framework": {
+            "locked": "2.11.0",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.titus:titus-server-master",
+                "org.apache.curator:curator-recipes"
+            ]
+        },
+        "org.apache.curator:curator-recipes": {
+            "locked": "2.11.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.mesos:mesos": {
+            "locked": "1.3.2",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.zookeeper:zookeeper": {
+            "locked": "3.4.6",
+            "transitive": [
+                "org.apache.curator:curator-client"
+            ]
+        },
+        "org.eclipse.jetty:jetty-http": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-io": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-security": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-servlet"
+            ]
+        },
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-security"
+            ]
+        },
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-webapp"
+            ]
+        },
+        "org.eclipse.jetty:jetty-util": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-http",
+                "org.eclipse.jetty:jetty-io",
+                "org.eclipse.jetty:jetty-xml"
+            ]
+        },
+        "org.eclipse.jetty:jetty-webapp": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.eclipse.jetty:jetty-xml": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-webapp"
             ]
         },
         "org.glassfish:javax.el": {
@@ -889,7 +1460,14 @@
         "org.hibernate:hibernate-validator": {
             "locked": "5.4.2.Final",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.javassist:javassist": {
+            "locked": "3.18.2-GA",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "org.jboss.logging:jboss-logging": {
@@ -898,16 +1476,45 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.json:json": {
+            "locked": "20140107",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.quartz-scheduler:quartz": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
+            ]
+        },
+        "org.reflections:reflections": {
+            "locked": "0.9.10",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.archaius:archaius2-core",
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.governator:governator-core",
                 "com.netflix.spectator:spectator-api",
                 "com.netflix.titus:titus-api",
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
                 "io.reactivex:rxnetty",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models",
+                "org.apache.curator:curator-client",
+                "org.apache.zookeeper:zookeeper",
+                "org.quartz-scheduler:quartz",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -915,7 +1522,10 @@
             "locked": "1.7.0",
             "transitive": [
                 "com.netflix.titus:titus-api",
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "org.springframework:spring-core": {
@@ -930,16 +1540,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "org.webjars:swagger-ui": {
+            "locked": "2.1.4",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "org.xerial.snappy:snappy-java": {
             "locked": "1.1.7.2",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
             ]
         }
     },
@@ -950,61 +1566,43 @@
                 "com.google.inject:guice"
             ]
         },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
+        "c3p0:c3p0": {
+            "locked": "0.9.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
+                "org.quartz-scheduler:quartz"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.8.0",
+            "locked": "2.8.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.fenzo:fenzo-triggers",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.netflix.titus:titus-common"
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-common",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs"
             ]
         },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.4",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "io.swagger:swagger-core"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -1025,10 +1623,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "com.google.api.grpc:proto-google-common-protos": {
             "locked": "1.0.0",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.code.findbugs:annotations": {
+            "locked": "2.0.1",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -1059,7 +1669,11 @@
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
-                "io.opencensus:opencensus-api"
+                "io.opencensus:opencensus-api",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs",
+                "org.apache.curator:curator-client",
+                "org.reflections:reflections"
             ]
         },
         "com.google.inject.extensions:guice-assistedinject": {
@@ -1078,7 +1692,16 @@
             "locked": "4.1.0",
             "transitive": [
                 "com.google.inject.extensions:guice-grapher",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-core"
+            ]
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.1.0",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.inject:guice": {
@@ -1087,7 +1710,12 @@
                 "com.google.inject.extensions:guice-assistedinject",
                 "com.google.inject.extensions:guice-grapher",
                 "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.governator:governator-core"
+                "com.google.inject.extensions:guice-servlet",
+                "com.netflix.archaius:archaius2-guice",
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -1095,7 +1723,10 @@
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
                 "com.netflix.titus:titus-common",
-                "io.grpc:grpc-protobuf"
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "io.grpc:grpc-protobuf",
+                "org.apache.mesos:mesos"
             ]
         },
         "com.google.protobuf:protobuf-java-util": {
@@ -1113,40 +1744,133 @@
         "com.netflix.archaius:archaius2-core": {
             "locked": "2.3.13",
             "transitive": [
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.netflix.archaius:archaius2-guice": {
+            "locked": "2.3.13",
+            "transitive": [
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-core": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-triggers": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.governator:governator-api": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.runtime:health-core"
             ]
         },
         "com.netflix.governator:governator-core": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jersey": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jetty": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-providers": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.netflix.governator:governator-servlet": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "com.netflix.numerus:numerus": {
             "locked": "1.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.runtime:health-api": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-core"
+            ]
+        },
+        "com.netflix.runtime:health-core": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-guice"
+            ]
+        },
+        "com.netflix.runtime:health-guice": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.59.0",
             "transitive": [
+                "com.netflix.runtime:health-core",
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.netflix.titus:titus-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
         },
         "com.netflix.titus:titus-common": {
             "project": true,
             "transitive": [
-                "com.netflix.titus:titus-api"
+                "com.netflix.titus:titus-api",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-grpc-api": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-server-master": {
+            "project": true
+        },
+        "com.netflix.titus:titus-server-runtime": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -1161,17 +1885,34 @@
                 "com.squareup.okhttp3:okhttp"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
+        "com.sun.jersey.contribs:jersey-guice": {
+            "locked": "1.19",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.sun.jersey:jersey-core": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey:jersey-server"
+            ]
+        },
+        "com.sun.jersey:jersey-server": {
+            "locked": "1.19",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.sun.jersey:jersey-servlet"
+            ]
+        },
+        "com.sun.jersey:jersey-servlet": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -1193,13 +1934,15 @@
         "io.grpc:grpc-netty-shaded": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "io.grpc:grpc-protobuf": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
             ]
         },
         "io.grpc:grpc-protobuf-lite": {
@@ -1211,7 +1954,14 @@
         "io.grpc:grpc-stub": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.7.0.Final",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "io.netty:netty-buffer": {
@@ -1285,6 +2035,7 @@
         "io.reactivex:rxjava": {
             "locked": "1.3.8",
             "transitive": [
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.titus:titus-common",
                 "io.reactivex:rxnetty"
             ]
@@ -1292,7 +2043,33 @@
         "io.reactivex:rxnetty": {
             "locked": "0.4.20",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "io.swagger:swagger-annotations": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-models"
+            ]
+        },
+        "io.swagger:swagger-core": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "io.swagger:swagger-jaxrs": {
+            "locked": "1.5.12",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "io.swagger:swagger-models": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-core"
             ]
         },
         "javax.el:javax.el-api": {
@@ -1306,44 +2083,146 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.netflix.archaius:archaius2-api",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.runtime:health-core",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
+            ]
+        },
+        "javax.servlet:javax.servlet-api": {
+            "locked": "3.1.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-server"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
+                "io.swagger:swagger-core",
                 "org.hibernate:hibernate-validator"
             ]
         },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
+        "javax.ws.rs:jsr311-api": {
+            "locked": "1.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.sun.jersey:jersey-core",
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.9",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
             ]
         },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
-                "com.netflix.archaius:archaius2-core"
+                "com.netflix.archaius:archaius2-core",
+                "io.swagger:swagger-core"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
+        "org.apache.curator:curator-client": {
+            "locked": "2.11.0",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "org.apache.curator:curator-framework"
             ]
         },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
+        "org.apache.curator:curator-framework": {
+            "locked": "2.11.0",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.titus:titus-server-master",
+                "org.apache.curator:curator-recipes"
+            ]
+        },
+        "org.apache.curator:curator-recipes": {
+            "locked": "2.11.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.mesos:mesos": {
+            "locked": "1.3.2",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.zookeeper:zookeeper": {
+            "locked": "3.4.6",
+            "transitive": [
+                "org.apache.curator:curator-client"
+            ]
+        },
+        "org.eclipse.jetty:jetty-http": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-io": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-security": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-servlet"
+            ]
+        },
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-security"
+            ]
+        },
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-webapp"
+            ]
+        },
+        "org.eclipse.jetty:jetty-util": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-http",
+                "org.eclipse.jetty:jetty-io",
+                "org.eclipse.jetty:jetty-xml"
+            ]
+        },
+        "org.eclipse.jetty:jetty-webapp": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.eclipse.jetty:jetty-xml": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-webapp"
             ]
         },
         "org.glassfish:javax.el": {
@@ -1361,7 +2240,14 @@
         "org.hibernate:hibernate-validator": {
             "locked": "5.4.2.Final",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.javassist:javassist": {
+            "locked": "3.18.2-GA",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "org.jboss.logging:jboss-logging": {
@@ -1370,16 +2256,45 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.json:json": {
+            "locked": "20140107",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.quartz-scheduler:quartz": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
+            ]
+        },
+        "org.reflections:reflections": {
+            "locked": "0.9.10",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.archaius:archaius2-core",
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.governator:governator-core",
                 "com.netflix.spectator:spectator-api",
                 "com.netflix.titus:titus-api",
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
                 "io.reactivex:rxnetty",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models",
+                "org.apache.curator:curator-client",
+                "org.apache.zookeeper:zookeeper",
+                "org.quartz-scheduler:quartz",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -1388,7 +2303,10 @@
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.titus:titus-api",
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "org.springframework:spring-core": {
@@ -1403,16 +2321,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "org.webjars:swagger-ui": {
+            "locked": "2.1.4",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "org.xerial.snappy:snappy-java": {
             "locked": "1.1.7.2",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
             ]
         }
     },
@@ -1486,61 +2410,43 @@
                 "com.google.inject:guice"
             ]
         },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
+        "c3p0:c3p0": {
+            "locked": "0.9.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
+                "org.quartz-scheduler:quartz"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.8.0",
+            "locked": "2.8.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.fenzo:fenzo-triggers",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.netflix.titus:titus-common"
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-common",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs"
             ]
         },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.4",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "io.swagger:swagger-core"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -1561,10 +2467,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "com.google.api.grpc:proto-google-common-protos": {
             "locked": "1.0.0",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.code.findbugs:annotations": {
+            "locked": "2.0.1",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -1595,7 +2513,11 @@
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
-                "io.opencensus:opencensus-api"
+                "io.opencensus:opencensus-api",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs",
+                "org.apache.curator:curator-client",
+                "org.reflections:reflections"
             ]
         },
         "com.google.inject.extensions:guice-assistedinject": {
@@ -1614,7 +2536,16 @@
             "locked": "4.1.0",
             "transitive": [
                 "com.google.inject.extensions:guice-grapher",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-core"
+            ]
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.1.0",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.inject:guice": {
@@ -1623,7 +2554,12 @@
                 "com.google.inject.extensions:guice-assistedinject",
                 "com.google.inject.extensions:guice-grapher",
                 "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.governator:governator-core"
+                "com.google.inject.extensions:guice-servlet",
+                "com.netflix.archaius:archaius2-guice",
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -1631,7 +2567,10 @@
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
                 "com.netflix.titus:titus-common",
-                "io.grpc:grpc-protobuf"
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "io.grpc:grpc-protobuf",
+                "org.apache.mesos:mesos"
             ]
         },
         "com.google.protobuf:protobuf-java-util": {
@@ -1649,40 +2588,133 @@
         "com.netflix.archaius:archaius2-core": {
             "locked": "2.3.13",
             "transitive": [
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.netflix.archaius:archaius2-guice": {
+            "locked": "2.3.13",
+            "transitive": [
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-core": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-triggers": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.governator:governator-api": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.runtime:health-core"
             ]
         },
         "com.netflix.governator:governator-core": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jersey": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jetty": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-providers": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.netflix.governator:governator-servlet": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "com.netflix.numerus:numerus": {
             "locked": "1.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.runtime:health-api": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-core"
+            ]
+        },
+        "com.netflix.runtime:health-core": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-guice"
+            ]
+        },
+        "com.netflix.runtime:health-guice": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.59.0",
             "transitive": [
+                "com.netflix.runtime:health-core",
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.netflix.titus:titus-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
         },
         "com.netflix.titus:titus-common": {
             "project": true,
             "transitive": [
-                "com.netflix.titus:titus-api"
+                "com.netflix.titus:titus-api",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-grpc-api": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-server-master": {
+            "project": true
+        },
+        "com.netflix.titus:titus-server-runtime": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -1697,17 +2729,34 @@
                 "com.squareup.okhttp3:okhttp"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
+        "com.sun.jersey.contribs:jersey-guice": {
+            "locked": "1.19",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.sun.jersey:jersey-core": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey:jersey-server"
+            ]
+        },
+        "com.sun.jersey:jersey-server": {
+            "locked": "1.19",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.sun.jersey:jersey-servlet"
+            ]
+        },
+        "com.sun.jersey:jersey-servlet": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -1729,13 +2778,15 @@
         "io.grpc:grpc-netty-shaded": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "io.grpc:grpc-protobuf": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
             ]
         },
         "io.grpc:grpc-protobuf-lite": {
@@ -1747,7 +2798,14 @@
         "io.grpc:grpc-stub": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.7.0.Final",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "io.netty:netty-buffer": {
@@ -1821,6 +2879,7 @@
         "io.reactivex:rxjava": {
             "locked": "1.3.8",
             "transitive": [
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.titus:titus-common",
                 "io.reactivex:rxnetty"
             ]
@@ -1828,7 +2887,33 @@
         "io.reactivex:rxnetty": {
             "locked": "0.4.20",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "io.swagger:swagger-annotations": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-models"
+            ]
+        },
+        "io.swagger:swagger-core": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "io.swagger:swagger-jaxrs": {
+            "locked": "1.5.12",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "io.swagger:swagger-models": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-core"
             ]
         },
         "javax.el:javax.el-api": {
@@ -1842,44 +2927,146 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.netflix.archaius:archaius2-api",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.runtime:health-core",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
+            ]
+        },
+        "javax.servlet:javax.servlet-api": {
+            "locked": "3.1.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-server"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
+                "io.swagger:swagger-core",
                 "org.hibernate:hibernate-validator"
             ]
         },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
+        "javax.ws.rs:jsr311-api": {
+            "locked": "1.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.sun.jersey:jersey-core",
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.9",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
             ]
         },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
-                "com.netflix.archaius:archaius2-core"
+                "com.netflix.archaius:archaius2-core",
+                "io.swagger:swagger-core"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
+        "org.apache.curator:curator-client": {
+            "locked": "2.11.0",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "org.apache.curator:curator-framework"
             ]
         },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
+        "org.apache.curator:curator-framework": {
+            "locked": "2.11.0",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.titus:titus-server-master",
+                "org.apache.curator:curator-recipes"
+            ]
+        },
+        "org.apache.curator:curator-recipes": {
+            "locked": "2.11.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.mesos:mesos": {
+            "locked": "1.3.2",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.zookeeper:zookeeper": {
+            "locked": "3.4.6",
+            "transitive": [
+                "org.apache.curator:curator-client"
+            ]
+        },
+        "org.eclipse.jetty:jetty-http": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-io": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-security": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-servlet"
+            ]
+        },
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-security"
+            ]
+        },
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-webapp"
+            ]
+        },
+        "org.eclipse.jetty:jetty-util": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-http",
+                "org.eclipse.jetty:jetty-io",
+                "org.eclipse.jetty:jetty-xml"
+            ]
+        },
+        "org.eclipse.jetty:jetty-webapp": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.eclipse.jetty:jetty-xml": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-webapp"
             ]
         },
         "org.glassfish:javax.el": {
@@ -1897,7 +3084,14 @@
         "org.hibernate:hibernate-validator": {
             "locked": "5.4.2.Final",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.javassist:javassist": {
+            "locked": "3.18.2-GA",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "org.jboss.logging:jboss-logging": {
@@ -1906,16 +3100,45 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.json:json": {
+            "locked": "20140107",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.quartz-scheduler:quartz": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
+            ]
+        },
+        "org.reflections:reflections": {
+            "locked": "0.9.10",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.archaius:archaius2-core",
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.governator:governator-core",
                 "com.netflix.spectator:spectator-api",
                 "com.netflix.titus:titus-api",
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
                 "io.reactivex:rxnetty",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models",
+                "org.apache.curator:curator-client",
+                "org.apache.zookeeper:zookeeper",
+                "org.quartz-scheduler:quartz",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -1924,7 +3147,10 @@
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.titus:titus-api",
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "org.springframework:spring-core": {
@@ -1939,16 +3165,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "org.webjars:swagger-ui": {
+            "locked": "2.1.4",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "org.xerial.snappy:snappy-java": {
             "locked": "1.1.7.2",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
             ]
         }
     },
@@ -1959,61 +3191,43 @@
                 "com.google.inject:guice"
             ]
         },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
+        "c3p0:c3p0": {
+            "locked": "0.9.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
+                "org.quartz-scheduler:quartz"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.8.0",
+            "locked": "2.8.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.netflix.fenzo:fenzo-triggers",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.netflix.titus:titus-common"
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-common",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs"
             ]
         },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
+            "locked": "2.8.4",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "io.swagger:swagger-core"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -2034,10 +3248,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "com.google.api.grpc:proto-google-common-protos": {
             "locked": "1.0.0",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.code.findbugs:annotations": {
+            "locked": "2.0.1",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -2068,7 +3294,11 @@
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
-                "io.opencensus:opencensus-api"
+                "io.opencensus:opencensus-api",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-jaxrs",
+                "org.apache.curator:curator-client",
+                "org.reflections:reflections"
             ]
         },
         "com.google.inject.extensions:guice-assistedinject": {
@@ -2087,7 +3317,16 @@
             "locked": "4.1.0",
             "transitive": [
                 "com.google.inject.extensions:guice-grapher",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-core"
+            ]
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.1.0",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.inject:guice": {
@@ -2096,7 +3335,12 @@
                 "com.google.inject.extensions:guice-assistedinject",
                 "com.google.inject.extensions:guice-grapher",
                 "com.google.inject.extensions:guice-multibindings",
-                "com.netflix.governator:governator-core"
+                "com.google.inject.extensions:guice-servlet",
+                "com.netflix.archaius:archaius2-guice",
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -2104,7 +3348,10 @@
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
                 "com.netflix.titus:titus-common",
-                "io.grpc:grpc-protobuf"
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "io.grpc:grpc-protobuf",
+                "org.apache.mesos:mesos"
             ]
         },
         "com.google.protobuf:protobuf-java-util": {
@@ -2122,40 +3369,133 @@
         "com.netflix.archaius:archaius2-core": {
             "locked": "2.3.13",
             "transitive": [
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.netflix.archaius:archaius2-guice": {
+            "locked": "2.3.13",
+            "transitive": [
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-core": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.fenzo:fenzo-triggers": {
+            "locked": "1.1.0-rc.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.governator:governator-api": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.runtime:health-core"
             ]
         },
         "com.netflix.governator:governator-core": {
             "locked": "1.15.11",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.governator:governator-jersey",
+                "com.netflix.governator:governator-servlet",
+                "com.netflix.runtime:health-guice",
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jersey": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-jetty": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.governator:governator-providers": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.netflix.governator:governator-servlet": {
+            "locked": "1.15.11",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "com.netflix.numerus:numerus": {
             "locked": "1.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "com.netflix.runtime:health-api": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-core"
+            ]
+        },
+        "com.netflix.runtime:health-core": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.runtime:health-guice"
+            ]
+        },
+        "com.netflix.runtime:health-guice": {
+            "locked": "1.1.3",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.59.0",
             "transitive": [
+                "com.netflix.runtime:health-core",
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.netflix.titus:titus-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
         },
         "com.netflix.titus:titus-common": {
             "project": true,
             "transitive": [
-                "com.netflix.titus:titus-api"
+                "com.netflix.titus:titus-api",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-grpc-api": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "com.netflix.titus:titus-server-master": {
+            "project": true
+        },
+        "com.netflix.titus:titus-server-runtime": {
+            "project": true,
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -2170,17 +3510,34 @@
                 "com.squareup.okhttp3:okhttp"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
+        "com.sun.jersey.contribs:jersey-guice": {
+            "locked": "1.19",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.governator:governator-jersey"
+            ]
+        },
+        "com.sun.jersey:jersey-core": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey:jersey-server"
+            ]
+        },
+        "com.sun.jersey:jersey-server": {
+            "locked": "1.19",
+            "transitive": [
+                "com.netflix.governator:governator-jersey",
+                "com.sun.jersey:jersey-servlet"
+            ]
+        },
+        "com.sun.jersey:jersey-servlet": {
+            "locked": "1.19",
+            "transitive": [
+                "com.sun.jersey.contribs:jersey-guice"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -2202,13 +3559,15 @@
         "io.grpc:grpc-netty-shaded": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "io.grpc:grpc-protobuf": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
             ]
         },
         "io.grpc:grpc-protobuf-lite": {
@@ -2220,7 +3579,14 @@
         "io.grpc:grpc-stub": {
             "locked": "1.10.1",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api"
+            ]
+        },
+        "io.netty:netty": {
+            "locked": "3.7.0.Final",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "io.netty:netty-buffer": {
@@ -2294,6 +3660,7 @@
         "io.reactivex:rxjava": {
             "locked": "1.3.8",
             "transitive": [
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.titus:titus-common",
                 "io.reactivex:rxnetty"
             ]
@@ -2301,7 +3668,33 @@
         "io.reactivex:rxnetty": {
             "locked": "0.4.20",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "io.swagger:swagger-annotations": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-models"
+            ]
+        },
+        "io.swagger:swagger-core": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "io.swagger:swagger-jaxrs": {
+            "locked": "1.5.12",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "io.swagger:swagger-models": {
+            "locked": "1.5.12",
+            "transitive": [
+                "io.swagger:swagger-core"
             ]
         },
         "javax.el:javax.el-api": {
@@ -2315,44 +3708,146 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.netflix.archaius:archaius2-api",
+                "com.netflix.archaius:archaius2-guice",
                 "com.netflix.governator:governator-api",
-                "com.netflix.governator:governator-core"
+                "com.netflix.governator:governator-core",
+                "com.netflix.governator:governator-providers",
+                "com.netflix.runtime:health-core",
+                "com.netflix.titus:titus-server-master",
+                "com.sun.jersey.contribs:jersey-guice"
+            ]
+        },
+        "javax.servlet:javax.servlet-api": {
+            "locked": "3.1.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-server"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
+                "io.swagger:swagger-core",
                 "org.hibernate:hibernate-validator"
             ]
         },
-        "joda-time:joda-time": {
-            "locked": "2.8.1",
+        "javax.ws.rs:jsr311-api": {
+            "locked": "1.1.1",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.sun.jersey:jersey-core",
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
+        "joda-time:joda-time": {
+            "locked": "2.9.9",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
             ]
         },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
-                "com.netflix.archaius:archaius2-core"
+                "com.netflix.archaius:archaius2-core",
+                "io.swagger:swagger-core"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
+        "org.apache.curator:curator-client": {
+            "locked": "2.11.0",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "org.apache.curator:curator-framework"
             ]
         },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
+        "org.apache.curator:curator-framework": {
+            "locked": "2.11.0",
             "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.netflix.titus:titus-server-master",
+                "org.apache.curator:curator-recipes"
+            ]
+        },
+        "org.apache.curator:curator-recipes": {
+            "locked": "2.11.0",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.mesos:mesos": {
+            "locked": "1.3.2",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.apache.zookeeper:zookeeper": {
+            "locked": "3.4.6",
+            "transitive": [
+                "org.apache.curator:curator-client"
+            ]
+        },
+        "org.eclipse.jetty:jetty-http": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-io": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-server"
+            ]
+        },
+        "org.eclipse.jetty:jetty-security": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-servlet"
+            ]
+        },
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-security"
+            ]
+        },
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
+                "org.eclipse.jetty:jetty-webapp"
+            ]
+        },
+        "org.eclipse.jetty:jetty-util": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-http",
+                "org.eclipse.jetty:jetty-io",
+                "org.eclipse.jetty:jetty-xml"
+            ]
+        },
+        "org.eclipse.jetty:jetty-webapp": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.eclipse.jetty:jetty-xml": {
+            "locked": "9.2.12.v20150709",
+            "transitive": [
+                "org.eclipse.jetty:jetty-webapp"
             ]
         },
         "org.glassfish:javax.el": {
@@ -2370,7 +3865,14 @@
         "org.hibernate:hibernate-validator": {
             "locked": "5.4.2.Final",
             "transitive": [
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-server-runtime"
+            ]
+        },
+        "org.javassist:javassist": {
+            "locked": "3.18.2-GA",
+            "transitive": [
+                "org.reflections:reflections"
             ]
         },
         "org.jboss.logging:jboss-logging": {
@@ -2379,16 +3881,45 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.json:json": {
+            "locked": "20140107",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
+        "org.quartz-scheduler:quartz": {
+            "locked": "2.2.1",
+            "transitive": [
+                "com.netflix.fenzo:fenzo-triggers"
+            ]
+        },
+        "org.reflections:reflections": {
+            "locked": "0.9.10",
+            "transitive": [
+                "io.swagger:swagger-jaxrs"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.archaius:archaius2-core",
+                "com.netflix.fenzo:fenzo-core",
+                "com.netflix.fenzo:fenzo-triggers",
                 "com.netflix.governator:governator-core",
                 "com.netflix.spectator:spectator-api",
                 "com.netflix.titus:titus-api",
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime",
                 "io.reactivex:rxnetty",
+                "io.swagger:swagger-core",
+                "io.swagger:swagger-models",
+                "org.apache.curator:curator-client",
+                "org.apache.zookeeper:zookeeper",
+                "org.quartz-scheduler:quartz",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -2397,7 +3928,10 @@
             "requested": "1.7.0",
             "transitive": [
                 "com.netflix.titus:titus-api",
-                "com.netflix.titus:titus-common"
+                "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-grpc-api",
+                "com.netflix.titus:titus-server-master",
+                "com.netflix.titus:titus-server-runtime"
             ]
         },
         "org.springframework:spring-core": {
@@ -2412,16 +3946,22 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "org.webjars:swagger-ui": {
+            "locked": "2.1.4",
+            "transitive": [
+                "com.netflix.titus:titus-server-master"
+            ]
+        },
         "org.xerial.snappy:snappy-java": {
             "locked": "1.1.7.2",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
+        "org.yaml:snakeyaml": {
+            "locked": "1.15",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
             ]
         }
     },
@@ -2444,6 +3984,10 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "com.101tec:zkclient": {
+            "locked": "0.4",
+            "requested": "0.4"
+        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -2454,34 +3998,6 @@
             "locked": "3.0.0",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
             ]
         },
         "com.boundary:high-scale-lib": {
@@ -2528,7 +4044,6 @@
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
@@ -2536,19 +4051,11 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-common",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
@@ -3001,17 +4508,14 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.10",
+            "locked": "1.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -3255,7 +4759,6 @@
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
                 "com.netflix.fenzo:fenzo-triggers",
                 "org.apache.cassandra:cassandra-all"
             ]
@@ -3263,6 +4766,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -3276,6 +4780,7 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -3380,18 +4885,6 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.3.2",
             "transitive": [
@@ -3410,6 +4903,7 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -3692,7 +5186,8 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit"
+                "com.netflix.titus:titus-testkit",
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "org.springframework:spring-core": {
@@ -3727,12 +5222,6 @@
                 "com.addthis.metrics:reporter-config3",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         }
     },
@@ -3755,6 +5244,10 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "com.101tec:zkclient": {
+            "locked": "0.4",
+            "requested": "0.4"
+        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -3765,34 +5258,6 @@
             "locked": "3.0.0",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
             ]
         },
         "com.boundary:high-scale-lib": {
@@ -3839,7 +5304,6 @@
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
@@ -3847,19 +5311,11 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-common",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
@@ -4312,17 +5768,14 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.10",
+            "locked": "1.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -4566,7 +6019,6 @@
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
                 "com.netflix.fenzo:fenzo-triggers",
                 "org.apache.cassandra:cassandra-all"
             ]
@@ -4574,6 +6026,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -4587,6 +6040,7 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -4691,18 +6145,6 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.3.2",
             "transitive": [
@@ -4721,6 +6163,7 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -5003,7 +6446,8 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit"
+                "com.netflix.titus:titus-testkit",
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "org.springframework:spring-core": {
@@ -5038,12 +6482,6 @@
                 "com.addthis.metrics:reporter-config3",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         }
     },
@@ -5066,6 +6504,10 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "com.101tec:zkclient": {
+            "locked": "0.4",
+            "requested": "0.4"
+        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -5076,34 +6518,6 @@
             "locked": "3.0.0",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
             ]
         },
         "com.boundary:high-scale-lib": {
@@ -5150,7 +6564,6 @@
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
@@ -5158,19 +6571,11 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-common",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
@@ -5623,17 +7028,14 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.10",
+            "locked": "1.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -5877,7 +7279,6 @@
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
                 "com.netflix.fenzo:fenzo-triggers",
                 "org.apache.cassandra:cassandra-all"
             ]
@@ -5885,6 +7286,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -5898,6 +7300,7 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -6002,18 +7405,6 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.3.2",
             "transitive": [
@@ -6032,6 +7423,7 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -6315,7 +7707,8 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit"
+                "com.netflix.titus:titus-testkit",
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "org.springframework:spring-core": {
@@ -6350,12 +7743,6 @@
                 "com.addthis.metrics:reporter-config3",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         }
     },
@@ -6378,6 +7765,10 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "com.101tec:zkclient": {
+            "locked": "0.4",
+            "requested": "0.4"
+        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -6388,34 +7779,6 @@
             "locked": "3.0.0",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
-            ]
-        },
-        "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.393",
-            "requested": "1.11.+"
-        },
-        "com.amazonaws:jmespath-java": {
-            "locked": "1.11.393",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-autoscaling",
-                "com.amazonaws:aws-java-sdk-ec2",
-                "com.amazonaws:aws-java-sdk-elasticloadbalancingv2"
             ]
         },
         "com.boundary:high-scale-lib": {
@@ -6462,7 +7825,6 @@
             "locked": "2.8.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
@@ -6470,19 +7832,11 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.8.7",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "com.amazonaws:jmespath-java",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-common",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs"
-            ]
-        },
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": {
@@ -6935,17 +8289,14 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.10",
+            "locked": "1.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.httpcomponents:httpclient"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-logging:commons-logging": {
             "locked": "1.2",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
-                "org.apache.httpcomponents:httpclient",
                 "org.springframework:spring-core"
             ]
         },
@@ -7189,7 +8540,6 @@
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
-                "com.amazonaws:aws-java-sdk-core",
                 "com.netflix.fenzo:fenzo-triggers",
                 "org.apache.cassandra:cassandra-all"
             ]
@@ -7197,6 +8547,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -7210,6 +8561,7 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -7314,18 +8666,6 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.5.5",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.4.9",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.3.2",
             "transitive": [
@@ -7344,6 +8684,7 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
+                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -7627,7 +8968,8 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit"
+                "com.netflix.titus:titus-testkit",
+                "org.apache.zookeeper:zookeeper"
             ]
         },
         "org.springframework:spring-core": {
@@ -7662,12 +9004,6 @@
                 "com.addthis.metrics:reporter-config3",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "software.amazon.ion:ion-java": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.amazonaws:aws-java-sdk-core"
             ]
         }
     }

--- a/titus-grpc-api/dependencies.lock
+++ b/titus-grpc-api/dependencies.lock
@@ -375,7 +375,7 @@
     },
     "protobuf": {
         "com.netflix.titus:titus-api-definitions": {
-            "locked": "0.0.1-rc36",
+            "locked": "0.0.1-rc38",
             "requested": "0.0.1-rc+"
         }
     },

--- a/titus-server-master/dependencies.lock
+++ b/titus-server-master/dependencies.lock
@@ -3884,10 +3884,6 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "com.101tec:zkclient": {
-            "locked": "0.4",
-            "requested": "0.4"
-        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -4682,7 +4678,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -4696,7 +4691,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -4822,7 +4816,6 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -5108,8 +5101,7 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit",
-                "org.apache.zookeeper:zookeeper"
+                "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework:spring-core": {
@@ -5167,10 +5159,6 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "com.101tec:zkclient": {
-            "locked": "0.4",
-            "requested": "0.4"
-        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -5965,7 +5953,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -5979,7 +5966,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -6105,7 +6091,6 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -6391,8 +6376,7 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit",
-                "org.apache.zookeeper:zookeeper"
+                "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework:spring-core": {
@@ -6450,10 +6434,6 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "com.101tec:zkclient": {
-            "locked": "0.4",
-            "requested": "0.4"
-        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -7248,7 +7228,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -7262,7 +7241,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -7388,7 +7366,6 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -7675,8 +7652,7 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit",
-                "org.apache.zookeeper:zookeeper"
+                "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework:spring-core": {
@@ -7734,10 +7710,6 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "com.101tec:zkclient": {
-            "locked": "0.4",
-            "requested": "0.4"
-        },
         "com.addthis.metrics:reporter-config-base": {
             "locked": "3.0.0",
             "transitive": [
@@ -8532,7 +8504,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "jline:jline",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -8546,7 +8517,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
@@ -8672,7 +8642,6 @@
         "org.apache.zookeeper:zookeeper": {
             "locked": "3.4.6",
             "transitive": [
-                "com.101tec:zkclient",
                 "org.apache.curator:curator-client"
             ]
         },
@@ -8959,8 +8928,7 @@
                 "com.netflix.titus:titus-server-gateway",
                 "com.netflix.titus:titus-server-master",
                 "com.netflix.titus:titus-server-runtime",
-                "com.netflix.titus:titus-testkit",
-                "org.apache.zookeeper:zookeeper"
+                "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework:spring-core": {


### PR DESCRIPTION
 by https://titus.builds.test.netflix.net/job/titus-control-plane-lock-dependencies/60/

aopalliance:aopalliance: -> 1.0
c3p0:c3p0: -> 0.9.1.1
cglib:cglib-nodep: -> 3.1
com.101tec:zkclient: -> 0.4
com.101tec:zkclient: 0.4 ->
com.addthis.metrics:reporter-config3: -> 3.0.0
com.addthis.metrics:reporter-config-base: -> 3.0.0
com.amazonaws:aws-java-sdk-autoscaling: 1.11.390 -> 1.11.393
com.amazonaws:aws-java-sdk-core: 1.11.390 -> 1.11.393
com.amazonaws:aws-java-sdk-ec2: 1.11.390 -> 1.11.393
com.amazonaws:aws-java-sdk-elasticloadbalancingv2: 1.11.390 -> 1.11.393
com.amazonaws:jmespath-java: 1.11.390 -> 1.11.393
com.boundary:high-scale-lib: -> 1.0.6
com.carrotsearch:hppc: -> 0.5.4
com.clearspring.analytics:stream: -> 2.5.2
com.datastax.cassandra:cassandra-driver-core: -> 3.3.2
com.datastax.cassandra:cassandra-driver-extras: -> 3.3.2
com.fasterxml:classmate: -> 1.3.1
com.fasterxml.jackson.core:jackson-annotations: -> 2.8.4
com.fasterxml.jackson.core:jackson-core: -> 2.8.7
com.fasterxml.jackson.core:jackson-databind: -> 2.8.7
com.fasterxml.jackson.dataformat:jackson-dataformat-yaml: -> 2.8.4
com.fasterxml.jackson.datatype:jackson-datatype-jdk8: -> 2.8.7
com.github.ben-manes.caffeine:caffeine: -> 2.6.2
com.github.jbellis:jamm: -> 0.3.0
com.github.jnr:jffi: -> 1.2.10
com.github.jnr:jnr-constants: -> 0.9.0
com.github.jnr:jnr-ffi: -> 2.0.7
com.github.jnr:jnr-posix: -> 3.0.27
com.github.jnr:jnr-x86asm: -> 1.0.2
com.github.rholder:snowball-stemmer: -> 1.3.0.581.1
com.github.spullara.cli-parser:cli-parser: -> 1.1.1
com.google.api.grpc:proto-google-common-protos: -> 1.0.0
com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru: -> 1.4
com.googlecode.concurrent-trees:concurrent-trees: -> 2.4.0
com.google.code.findbugs:annotations: -> 2.0.1
com.google.code.findbugs:jsr305: -> 3.0.0
com.google.code.gson:gson: -> 2.7
com.googlecode.json-simple:json-simple: -> 1.1
com.google.errorprone:error_prone_annotations: -> 2.1.2
com.google.guava:guava: -> 20.0
com.google.inject.extensions:guice-assistedinject: -> 4.1.0
com.google.inject.extensions:guice-grapher: -> 4.1.0
com.google.inject.extensions:guice-multibindings: -> 4.1.0
com.google.inject.extensions:guice-servlet: -> 4.1.0
com.google.inject:guice: -> 4.1.0
com.google.protobuf:protobuf-java: -> 3.5.1
com.google.protobuf:protobuf-java-util: -> 3.5.1
com.jayway.awaitility:awaitility: -> 1.7.0
com.lmax:disruptor: -> 3.0.1
commons-cli:commons-cli: -> 1.3.1
commons-codec:commons-codec: -> 1.2
commons-logging:commons-logging: -> 1.2
com.netflix.archaius:archaius2-api: -> 2.3.13
com.netflix.archaius:archaius2-core: -> 2.3.13
com.netflix.archaius:archaius2-guice: -> 2.3.13
com.netflix.fenzo:fenzo-core: -> 1.1.0-rc.3
com.netflix.fenzo:fenzo-triggers: -> 1.1.0-rc.3
com.netflix.governator:governator-api: -> 1.15.11
com.netflix.governator:governator-core: -> 1.15.11
com.netflix.governator:governator-jersey: -> 1.15.11
com.netflix.governator:governator-jetty: -> 1.15.11
com.netflix.governator:governator-providers: -> 1.15.11
com.netflix.governator:governator-servlet: -> 1.15.11
com.netflix.numerus:numerus: -> 1.1
com.netflix.runtime:health-api: -> 1.1.3
com.netflix.runtime:health-core: -> 1.1.3
com.netflix.runtime:health-guice: -> 1.1.3
com.netflix.spectator:spectator-api: -> 0.59.0
com.netflix.titus:titus-api-definitions: 0.0.1-rc36 -> 0.0.1-rc38
com.ning:compress-lzf: -> 0.8.4
com.squareup.okhttp3:okhttp: -> 3.8.0
com.squareup.okio:okio: -> 1.13.0
com.sun.jersey.contribs:jersey-guice: -> 1.19
com.sun.jersey:jersey-core: -> 1.19
com.sun.jersey:jersey-server: -> 1.19
com.sun.jersey:jersey-servlet: -> 1.19
com.thinkaurelius.thrift:thrift-server: -> 0.3.7
de.jflex:jflex: -> 1.6.0
io.dropwizard.metrics:metrics-core: -> 3.2.2
io.dropwizard.metrics:metrics-jvm: -> 3.1.0
io.grpc:grpc-context: -> 1.10.1
io.grpc:grpc-core: -> 1.10.1
io.grpc:grpc-netty-shaded: -> 1.10.1
io.grpc:grpc-protobuf: -> 1.10.1
io.grpc:grpc-protobuf-lite: -> 1.10.1
io.grpc:grpc-stub: -> 1.10.1
io.netty:netty: -> 3.7.0.Final
io.netty:netty-buffer: -> 4.1.5.Final
io.netty:netty-codec: -> 4.1.5.Final
io.netty:netty-codec-http: -> 4.1.5.Final
io.netty:netty-common: -> 4.1.5.Final
io.netty:netty-handler: -> 4.1.5.Final
io.netty:netty-resolver: -> 4.1.5.Final
io.netty:netty-transport: -> 4.1.5.Final
io.netty:netty-transport-native-epoll: -> 4.1.5.Final
io.opencensus:opencensus-api: -> 0.11.0
io.opencensus:opencensus-contrib-grpc-metrics: -> 0.11.0
io.reactivex:rxjava: -> 1.3.8
io.reactivex:rxnetty: -> 0.4.20
io.swagger:swagger-annotations: -> 1.5.12
io.swagger:swagger-core: -> 1.5.12
io.swagger:swagger-jaxrs: -> 1.5.12
io.swagger:swagger-models: -> 1.5.12
it.unimi.dsi:fastutil: -> 6.5.7
javax.el:javax.el-api: -> 3.0.1-b06
javax.inject:javax.inject: -> 1
javax.servlet:javax.servlet-api: -> 3.1.0
javax.validation:validation-api: -> 1.1.0.Final
javax.ws.rs:jsr311-api: -> 1.1.1
jline:jline: -> 0.9.94
joda-time:joda-time: -> 2.9.9
junit:junit: -> 4.12
junit:junit-dep: -> 4.10
log4j:log4j: -> 1.2.17
net.bytebuddy:byte-buddy: -> 1.8.15
net.bytebuddy:byte-buddy-agent: -> 1.8.15
net.java.dev.jna:jna: -> 4.1.0
net.jpountz.lz4:lz4: -> 1.3.0
net.mintern:primitive: -> 1.0
org.antlr:antlr: -> 3.5.2
org.antlr:antlr-runtime: -> 3.5.2
org.antlr:ST4: -> 4.0.8
org.apache.cassandra:cassandra-all: -> 3.9
org.apache.cassandra:cassandra-thrift: -> 3.9
org.apache.commons:commons-lang3: -> 3.3.2
org.apache.commons:commons-lang3: -> 3.4
org.apache.commons:commons-math3: -> 3.2
org.apache.curator:curator-client: -> 2.11.0
org.apache.curator:curator-framework: -> 2.11.0
org.apache.curator:curator-recipes: -> 2.11.0
org.apache.mesos:mesos: -> 1.3.2
org.apache.thrift:libthrift: -> 0.9.2
org.apache.zookeeper:zookeeper: -> 3.4.6
org.assertj:assertj-core: -> 3.8.0
org.caffinitas.ohc:ohc-core: -> 0.4.3
org.cassandraunit:cassandra-unit: -> 3.1.1.0
org.codehaus.jackson:jackson-core-asl: -> 1.9.2
org.codehaus.jackson:jackson-mapper-asl: -> 1.9.2
org.eclipse.jdt.core.compiler:ecj: -> 4.4.2
org.eclipse.jetty:jetty-http: -> 9.2.12.v20150709
org.eclipse.jetty:jetty-io: -> 9.2.12.v20150709
org.eclipse.jetty:jetty-security: -> 9.2.12.v20150709
org.eclipse.jetty:jetty-server: -> 9.2.12.v20150709
org.eclipse.jetty:jetty-servlet: -> 9.2.12.v20150709
org.eclipse.jetty:jetty-util: -> 9.2.12.v20150709
org.eclipse.jetty:jetty-webapp: -> 9.2.12.v20150709
org.eclipse.jetty:jetty-xml: -> 9.2.12.v20150709
org.fusesource:sigar: -> 1.6.4
org.glassfish:javax.el: -> 3.0.1-b10
org.hamcrest:hamcrest-core: -> 1.3
org.hamcrest:hamcrest-library: -> 1.3
org.hdrhistogram:HdrHistogram: -> 2.1.10
org.hibernate:hibernate-validator: -> 5.4.2.Final
org.jacoco:org.jacoco.agent: -> 0.8.0
org.jacoco:org.jacoco.ant: -> 0.8.0
org.jacoco:org.jacoco.core: -> 0.8.0
org.jacoco:org.jacoco.report: -> 0.8.0
org.javassist:javassist: -> 3.18.2-GA
org.jboss.logging:jboss-logging: -> 3.3.0.Final
org.json:json: -> 20140107
org.mindrot:jbcrypt: -> 0.3m
org.mockito:mockito-core: -> 2.21.0
org.objenesis:objenesis: -> 2.6
org.ow2.asm:asm: -> 5.0.3
org.ow2.asm:asm: -> 6.0
org.ow2.asm:asm-analysis: -> 5.0.3
org.ow2.asm:asm-analysis: -> 6.0
org.ow2.asm:asm-commons: -> 5.0.3
org.ow2.asm:asm-commons: -> 6.0
org.ow2.asm:asm-tree: -> 5.0.3
org.ow2.asm:asm-tree: -> 6.0
org.ow2.asm:asm-util: -> 5.0.3
org.ow2.asm:asm-util: -> 6.0
org.quartz-scheduler:quartz: -> 2.2.1
org.reflections:reflections: -> 0.9.10
org.slf4j:jcl-over-slf4j: -> 1.7.7
org.slf4j:slf4j-api: -> 1.7.25
org.slf4j:slf4j-log4j12: -> 1.7.0
org.springframework:spring-core: -> 4.3.9.RELEASE
org.springframework:spring-expression: -> 4.3.9.RELEASE
org.webjars:swagger-ui: -> 2.1.4
org.xerial.snappy:snappy-java: -> 1.1.7.2
org.yaml:snakeyaml: -> 1.15
