### PR TITLE
AgentStoreReaper retention period should be configurable and have longer default delay

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/AgentModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/AgentModule.java
@@ -35,6 +35,7 @@ import com.netflix.titus.master.agent.service.monitor.V2JobStatusMonitor;
 import com.netflix.titus.master.agent.service.server.ServerInfoResolver;
 import com.netflix.titus.master.agent.service.server.ServerInfoResolvers;
 import com.netflix.titus.master.agent.store.AgentStoreReaper;
+import com.netflix.titus.master.agent.store.AgentStoreReaperConfiguration;
 import com.netflix.titus.master.agent.store.InMemoryAgentStore;
 import com.netflix.titus.master.scheduler.VmOperationsInstanceCloudConnector;
 import rx.schedulers.Schedulers;
@@ -63,6 +64,12 @@ public class AgentModule extends AbstractModule {
     @Singleton
     public AgentManagementConfiguration getAgentManagementConfiguration(ConfigProxyFactory factory) {
         return factory.newProxy(AgentManagementConfiguration.class);
+    }
+
+    @Provides
+    @Singleton
+    public AgentStoreReaperConfiguration getAgentStoreReaperConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(AgentStoreReaperConfiguration.class);
     }
 
     @Provides

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/store/AgentStoreReaperConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/store/AgentStoreReaperConfiguration.java
@@ -1,0 +1,11 @@
+package com.netflix.titus.master.agent.store;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+
+@Configuration(prefix = "titus.agent.reaper")
+public interface AgentStoreReaperConfiguration {
+
+    @DefaultValue("" + 24 * 60 * 60 * 1000)
+    long getExpiredDataRetentionPeriodMs();
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import com.google.protobuf.Any;
 import com.google.rpc.BadRequest;
 import com.google.rpc.DebugInfo;
+import com.netflix.titus.api.agent.service.AgentManagementException;
 import com.netflix.titus.api.jobmanager.service.JobManagerException;
 import com.netflix.titus.api.scheduler.service.SchedulerException;
 import com.netflix.titus.api.service.TitusServiceException;
@@ -139,6 +140,20 @@ public final class ErrorResponses {
                 case UNIMPLEMENTED:
                     return Status.UNIMPLEMENTED;
                 case UNEXPECTED:
+                    return Status.INTERNAL;
+            }
+        } else if (cause instanceof AgentManagementException) {
+            AgentManagementException e = (AgentManagementException) cause;
+            switch (e.getErrorCode()) {
+                case InitializationError:
+                    return Status.INTERNAL;
+                case InvalidArgument:
+                    return Status.INVALID_ARGUMENT;
+                case InstanceGroupNotFound:
+                case AgentNotFound:
+                case InstanceTypeNotFound:
+                    return Status.NOT_FOUND;
+                default:
                     return Status.INTERNAL;
             }
         } else if (cause instanceof JobManagerException) {


### PR DESCRIPTION
### Description of the Change

Too short delay, may cause too eager data cleanup if there is a connectivity issue to AWS.