### PR TITLE
Server side filters for JobManagement event streams

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/V3JobOperations.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/V3JobOperations.java
@@ -31,9 +31,8 @@ import com.netflix.titus.common.util.tuple.Pair;
 import rx.Completable;
 import rx.Observable;
 
-/**
- *
- */
+import static com.netflix.titus.common.util.FunctionExt.alwaysTrue;
+
 public interface V3JobOperations {
 
     String COMPONENT = "jobManagement";
@@ -88,7 +87,12 @@ public interface V3JobOperations {
      */
     Completable recordTaskPlacement(String taskId, Function<Task, Task> changeFunction);
 
-    Observable<JobManagerEvent<?>> observeJobs();
+    default Observable<JobManagerEvent<?>> observeJobs() {
+        return observeJobs(alwaysTrue(), alwaysTrue());
+    }
+
+    Observable<JobManagerEvent<?>> observeJobs(Predicate<Pair<Job<?>, List<Task>>> jobsPredicate,
+                                               Predicate<Pair<Job<?>, Task>> tasksPredicate);
 
     Observable<JobManagerEvent<?>> observeJob(String jobId);
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.util;
+
+import java.util.function.Predicate;
+
+public final class FunctionExt {
+    public static <T> Predicate<T> alwaysTrue() {
+        return ignored -> true;
+    }
+
+    public static <T> Predicate<T> alwaysFalse() {
+        return ignored -> false;
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
@@ -19,11 +19,14 @@ package com.netflix.titus.common.util;
 import java.util.function.Predicate;
 
 public final class FunctionExt {
+    private static final Predicate TRUE_PREDICATE = ignored -> true;
+    private static final Predicate FALSE_PREDICATE = ignored -> false;
+
     public static <T> Predicate<T> alwaysTrue() {
-        return ignored -> true;
+        return TRUE_PREDICATE;
     }
 
     public static <T> Predicate<T> alwaysFalse() {
-        return ignored -> false;
+        return FALSE_PREDICATE;
     }
 }

--- a/titus-grpc-api/dependencies.lock
+++ b/titus-grpc-api/dependencies.lock
@@ -375,7 +375,7 @@
     },
     "protobuf": {
         "com.netflix.titus:titus-api-definitions": {
-            "locked": "0.0.1-rc39",
+            "locked": "0.0.1-rc40",
             "requested": "0.0.1-rc+"
         }
     },

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementClientTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementClientTest.java
@@ -623,7 +623,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(cellOneSnapshot, cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(cellTwoSnapshot, cellTwoUpdates.serialize()));
 
-        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
+        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.getDefaultInstance()).test();
         List<JobChangeNotification> expected = Stream.concat(
                 cellOneSnapshot.stream().map(this::toNotification).map(this::withStackName),
                 cellTwoSnapshot.stream().map(this::toNotification).map(this::withStackName)
@@ -654,7 +654,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellTwoUpdates.serialize()));
 
-        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
+        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.getDefaultInstance()).test();
 
         final JobChangeNotification cellOneUpdate = toNotification(Job.newBuilder().setId("cell-1-job-100").setStatus(ACCEPTED_STATE).build());
         final JobChangeNotification cellTwoUpdate = toNotification(Job.newBuilder().setId("cell-2-job-200").setStatus(ACCEPTED_STATE).build());
@@ -680,7 +680,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellTwoUpdates.serialize()));
 
-        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
+        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.getDefaultInstance()).test();
 
         final JobChangeNotification cellOneUpdate = toNotification(Job.newBuilder().setId("cell-1-job-100").setStatus(ACCEPTED_STATE).build());
         final JobChangeNotification cellTwoUpdate = toNotification(Job.newBuilder().setId("cell-2-job-200").setStatus(ACCEPTED_STATE).build());
@@ -767,7 +767,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellTwoUpdates.serialize()));
 
-        AssertableSubscriber<JobChangeNotification> subscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
+        AssertableSubscriber<JobChangeNotification> subscriber = service.observeJobs(ObserveJobsQuery.getDefaultInstance()).test();
 
         // TODO: make it easier to extract the Deadline for each cell call
         Thread.sleep(2 * GRPC_REQUEST_TIMEOUT_MS);

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementClientTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobManagementClientTest.java
@@ -54,6 +54,7 @@ import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementSer
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
 import com.netflix.titus.grpc.protogen.JobStatus;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
