### PR TITLE
Update critical tier capacity group behavior

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/aws/AwsInstanceType.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/aws/AwsInstanceType.java
@@ -101,6 +101,15 @@ public enum AwsInstanceType {
             .ebsBandwidthMbs(4000)
             .build()
     ),
+    M4_16XLarge(AwsInstanceDescriptor.newBuilder("m4.16xlarge")
+            .cpu(64)
+            .memoryGB(256)
+            .storageGB(1_000)
+            .networkMbs(25000)
+            .ebsOnly()
+            .ebsBandwidthMbs(10_000)
+            .build()
+    ),
 
     /*
      * R3 family
@@ -217,6 +226,7 @@ public enum AwsInstanceType {
     public static final String M4_2XLARGE_ID = "m4.2xlarge";
     public static final String M4_4XLARGE_ID = "m4.4xlarge";
     public static final String M4_10XLARGE_ID = "m4.10xlarge";
+    public static final String M4_16XLARGE_ID = "m4.16xlarge";
 
     public static final String R3_2XLARGE_ID = "r3.2xlarge";
     public static final String R3_4XLARGE_ID = "r3.4xlarge";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterOperationsConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterOperationsConfiguration.java
@@ -43,7 +43,7 @@ public interface ClusterOperationsConfiguration {
     /**
      * @return the maximum number of idle agents to keep for the Critical tier.
      */
-    @DefaultValue("10")
+    @DefaultValue("5")
     int getCriticalMaxIdle();
 
     /**
@@ -62,7 +62,7 @@ public interface ClusterOperationsConfiguration {
      * @return the amount of time the auto scaler can wait for an individual Critical tier task before scaling up instances
      * for it.
      */
