### PR TITLE
Add validator to evaluate validators in parallel

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/validator/FailJobValidator.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/validator/FailJobValidator.java
@@ -1,4 +1,4 @@
-package com.netflix.titus.master.integration.v3.job;
+package com.netflix.titus.api.jobmanager.model.job.validator;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.validator.EntityValidator;
@@ -8,19 +8,20 @@ import reactor.core.publisher.Mono;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * This {@link EntityValidator} implementation always causes validation to fail.  It is used for testing purposes.
  */
 public class FailJobValidator implements EntityValidator<JobDescriptor> {
     public static final String ERR_FIELD = "fail-field";
-    public static final String ERR_DESCRIPTION = "The FailJobValidator should always fail with this error.";
-
-    private static final ValidationError error = new ValidationError(ERR_FIELD, ERR_DESCRIPTION);
-    private static final Set<ValidationError> errors = new HashSet<>(Arrays.asList(error));
+    public static final String ERR_DESCRIPTION = "The FailJobValidator should always fail with a unique error:";
 
     @Override
     public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
-        return Mono.just(errors);
+        final String errorMsg = String.format("%s %s", ERR_DESCRIPTION, UUID.randomUUID().toString());
+        final ValidationError error = new ValidationError(ERR_FIELD, errorMsg);
+
+        return Mono.just(new HashSet<>(Arrays.asList(error)));
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/validator/ParallelValidator.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/validator/ParallelValidator.java
@@ -1,0 +1,80 @@
+package com.netflix.titus.api.jobmanager.model.job.validator;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.validator.EntityValidator;
+import com.netflix.titus.common.model.validator.ValidationError;
+import com.netflix.titus.common.util.tuple.Pair;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
+
+/**
+ * A ParallelValidator executes multiple {@link EntityValidator}s in parallel.
+ */
+public class ParallelValidator implements EntityValidator<JobDescriptor> {
+    private final Duration timeout;
+    private final Collection<EntityValidator<JobDescriptor>> hardValidators;
+    private final Collection<EntityValidator<JobDescriptor>> softValidators;
+
+    /**
+     * A ParallelValidator ensures that all its constituent validators complete within a specified duration.  The
+     * distinction between "hard" and "soft" validators is behavior on timeout.  When a "hard" validator fails to
+     * complete within the specified duration it produces a {@link ValidationError} with a {@link ValidationError.Type}
+     * of HARD.  Conversely "soft" validators which fail to complete within the specified duration have a
+     * {@link ValidationError.Type} of SOFT.
+     *
+     * @param timeout The duration within which each validator should complete.
+     * @param hardValidators Those validators which should generate a HARD {@link ValidationError} on timeout.
+     * @param softValidators Those validators which should generate a SOFT {@link ValidationError} on timeout.
+     */
+    public ParallelValidator(
+            Duration timeout,
+            Collection<EntityValidator<JobDescriptor>> hardValidators,
+            Collection<EntityValidator<JobDescriptor>> softValidators) {
+        this.timeout = timeout;
+        this.hardValidators = hardValidators;
+        this.softValidators = softValidators;
+    }
+
+    @Override
+    public Mono<Set<ValidationError>> validate(JobDescriptor jobDescriptor) {
+        Collection<Mono<Set<ValidationError>>> monos =
+                Stream.concat(
+                        getMonos(jobDescriptor, timeout, hardValidators, ValidationError.Type.HARD).stream(),
+                        getMonos(jobDescriptor, timeout, softValidators, ValidationError.Type.SOFT).stream())
+                        .collect(Collectors.toList());
+
+        return Mono.zip(
+                monos,
+                objects -> Arrays.stream(objects)
+                        .map(objectSet -> (Set<ValidationError>) objectSet)
+                        .flatMap(errorSet -> errorSet.stream())
+                        .collect(Collectors.toSet()))
+                .defaultIfEmpty(Collections.emptySet());
+    }
+
+    private static Collection<Mono<Set<ValidationError>>> getMonos(
+            JobDescriptor jobDescriptor,
+            Duration timeout,
+            Collection<EntityValidator<JobDescriptor>> validators,
+            ValidationError.Type errorType) {
+
+        return validators.stream()
+                .map(v -> new Pair<>(v.getClass().getSimpleName(), v.validate(jobDescriptor))) // (ValidatorClassName, Mono)
+                .map(pair -> pair.getRight().timeout(
+                        timeout,
+                        Mono.just(
+                                new HashSet<>(Arrays.asList(
+                                // Field: ValidatorClassName, Description: TimeoutMessage, Type: [SOFT|HARD]
+                                new ValidationError(pair.getLeft(), getTimeoutMsg(timeout), errorType))))))
+                .collect(Collectors.toList());
+    }
+
+    static String getTimeoutMsg(Duration timeout) {
+        return String.format("Timed out in %s ms", timeout.toMillis());
+    }
+}

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/validator/NeverJobValidator.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/validator/NeverJobValidator.java
@@ -1,0 +1,18 @@
+package com.netflix.titus.api.jobmanager.model.job.validator;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.validator.EntityValidator;
+import com.netflix.titus.common.model.validator.ValidationError;
+import reactor.core.publisher.Mono;
+
+import java.util.Set;
+
+/**
+ * This validator never completes.  It is used to test validation in the face of unresponsive service calls.
+ */
+public class NeverJobValidator implements EntityValidator<JobDescriptor> {
+    @Override
+    public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
+        return Mono.never();
+    }
+}

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/validator/ParallelValidatorTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/validator/ParallelValidatorTest.java
@@ -1,0 +1,231 @@
+package com.netflix.titus.api.jobmanager.model.job.validator;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.validator.EntityValidator;
+import com.netflix.titus.common.model.validator.ValidationError;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * This class tests the {@link ParallelValidator} class.
+ */
+public class ParallelValidatorTest {
+    private static final JobDescriptor MOCK_JOB = mock(JobDescriptor.class);
+    private static final Duration TIMEOUT = Duration.ofMillis(10);
+
+    // Hard validation tests
+
+    @Test
+    public void validateHardPassPass() {
+        EntityValidator pass0 = new PassJobValidator();
+        EntityValidator pass1 = new PassJobValidator();
+        ParallelValidator validator = new ParallelValidator(TIMEOUT, Arrays.asList(pass0, pass1), Collections.emptySet());
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNext(Collections.emptySet())
+                .verifyComplete();
+    }
+
+    @Test
+    public void validateHardFailFail() {
+        EntityValidator fail0 = new FailJobValidator();
+        EntityValidator fail1 = new FailJobValidator();
+        ParallelValidator validator = new ParallelValidator(TIMEOUT, Arrays.asList(fail0, fail1), Collections.emptySet());
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 2)
+                .verifyComplete();
+
+        Set<ValidationError> errors = mono.block();
+        validateFailErrors(errors);
+        validateErrorType(errors, ValidationError.Type.HARD);
+    }
+
+    @Test
+    public void validateHardPassFail() {
+        EntityValidator pass = new PassJobValidator();
+        EntityValidator fail = new FailJobValidator();
+        ParallelValidator validator = new ParallelValidator(TIMEOUT, Arrays.asList(pass, fail), Collections.emptySet());
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 1)
+                .verifyComplete();
+
+        Set<ValidationError> errors = mono.block();
+        validateFailErrors(errors);
+        validateErrorType(errors, ValidationError.Type.HARD);
+    }
+
+    @Test
+    public void validateHardPassTimeout() {
+        EntityValidator pass = new PassJobValidator();
+        EntityValidator never = new NeverJobValidator();
+        EntityValidator validator = new ParallelValidator(TIMEOUT, Arrays.asList(pass, never), Collections.emptySet());
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 1)
+                .verifyComplete();
+
+        Set<ValidationError> errors = mono.block();
+        validateTimeoutErrors(errors);
+        validateErrorType(errors, ValidationError.Type.HARD);
+    }
+
+    @Test
+    public void validateHardPassFailTimeout() {
+        EntityValidator pass = new PassJobValidator();
+        EntityValidator fail = new FailJobValidator();
+        EntityValidator never = new NeverJobValidator();
+        EntityValidator parallelValidator = new ParallelValidator(TIMEOUT, Arrays.asList(pass, fail, never), Collections.emptySet());
+        Mono<Set<ValidationError>> mono = parallelValidator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 2)
+                .verifyComplete();
+
+        Set<ValidationError> errors = mono.block();
+        validateErrorType(errors, ValidationError.Type.HARD);
+
+        Collection<ValidationError> failErrors = errors.stream()
+                .filter(error -> error.getField().equals(FailJobValidator.ERR_FIELD))
+                .collect(Collectors.toList());
+        assertThat(failErrors).hasSize(1);
+        validateFailErrors(failErrors);
+
+        Collection<ValidationError> timeoutErrors = errors.stream()
+                .filter(error -> error.getField().equals(NeverJobValidator.class.getSimpleName()))
+                .collect(Collectors.toList());
+        assertThat(timeoutErrors).hasSize(1);
+        validateTimeoutErrors(timeoutErrors);
+    }
+
+    // Soft validation tests
+
+    @Test
+    public void validateSoftTimeout() {
+        EntityValidator never = new NeverJobValidator();
+        EntityValidator validator = new ParallelValidator(TIMEOUT, Collections.emptySet(), Arrays.asList(never));
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 1)
+                .verifyComplete();
+
+        Collection<ValidationError> errors = mono.block();
+        validateTimeoutErrors(errors);
+        validateErrorType(errors, ValidationError.Type.SOFT);
+    }
+
+    @Test
+    public void validateSoftFailure() {
+        EntityValidator fail = new FailJobValidator();
+        EntityValidator validator = new ParallelValidator(TIMEOUT, Collections.emptySet(), Arrays.asList(fail));
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 1)
+                .verifyComplete();
+
+        Collection<ValidationError> errors = mono.block();
+        validateFailErrors(errors);
+        validateErrorType(errors, ValidationError.Type.HARD);
+    }
+
+    @Test
+    public void validateSoftPass() {
+        EntityValidator pass = new PassJobValidator();
+        EntityValidator validator = new ParallelValidator(TIMEOUT, Collections.emptySet(), Arrays.asList(pass));
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 0)
+                .verifyComplete();
+    }
+
+    // Hard/Soft validation tests
+
+    @Test
+    public void validateHardSoftTimeout() {
+        EntityValidator never0 = new NeverJobValidator();
+        EntityValidator never1 = new NeverJobValidator();
+        EntityValidator validator = new ParallelValidator(TIMEOUT, Arrays.asList(never0), Arrays.asList(never1));
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 2)
+                .verifyComplete();
+        Collection<ValidationError> errors = mono.block();
+        validateTimeoutErrors(errors);
+
+        Collection<ValidationError> hardErrors = errors.stream()
+                .filter(error -> error.getType().equals(ValidationError.Type.HARD))
+                .collect(Collectors.toList());
+        assertThat(hardErrors).hasSize(1);
+
+        Collection<ValidationError> softErrors = errors.stream()
+                .filter(error -> error.getType().equals(ValidationError.Type.SOFT))
+                .collect(Collectors.toList());
+        assertThat(softErrors).hasSize(1);
+    }
+
+    @Test
+    public void validateHardSoftPass() {
+        EntityValidator pass0 = new PassJobValidator();
+        EntityValidator pass1 = new PassJobValidator();
+        EntityValidator validator = new ParallelValidator(TIMEOUT, Arrays.asList(pass0), Arrays.asList(pass1));
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 0)
+                .verifyComplete();
+    }
+
+    @Test
+    public void validateHardSoftFail() {
+        EntityValidator fail0 = new FailJobValidator();
+        EntityValidator fail1 = new FailJobValidator();
+        EntityValidator validator = new ParallelValidator(TIMEOUT, Arrays.asList(fail0), Arrays.asList(fail1));
+        Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
+
+        StepVerifier.create(mono)
+                .expectNextMatches(errors -> errors.size() == 2)
+                .verifyComplete();
+
+        Collection<ValidationError> errors = mono.block();
+        validateFailErrors(errors);
+        assertThat(errors).allMatch(error -> error.getType().equals(ValidationError.Type.HARD));
+    }
+
+    private void validateFailErrors(Collection<ValidationError> failErrors) {
+        assertThat(failErrors.size() > 0).isTrue();
+        assertThat(failErrors)
+                .allMatch(error -> error.getField().equals(FailJobValidator.ERR_FIELD))
+                .allMatch(error -> error.getDescription().contains(FailJobValidator.ERR_DESCRIPTION));
+    }
+
+    private void validateTimeoutErrors(Collection<ValidationError> timeoutErrors) {
+        assertThat(timeoutErrors.size() > 0).isTrue();
+        assertThat(timeoutErrors)
+                .allMatch(error -> error.getField().equals(NeverJobValidator.class.getSimpleName()))
+                .allMatch(error -> error.getDescription().equals(ParallelValidator.getTimeoutMsg(TIMEOUT)));
+    }
+
+    private void validateErrorType(Collection<ValidationError> hardErrors, ValidationError.Type errorType) {
+        assertThat(hardErrors).allMatch(error -> error.getType().equals(errorType));
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/model/validator/ValidationError.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/validator/ValidationError.java
@@ -6,10 +6,26 @@ package com.netflix.titus.common.model.validator;
 public class ValidationError {
     private final String field;
     private final String description;
+    private final Type type;
+
+    /**
+     * The error type defined here is an indication of the seriousness of the error.  In general "HARD" errors should be
+     * considered fatal, in that continued use of the validated object is not recommended.  SOFT errors indicate that
+     * subsequent use of the validated object is possible.
+     */
+    public enum Type {
+        HARD,
+        SOFT
+    }
 
     public ValidationError(String field, String description) {
+        this(field, description, Type.HARD);
+    }
+
+    public ValidationError(String field, String description, Type type) {
         this.field = field;
         this.description = description;
+        this.type = type;
     }
 
     public String getField() {
@@ -20,8 +36,12 @@ public class ValidationError {
         return description;
     }
 
+    public Type getType() {
+        return type;
+    }
+
     public String getMessage() {
-        return String.format("field: '%s', description: '%s'", field, description);
+        return String.format("field: '%s', description: '%s', type: '%s'", field, description, type);
     }
 
     @Override

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
@@ -1,6 +1,7 @@
 package com.netflix.titus.master.integration.v3.job;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.validator.FailJobValidator;
 import com.netflix.titus.api.jobmanager.model.job.validator.PassJobValidator;
 import com.netflix.titus.common.model.validator.EntityValidator;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;


### PR DESCRIPTION
The ParallelValidator parallelizes execution of soft/hard validators.
Failure to return within the indicated timeout generates soft/hard
ValidationErrors respectively.