@@ -622,7 +623,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(cellOneSnapshot, cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(cellTwoSnapshot, cellTwoUpdates.serialize()));
 
-        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs().test();
+        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
         List<JobChangeNotification> expected = Stream.concat(
                 cellOneSnapshot.stream().map(this::toNotification).map(this::withStackName),
                 cellTwoSnapshot.stream().map(this::toNotification).map(this::withStackName)
@@ -653,7 +654,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellTwoUpdates.serialize()));
 
-        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs().test();
+        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
 
         final JobChangeNotification cellOneUpdate = toNotification(Job.newBuilder().setId("cell-1-job-100").setStatus(ACCEPTED_STATE).build());
         final JobChangeNotification cellTwoUpdate = toNotification(Job.newBuilder().setId("cell-2-job-200").setStatus(ACCEPTED_STATE).build());
@@ -679,7 +680,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellTwoUpdates.serialize()));
 
-        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs().test();
+        final AssertableSubscriber<JobChangeNotification> testSubscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
 
         final JobChangeNotification cellOneUpdate = toNotification(Job.newBuilder().setId("cell-1-job-100").setStatus(ACCEPTED_STATE).build());
         final JobChangeNotification cellTwoUpdate = toNotification(Job.newBuilder().setId("cell-2-job-200").setStatus(ACCEPTED_STATE).build());
@@ -766,7 +767,7 @@ public class AggregatingJobManagementClientTest {
         cellOne.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellOneUpdates.serialize()));
         cellTwo.getServiceRegistry().addService(new CellWithFixedJobsService(Collections.emptyList(), cellTwoUpdates.serialize()));
 
-        AssertableSubscriber<JobChangeNotification> subscriber = service.observeJobs().test();
+        AssertableSubscriber<JobChangeNotification> subscriber = service.observeJobs(ObserveJobsQuery.newBuilder().build()).test();
 
         // TODO: make it easier to extract the Deadline for each cell call
         Thread.sleep(2 * GRPC_REQUEST_TIMEOUT_MS);

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithFixedJobsService.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithFixedJobsService.java
@@ -21,6 +21,7 @@ import com.netflix.titus.grpc.protogen.JobId;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.runtime.jobmanager.JobManagerCursors;
 import io.grpc.stub.StreamObserver;
@@ -91,7 +92,8 @@ class CellWithFixedJobsService extends JobManagementServiceGrpc.JobManagementSer
     }
 
     @Override