-    @DefaultValue("60000")
+    @DefaultValue("300000")
     long getCriticalTaskSloMs();
 
     /**

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/DefaultAvailableCapacityService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/DefaultAvailableCapacityService.java
@@ -129,7 +129,8 @@ public class DefaultAvailableCapacityService implements AvailableCapacityService
             if (instanceGroup.getTier() == tier && isActiveOrPhasedOut(instanceGroup)) {
                 Optional<ServerInfo> serverInfo = serverInfoResolver.resolve(instanceGroup.getInstanceType());
                 if (serverInfo.isPresent()) {
-                    total = ResourceDimensions.add(total, toResourceDimension(serverInfo.get(), instanceGroup.getMax()));
+                    long maxSize = tier == Tier.Critical ? instanceGroup.getCurrent() : instanceGroup.getMax();
+                    total = ResourceDimensions.add(total, toResourceDimension(serverInfo.get(), maxSize));
                 }
             }
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/ResourceConsumptionEvaluator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/ResourceConsumptionEvaluator.java
@@ -115,8 +115,7 @@ class ResourceConsumptionEvaluator {
         capacityGroupConsumptionMap.forEach((capacityGroup, appConsumptions) -> {
 
             ApplicationSLA sla = applicationSlaMap.get(capacityGroup);
-            double buffer = getBuffer(sla.getTier());
-            ResourceDimension allowedConsumption = ResourceDimensions.multiply(sla.getResourceDimension(), sla.getInstanceCount() * (1 + buffer));
+            ResourceDimension allowedConsumption = ResourceDimensions.multiply(sla.getResourceDimension(), sla.getInstanceCount());
             ResourceDimension maxConsumption = ResourceConsumptions.addMaxConsumptions(appConsumptions.values());
 
             List<Map<String, Object>> attrsList = appConsumptions.values().stream().map(ResourceConsumption::getAttributes).collect(Collectors.toList());

--- a/titus-server-master/src/test/java/com/netflix/titus/master/service/management/internal/DefaultAvailableCapacityServiceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/service/management/internal/DefaultAvailableCapacityServiceTest.java
@@ -81,6 +81,7 @@ public class DefaultAvailableCapacityServiceTest {
 
         AgentInstanceGroup criticalInstanceGroup = AgentGenerator.agentServerGroups(Tier.Critical, 0, singletonList(M4_XLARGE_ID)).getValue()
                 .toBuilder()
+                .withCurrent(CRITICAL_INSTANCE_COUNT)
                 .withMax(CRITICAL_INSTANCE_COUNT)
                 .build();
 
@@ -95,12 +96,12 @@ public class DefaultAvailableCapacityServiceTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         availableCapacityService.shutdown();
     }
 
     @Test
-    public void testCapacityComputationCorrectness() throws Exception {
+    public void testCapacityComputationCorrectness() {
         testScheduler.triggerActions();
 
         Optional<ResourceDimension> capacity = availableCapacityService.totalCapacityOf(Tier.Critical);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/service/management/internal/ResourceConsumptionEvaluatorTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/service/management/internal/ResourceConsumptionEvaluatorTest.java
@@ -59,7 +59,7 @@ public class ResourceConsumptionEvaluatorTest {
     private final RuntimeModelGenerator runtimeModelGenerator = new RuntimeModelGenerator(getClass().getSimpleName());
 
     @Test
-    public void testEvaluation() throws Exception {
+    public void testEvaluation() {
         when(applicationSlaManagementService.getApplicationSLAs()).thenReturn(asList(ConsumptionModelGenerator.DEFAULT_SLA, ConsumptionModelGenerator.CRITICAL_SLA_1, ConsumptionModelGenerator.NOT_USED_SLA));
 
         // Job with defined capacity group SLA
@@ -109,7 +109,7 @@ public class ResourceConsumptionEvaluatorTest {
                 ConsumptionModelGenerator.singleWorkerConsumptionOf(goodCapacityJob) // We have single worker in Started state
         );
 
-        assertThat(criticalConsumption.getAllowedConsumption()).isEqualTo(ResourceDimensions.multiply(ConsumptionModelGenerator.capacityGroupLimit(ConsumptionModelGenerator.CRITICAL_SLA_1), (1 + BUFFER)));
+        assertThat(criticalConsumption.getAllowedConsumption()).isEqualTo(ConsumptionModelGenerator.capacityGroupLimit(ConsumptionModelGenerator.CRITICAL_SLA_1));
         assertThat(criticalConsumption.isAboveLimit()).isTrue();
 
         // Default capacity group
@@ -123,7 +123,7 @@ public class ResourceConsumptionEvaluatorTest {
                 )
         );
 
-        assertThat(defaultConsumption.getAllowedConsumption()).isEqualTo(ResourceDimensions.multiply(ConsumptionModelGenerator.capacityGroupLimit(ConsumptionModelGenerator.DEFAULT_SLA), (1 + BUFFER)));
+        assertThat(defaultConsumption.getAllowedConsumption()).isEqualTo(ConsumptionModelGenerator.capacityGroupLimit(ConsumptionModelGenerator.DEFAULT_SLA));
         assertThat(defaultConsumption.isAboveLimit()).isFalse();
 
         // Not used capacity group
@@ -131,7 +131,7 @@ public class ResourceConsumptionEvaluatorTest {
                 systemConsumption, Tier.Critical.name(), ConsumptionModelGenerator.NOT_USED_SLA.getAppName()
         ).get();
         assertThat(notUsedConsumption.getCurrentConsumption()).isEqualTo(ResourceDimension.empty());
-        assertThat(notUsedConsumption.getAllowedConsumption()).isEqualTo(ResourceDimensions.multiply(ConsumptionModelGenerator.capacityGroupLimit(ConsumptionModelGenerator.NOT_USED_SLA), (1 + BUFFER)));
+        assertThat(notUsedConsumption.getAllowedConsumption()).isEqualTo(ConsumptionModelGenerator.capacityGroupLimit(ConsumptionModelGenerator.NOT_USED_SLA));
         assertThat(notUsedConsumption.isAboveLimit()).isFalse();
     }
 }


### PR DESCRIPTION
### Description of the Change

* Remove buffer from each capacity group in order to have a global shared buffer.
* Use only the current instance count instead of max for the critical tier within an instance group to determine available capacity.