### PR TITLE
emit a system log event for API calls using page numbers

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerResource.java
@@ -1,15 +1,36 @@
 package com.netflix.titus.runtime.endpoint.v3.rest;
 
-import com.netflix.titus.grpc.protogen.*;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import com.netflix.titus.common.runtime.SystemLogService;
+import com.netflix.titus.grpc.protogen.AddLoadBalancerRequest;
+import com.netflix.titus.grpc.protogen.GetAllLoadBalancersRequest;
+import com.netflix.titus.grpc.protogen.GetAllLoadBalancersResult;
+import com.netflix.titus.grpc.protogen.GetJobLoadBalancersResult;
+import com.netflix.titus.grpc.protogen.JobId;
+import com.netflix.titus.grpc.protogen.LoadBalancerId;
+import com.netflix.titus.grpc.protogen.Page;
+import com.netflix.titus.grpc.protogen.RemoveLoadBalancerRequest;
 import com.netflix.titus.runtime.endpoint.common.rest.Responses;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.service.LoadBalancerService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
+import static com.netflix.titus.runtime.endpoint.v3.grpc.TitusPaginationUtils.logPageNumberUsage;
 
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -18,10 +39,16 @@ import javax.ws.rs.core.*;
 @Singleton
 public class LoadBalancerResource {
     private final LoadBalancerService loadBalancerService;
+    private final SystemLogService systemLog;
+    private final CallMetadataResolver callMetadataResolver;
 
     @Inject
-    public LoadBalancerResource(LoadBalancerService loadBalancerService) {
+    public LoadBalancerResource(LoadBalancerService loadBalancerService,
+                                SystemLogService systemLog,
+                                CallMetadataResolver callMetadataResolver) {
         this.loadBalancerService = loadBalancerService;
+        this.systemLog = systemLog;
+        this.callMetadataResolver = callMetadataResolver;
     }
 
     @GET
@@ -37,11 +64,12 @@ public class LoadBalancerResource {
     @GET
     @ApiOperation("Get all load balancers")
     public GetAllLoadBalancersResult getAllLoadBalancers(@Context UriInfo info) {
+        Page page = RestUtil.createPage(info.getQueryParameters());
+        logPageNumberUsage(systemLog, callMetadataResolver, getClass().getSimpleName(), "getAllLoadBalancers", page);
         return Responses.fromSingleValueObservable(
-                loadBalancerService.getAllLoadBalancers(
-                        GetAllLoadBalancersRequest.newBuilder()
-                                .setPage(RestUtil.createPage(info.getQueryParameters()))
-                                .build()));
+                loadBalancerService.getAllLoadBalancers(GetAllLoadBalancersRequest.newBuilder()
+                        .setPage(page)
+                        .build()));
     }
 
     @POST

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerResourceTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerResourceTest.java
@@ -1,8 +1,14 @@
 package com.netflix.titus.runtime.endpoint.v3.rest;
 
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
 import com.netflix.titus.api.service.TitusServiceException;
+import com.netflix.titus.common.runtime.SystemLogService;
 import com.netflix.titus.grpc.protogen.GetAllLoadBalancersResult;
 import com.netflix.titus.grpc.protogen.GetJobLoadBalancersResult;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.service.LoadBalancerService;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
 import org.junit.Before;
@@ -11,10 +17,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import rx.Completable;
 import rx.Observable;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.core.MultivaluedMap;
 
 import static com.netflix.titus.runtime.endpoint.v3.rest.RestConstants.CURSOR_QUERY_KEY;
 import static com.netflix.titus.runtime.endpoint.v3.rest.RestConstants.PAGE_QUERY_KEY;
@@ -28,8 +30,15 @@ import static org.mockito.Mockito.when;
  * Tests the {@link LoadBalancerResource} class.
  */
 public class LoadBalancerResourceTest {
-    @Mock private LoadBalancerService loadBalancerService;
-    @Mock private UriInfo uriInfo;
+    @Mock
+    private LoadBalancerService loadBalancerService;
+    @Mock
+    private UriInfo uriInfo;
+    @Mock
+    private SystemLogService systemLog;
+    @Mock
+    private CallMetadataResolver callMetadataResolver;
+
 
     private LoadBalancerResource loadBalancerResource;
 
@@ -39,7 +48,7 @@ public class LoadBalancerResourceTest {
     @Before
     public void beforeAll() {
         MockitoAnnotations.initMocks(this);
-        this.loadBalancerResource = new LoadBalancerResource(loadBalancerService);
+        this.loadBalancerResource = new LoadBalancerResource(loadBalancerService, systemLog, callMetadataResolver);
     }
 
     @Test


### PR DESCRIPTION
Pagination with page numbers will be deprecated and removed, this will help track callers of the API to assist in migrating them to cursors.