-    public void observeJobs(Empty request, StreamObserver<JobChangeNotification> responseObserver) {
+    public void observeJobs(ObserveJobsQuery query, StreamObserver<JobChangeNotification> responseObserver) {
+        // TODO: query criteria (filters) are not implemented
         for (Job job : jobsIndex.values()) {
             JobChangeNotification.JobUpdate update = JobChangeNotification.JobUpdate.newBuilder().setJob(job).build();
             JobChangeNotification notification = JobChangeNotification.newBuilder().setJobUpdate(update).build();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobFederationTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobFederationTest.java
@@ -5,10 +5,10 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import com.google.protobuf.Empty;
 import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.master.integration.BaseIntegrationTest;
 import com.netflix.titus.testkit.embedded.federation.EmbeddedTitusFederation;
@@ -47,7 +47,7 @@ public class JobFederationTest extends BaseIntegrationTest {
         this.eventStreamObserver = new TestStreamObserver<>();
 
         JobManagementServiceGrpc.JobManagementServiceStub asyncClient = titusStackResource.getOperations().getV3GrpcClient();
-        asyncClient.observeJobs(Empty.getDefaultInstance(), eventStreamObserver);
+        asyncClient.observeJobs(ObserveJobsQuery.newBuilder().build(), eventStreamObserver);
     }
 
     @Test

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobObserveTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobObserveTest.java
@@ -16,11 +16,26 @@
 
 package com.netflix.titus.master.integration.v3.job;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
-import com.google.protobuf.Empty;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.JobModel;
+import com.netflix.titus.api.jobmanager.model.job.Owner;
+import com.netflix.titus.grpc.protogen.Image;
+import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobChangeNotification.NotificationCase;
+import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
+import com.netflix.titus.grpc.protogen.JobStatus.JobState;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
+import com.netflix.titus.grpc.protogen.Task;
+import com.netflix.titus.grpc.protogen.TaskStatus.TaskState;
 import com.netflix.titus.master.integration.BaseIntegrationTest;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTemplates;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
@@ -36,13 +51,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
+import rx.observers.AssertableSubscriber;
 
+import static com.netflix.titus.grpc.protogen.JobDescriptor.JobSpecCase.SERVICE;
+import static com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates.killJob;
+import static com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates.startTasksInNewJob;
+import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.batchJobDescriptors;
 import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskBatchJobDescriptor;
 import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskServiceJobDescriptor;
+import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.serviceJobDescriptors;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
-/**
- */
 @Category(IntegrationTest.class)
 public class JobObserveTest extends BaseIntegrationTest {
 
@@ -60,20 +80,246 @@ public class JobObserveTest extends BaseIntegrationTest {
         instanceGroupsScenarioBuilder.synchronizeWithCloud().template(InstanceGroupScenarioTemplates.basicCloudActivation());
     }
 
-    @Test(timeout = 30_000)
-    public void testObserveJobs() throws Exception {
+    @Test(timeout = TEST_TIMEOUT_MS)
+    public void observeJobs() throws Exception {
         TestStreamObserver<JobChangeNotification> eventObserver = new TestStreamObserver<>();
-        titusStackResource.getGateway().getV3GrpcClient().observeJobs(Empty.getDefaultInstance(), eventObserver);
+        titusStackResource.getGateway().getV3GrpcClient().observeJobs(ObserveJobsQuery.newBuilder().build(), eventObserver);
 
-        jobsScenarioBuilder.schedule(oneTaskBatchJobDescriptor(), jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.startTasksInNewJob()));
-        jobsScenarioBuilder.schedule(oneTaskServiceJobDescriptor(), jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.startTasksInNewJob()));
-        jobsScenarioBuilder.takeJob(0).template(ScenarioTemplates.killJob());
-        jobsScenarioBuilder.takeJob(1).template(ScenarioTemplates.killJob());
+        CountDownLatch latch = new CountDownLatch(2);
+        AssertableSubscriber<JobChangeNotification> events = eventObserver.toObservable().doOnNext(n -> {
+            if (n.getNotificationCase() == NotificationCase.JOBUPDATE &&
+                    n.getJobUpdate().getJob().getStatus().getState() == JobState.Finished) {
+                latch.countDown();
+            }
+        }).test();
 
-        List<JobChangeNotification> emittedItems = eventObserver.getEmittedItems();
-        assertThat(emittedItems).hasSize(19);
-        emittedItems.stream()
+        jobsScenarioBuilder.schedule(oneTaskBatchJobDescriptor(), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .killJob()
+        );
+        jobsScenarioBuilder.schedule(oneTaskServiceJobDescriptor(), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .killJob()
+        );
+
+        if (!latch.await(25, TimeUnit.SECONDS)) {
+            fail("jobs did not finish within 25s");
+        }
+
+        assertThat(events.getValueCount()).isGreaterThan(0);
+        events.getOnNextEvents().stream()
                 .filter(n -> n.getNotificationCase() == NotificationCase.JOBUPDATE)
                 .forEach(n -> CellAssertions.assertCellInfo(n.getJobUpdate().getJob(), EmbeddedTitusMaster.CELL_NAME));
+    }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
+    public void observeSnapshotWithFilter() throws Exception {
+        startAll(
+                batchJobDescriptors().getValue().toBuilder()
+                        .withApplicationName("myApp")
+                        .build(),
+                batchJobDescriptors().getValue().toBuilder()
+                        .withApplicationName("otherApp")
+                        .build()
+        );
+        String myAppJobId = jobsScenarioBuilder.takeJobId(0);
+
+        // start the stream after tasks are already running
+        TestStreamObserver<JobChangeNotification> eventObserver = new TestStreamObserver<>();
+        ObserveJobsQuery query = ObserveJobsQuery.newBuilder()
+                .putFilteringCriteria("applicationName", "myApp")
+                .build();
+        titusStackResource.getGateway().getV3GrpcClient().observeJobs(query, eventObserver);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AssertableSubscriber<JobChangeNotification> events = eventObserver.toObservable().doOnNext(n -> {
+            if (n.getNotificationCase() == NotificationCase.SNAPSHOTEND) {
+                latch.countDown();
+            }
+        }).test();
+        if (!latch.await(25, TimeUnit.SECONDS)) {
+            fail("snapshot did not finish within 25s");
+        }
+
+        assertEvents(eventObserver,
+                job -> assertThat(job.getJobDescriptor().getApplicationName()).isEqualTo("myApp"),
+                task -> assertThat(task.getJobId()).isEqualTo(myAppJobId)
+        );
+    }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
+    public void observeByJobDescriptor() throws Exception {
+        List<TestStreamObserver<JobChangeNotification>> observers = observeAll(
+                ObserveJobsQuery.newBuilder()
+                        .putFilteringCriteria("applicationName", "myApp")
+                        .build(),
+                ObserveJobsQuery.newBuilder()
+                        .putFilteringCriteria("owner", "me@netflix.com")
+                        .build(),
+                ObserveJobsQuery.newBuilder()
+                        .putFilteringCriteria("imageName", "some/image")
+                        .putFilteringCriteria("imageTag", "stable")
+                        .build(),
+                ObserveJobsQuery.newBuilder()
+                        .putFilteringCriteria("attributes", "attr1,attr2:value2")
+                        .putFilteringCriteria("attributes.op", "and")
+                        .build(),
+                ObserveJobsQuery.newBuilder()
+                        .putFilteringCriteria("jobType", "service")
+                        .build()
+        );
+
+        CountDownLatch latch = new CountDownLatch(observers.size());
+        for (TestStreamObserver<JobChangeNotification> eventObserver : observers) {
+            eventObserver.toObservable().doOnNext(n -> {
+                if (n.getNotificationCase() == NotificationCase.TASKUPDATE &&
+                        n.getTaskUpdate().getTask().getStatus().getState() == TaskState.Started) {
+                    latch.countDown();
+                }
+            }).test();
+        }
+
+        startAll(
+                batchJobDescriptors().getValue().toBuilder()
+                        .withApplicationName("myApp")
+                        .build(),
+                batchJobDescriptors().getValue().toBuilder()
+                        .withApplicationName("otherApp")
+                        .withOwner(Owner.newBuilder().withTeamEmail("me@netflix.com").build())
+                        .build(),
+                batchJobDescriptors().getValue().but(j -> j.getContainer().toBuilder().withImage(
+                        JobModel.newImage().withName("some/image").withTag("stable").build()
+                )),
+                batchJobDescriptors().getValue().toBuilder()
+                        .withAttributes(ImmutableMap.<String, String>builder()
+                                .put("attr1", "value1")
+                                .put("attr2", "value2")
+                                .build())
+                        .build()
+        );
+        startAll(serviceJobDescriptors().getValue());
+
+        String myAppJobId = jobsScenarioBuilder.takeJobId(0);
+        String meOwnerJobId = jobsScenarioBuilder.takeJobId(1);
+        String someImageJobId = jobsScenarioBuilder.takeJobId(2);
+        String attributesJobId = jobsScenarioBuilder.takeJobId(3);
+        String serviceJobId = jobsScenarioBuilder.takeJobId(4);
+
+        if (!latch.await(25, TimeUnit.SECONDS)) {
+            fail("all tasks did not start within 25s");
+        }
+
+        assertEvents(observers.get(0),
+                job -> assertThat(job.getJobDescriptor().getApplicationName()).isEqualTo("myApp"),
+                task -> assertThat(task.getJobId()).isEqualTo(myAppJobId)
+        );
+        assertEvents(observers.get(1),
+                job -> assertThat(job.getJobDescriptor().getOwner().getTeamEmail()).isEqualTo("me@netflix.com"),
+                task -> assertThat(task.getJobId()).isEqualTo(meOwnerJobId)
+        );
+        assertEvents(observers.get(2),
+                job -> {
+                    Image image = job.getJobDescriptor().getContainer().getImage();
+                    assertThat(image.getName()).isEqualTo("some/image");
+                    assertThat(image.getTag()).isEqualTo("stable");
+                },
+                task -> assertThat(task.getJobId()).isEqualTo(someImageJobId)
+        );
+        assertEvents(observers.get(3),
+                job -> assertThat(job.getJobDescriptor().getAttributesMap())
+                        .containsKey("attr1")
+                        .containsEntry("attr2", "value2"),
+                task -> assertThat(task.getJobId()).isEqualTo(attributesJobId)
+        );
+        assertEvents(observers.get(4),
+                job -> {
+                    assertThat(job.getJobDescriptor().getJobSpecCase()).isEqualTo(SERVICE);
+                    assertThat(job.getId()).isEqualTo(serviceJobId);
+                },
+                task -> assertThat(task.getJobId()).isEqualTo(serviceJobId)
+        );
+    }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
+    public void observeByStates() throws Exception {
+        List<TestStreamObserver<JobChangeNotification>> observers = observeAll(
+                ObserveJobsQuery.newBuilder()
+                        .putFilteringCriteria("jobState", JobState.KillInitiated.toString())
+                        .build(),
+                ObserveJobsQuery.newBuilder()
+                        .putFilteringCriteria("taskStates", String.join(",", Arrays.asList(
+                                TaskState.Launched.toString(),
+                                TaskState.Started.toString()
+                        )))
+                        .build()
+        );
+        CountDownLatch latch = new CountDownLatch(2);
+        // look for task events since the job ones are being filtered
+        observers.get(0).toObservable().doOnNext(n -> {
+            if (n.getNotificationCase() == NotificationCase.TASKUPDATE &&
+                    n.getTaskUpdate().getTask().getStatus().getState() == TaskState.Finished) {
+                latch.countDown();
+            }
+        }).test();
+        // look for job events since the task ones are being filtered
+        observers.get(1).toObservable().doOnNext(n -> {
+            if (n.getNotificationCase() == NotificationCase.JOBUPDATE &&
+                    n.getJobUpdate().getJob().getStatus().getState() == JobState.KillInitiated) {
+                latch.countDown();
+            }
+        }).test();
+
+        jobsScenarioBuilder.schedule(batchJobDescriptors().getValue(), jobScenarioBuilder -> jobScenarioBuilder
+                .template(startTasksInNewJob())
+                .template(killJob())
+        );
+        String jobId = jobsScenarioBuilder.takeJobId(0);
+
+        if (!latch.await(25, TimeUnit.SECONDS)) {
+            fail("timed out waiting streams to see finished events");
+        }
+
+        assertEvents(observers.get(0),
+                job -> assertThat(job.getStatus().getState()).isEqualTo(JobState.KillInitiated),
+                task -> assertThat(task.getJobId()).isEqualTo(jobId)
+        );
+        assertEvents(observers.get(1),
+                job -> assertThat(job.getId()).isEqualTo(jobId),
+                task -> assertThat(task.getStatus().getState()).isIn(TaskState.Launched, TaskState.Started)
+        );
+    }
+
+    @SafeVarargs
+    private final <E extends JobDescriptor.JobDescriptorExt> void startAll(JobDescriptor<E>... descriptors) throws Exception {
+        for (JobDescriptor<E> descriptor : descriptors) {
+            jobsScenarioBuilder.schedule(descriptor, jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.startTasksInNewJob()));
+        }
+    }
+
+    private List<TestStreamObserver<JobChangeNotification>> observeAll(ObserveJobsQuery... queries) {
+        JobManagementServiceGrpc.JobManagementServiceStub client = titusStackResource.getGateway().getV3GrpcClient();
+        List<TestStreamObserver<JobChangeNotification>> observers = new ArrayList<>();
+        for (ObserveJobsQuery query : queries) {
+            TestStreamObserver<JobChangeNotification> observer = new TestStreamObserver<>();
+            observers.add(observer);
+            client.observeJobs(query, observer);
+        }
+        return observers;
+    }
+
+    private void assertEvents(TestStreamObserver<JobChangeNotification> events, Consumer<Job> jobAssertions, Consumer<Task> taskAssertions) {
+        List<JobChangeNotification> emittedItems = events.getEmittedItems();
+        assertThat(emittedItems).isNotEmpty();
+        for (JobChangeNotification notification : emittedItems) {
+            switch (notification.getNotificationCase()) {
+                case JOBUPDATE:
+                    jobAssertions.accept(notification.getJobUpdate().getJob());
+                    break;
+                case TASKUPDATE:
+                    taskAssertions.accept(notification.getTaskUpdate().getTask());
+                    break;
+            }
+        }
+        events.cancel();
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerServiceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerServiceTest.java
@@ -36,7 +36,6 @@ import com.netflix.titus.api.jobmanager.service.JobManagerException;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.api.loadbalancer.model.JobLoadBalancer;
 import com.netflix.titus.api.loadbalancer.model.JobLoadBalancerState;
-import com.netflix.titus.api.loadbalancer.model.LoadBalancerTarget;
 import com.netflix.titus.api.loadbalancer.model.sanitizer.DefaultLoadBalancerJobValidator;
 import com.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerJobValidator;
 import com.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerValidationConfiguration;
@@ -48,7 +47,6 @@ import com.netflix.titus.common.util.rx.batch.Batch;
 import com.netflix.titus.runtime.store.v3.memory.InMemoryLoadBalancerStore;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import rx.Completable;
 import rx.Single;
 import rx.observers.AssertableSubscriber;
@@ -719,7 +717,6 @@ public class DefaultLoadBalancerServiceTest {
 
     private void verifyReconcilerIgnore(String jobId, String loadBalancerId, String... ipAddresses) {
         final Set<String> ipSet = CollectionsExt.asSet(ipAddresses);
-        final ArgumentCaptor<LoadBalancerTarget> captor = ArgumentCaptor.forClass(LoadBalancerTarget.class);
         verify(reconciler, times(ipAddresses.length)).activateCooldownFor(argThat(target ->
                 jobId.equals(target.getJobId())
                         && loadBalancerId.equals(target.getLoadBalancerId())

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagementClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagementClient.java
@@ -26,6 +26,7 @@ import com.netflix.titus.grpc.protogen.JobProcessesUpdate;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
 import com.netflix.titus.grpc.protogen.JobStatusUpdate;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
@@ -58,7 +59,7 @@ public interface JobManagementClient {
 
     Observable<JobChangeNotification> observeJob(String jobId);
 
-    Observable<JobChangeNotification> observeJobs();
+    Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query);
 
     Completable killJob(String jobId);
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/client/GrpcJobManagementClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/client/GrpcJobManagementClient.java
@@ -25,6 +25,7 @@ import com.netflix.titus.grpc.protogen.JobProcessesUpdate;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
 import com.netflix.titus.grpc.protogen.JobStatusUpdate;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.TaskId;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
@@ -172,10 +173,10 @@ public class GrpcJobManagementClient implements JobManagementClient {
     }
 
     @Override
-    public Observable<JobChangeNotification> observeJobs() {
+    public Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query) {
         return createRequestObservable(emitter -> {
             StreamObserver<JobChangeNotification> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver).observeJobs(Empty.getDefaultInstance(), streamObserver);
+            createWrappedStub(client, callMetadataResolver).observeJobs(query, streamObserver);
         });
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/client/JobManagementClientDelegate.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/client/JobManagementClientDelegate.java
@@ -8,6 +8,7 @@ import com.netflix.titus.grpc.protogen.JobProcessesUpdate;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
 import com.netflix.titus.grpc.protogen.JobStatusUpdate;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
@@ -60,8 +61,8 @@ public class JobManagementClientDelegate implements JobManagementClient {
     }
 
     @Override
-    public Observable<JobChangeNotification> observeJobs() {
-        return delegate.observeJobs();
+    public Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query) {
+        return delegate.observeJobs(query);
     }
 
     @Override

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
@@ -44,7 +44,7 @@ public class GrpcJobReplicatorEventStream extends AbstractReplicatorEventStream<
         return Flux.defer(() -> {
             CacheUpdater cacheUpdater = new CacheUpdater();
             logger.info("Connecting to the job event stream...");
-            return ReactorExt.toFlux(client.observeJobs(ObserveJobsQuery.newBuilder().build()))
+            return ReactorExt.toFlux(client.observeJobs(ObserveJobsQuery.getDefaultInstance()))
                     .flatMap(cacheUpdater::onEvent);
         });
     }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
@@ -13,6 +13,7 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.rx.ReactorExt;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobStatus;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.TaskStatus;
 import com.netflix.titus.runtime.connector.common.replicator.AbstractReplicatorEventStream;
 import com.netflix.titus.runtime.connector.common.replicator.DataReplicatorMetrics;
@@ -43,7 +44,8 @@ public class GrpcJobReplicatorEventStream extends AbstractReplicatorEventStream<
         return Flux.defer(() -> {
             CacheUpdater cacheUpdater = new CacheUpdater();
             logger.info("Connecting to the job event stream...");
-            return ReactorExt.toFlux(client.observeJobs()).flatMap(cacheUpdater::onEvent);
+            return ReactorExt.toFlux(client.observeJobs(ObserveJobsQuery.newBuilder().build()))
+                    .flatMap(cacheUpdater::onEvent);
         });
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/grpc/CommonGrpcModelConverters.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/grpc/CommonGrpcModelConverters.java
@@ -29,6 +29,7 @@ import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.grpc.protogen.JobDescriptor.JobSpecCase;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobStatus;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.Pagination;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskStatus;
@@ -123,6 +124,13 @@ public class CommonGrpcModelConverters {
                 .setCursor("")
                 .setCursorPosition(0)
                 .build();
+    }
+
+    public static JobQueryCriteria<TaskStatus.TaskState, JobSpecCase> toJobQueryCriteria(ObserveJobsQuery query) {
+        if (query.getFilteringCriteriaCount() == 0) {
+            return JobQueryCriteria.<TaskStatus.TaskState, JobSpecCase>newBuilder().build();
+        }
+        return toJobQueryCriteria(query.getFilteringCriteriaMap());
     }
 
     public static JobQueryCriteria<TaskStatus.TaskState, JobSpecCase> toJobQueryCriteria(JobQuery jobQuery) {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -31,6 +31,7 @@ import com.netflix.titus.grpc.protogen.JobProcessesUpdate;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
 import com.netflix.titus.grpc.protogen.JobStatusUpdate;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskId;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
@@ -117,8 +118,8 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
     }
 
     @Override
-    public void observeJobs(Empty request, StreamObserver<JobChangeNotification> responseObserver) {
-        Subscription subscription = jobManagementClient.observeJobs().subscribe(
+    public void observeJobs(ObserveJobsQuery request, StreamObserver<JobChangeNotification> responseObserver) {
+        Subscription subscription = jobManagementClient.observeJobs(request).subscribe(
                 responseObserver::onNext,
                 e -> safeOnError(logger, e, responseObserver),
                 responseObserver::onCompleted

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
@@ -24,6 +24,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -139,7 +140,7 @@ public class GrpcJobReplicatorEventStreamTest {
     }
 
     private GrpcJobReplicatorEventStream newStream() {
-        when(client.observeJobs()).thenReturn(dataGenerator.grpcObserveJobs(true));
+        when(client.observeJobs(any())).thenReturn(dataGenerator.grpcObserveJobs(true));
         return new GrpcJobReplicatorEventStream(client, new DataReplicatorMetrics("test", titusRuntime), titusRuntime, Schedulers.parallel());
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/Terminator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/Terminator.java
@@ -29,6 +29,7 @@ import com.netflix.titus.common.util.ExceptionExt;
 import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobStatus;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.testkit.perf.load.ExecutionContext;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -89,7 +90,8 @@ public class Terminator {
 
     private boolean doTry(Set<String> jobIdsToRemove, Set<String> unknownJobs) {
         try {
-            Iterator<JobChangeNotification> it = context.getJobManagementClientBlocking().observeJobs(Empty.getDefaultInstance());
+            Iterator<JobChangeNotification> it = context.getJobManagementClientBlocking()
+                    .observeJobs(ObserveJobsQuery.newBuilder().build());
             while (it.hasNext()) {
                 JobChangeNotification event = it.next();
                 if (event.getNotificationCase() == JobChangeNotification.NotificationCase.SNAPSHOTEND) {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/rx/RxGrpcJobManagementService.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/rx/RxGrpcJobManagementService.java
@@ -16,7 +16,6 @@
 
 package com.netflix.titus.testkit.rx;
 
-import com.google.protobuf.Empty;
 import com.netflix.titus.grpc.protogen.Capacity;
 import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
@@ -28,6 +27,7 @@ import com.netflix.titus.grpc.protogen.JobProcessesUpdate;
 import com.netflix.titus.grpc.protogen.JobQuery;
 import com.netflix.titus.grpc.protogen.JobQueryResult;
 import com.netflix.titus.grpc.protogen.JobStatusUpdate;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.ServiceJobSpec;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskId;
@@ -151,7 +151,7 @@ public class RxGrpcJobManagementService {
         return Observable.unsafeCreate(subscriber -> {
             ObservableClientCall.create(
                     channel.newCall(JobManagementServiceGrpc.METHOD_OBSERVE_JOBS, CallOptions.DEFAULT),
-                    Empty.getDefaultInstance()
+                    ObserveJobsQuery.newBuilder().build()
             ).subscribe(subscriber);
         });
     }


### PR DESCRIPTION
### Description of the Change

Allow gRPC event streams (`JobManagement`) to be filtered, with the same criteria that can be used with `FindJobs` and `FindTasks`.

This depends on Netflix/titus-api-definitions#59. I will modify this PR once it gets merged with the dependencies updated.