### PR TITLE
es publisher wrapped in retry w/ exponential backoff

### DIFF
--- a/titus-ext/elasticsearch/src/main/java/com/netflix/titus/ext/elasticsearch/ElasticsearchTaskDocumentPublisher.java
+++ b/titus-ext/elasticsearch/src/main/java/com/netflix/titus/ext/elasticsearch/ElasticsearchTaskDocumentPublisher.java
@@ -68,7 +68,7 @@ public class ElasticsearchTaskDocumentPublisher {
     private final Client client;
     private final Map<String, String> taskDocumentContext;
     private final TitusRuntime titusRuntime;
-    private Registry registry;
+    private final Registry registry;
     private final ObjectMapper objectMapper;
     private final SimpleDateFormat indexDateFormat;
     private final SimpleDateFormat taskDateFormat;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/MetricConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/MetricConstants.java
@@ -50,4 +50,6 @@ public class MetricConstants {
     public static final String METRIC_WORKER_STATE_OBSERVER = METRIC_ROOT + "workerStateObserver.";
 
     public static final String METRIC_LOADBALANCER = METRIC_ROOT + "loadBalancer.";
+
+    public static final String METRIC_ES_PUBLISHER = METRIC_ROOT + "esPublisher.";
 }


### PR DESCRIPTION
### Description of the Change

A full v3TasksStream needs to be wrapped with titusRuntime.persistentStream. This is to ensure any errors downstream won't terminate it.