### PR TITLE
Improve orphaned tasks metrics/reporting

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/TitusRuntimeModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/TitusRuntimeModule.java
@@ -49,9 +49,9 @@ import com.netflix.titus.common.util.code.SpectatorCodeInvariants;
 import com.netflix.titus.common.util.guice.ContainerEventBusModule;
 import com.netflix.titus.common.util.rx.eventbus.RxEventBus;
 import com.netflix.titus.common.util.rx.eventbus.internal.DefaultRxEventBus;
-import com.netflix.titus.master.supervisor.service.LeaderActivator;
 import com.netflix.titus.master.mesos.MesosStatusOverrideFitAction;
 import com.netflix.titus.master.scheduler.SchedulingService;
+import com.netflix.titus.master.supervisor.service.LeaderActivator;
 import com.netflix.titus.runtime.Fit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,12 +84,12 @@ public class TitusRuntimeModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public TitusRuntime getTitusRuntime(LoggingSystemLogService loggingSystemLogService, SystemAbortListener systemAbortListener, Registry registry) {
+    public TitusRuntime getTitusRuntime(SystemLogService systemLogService, SystemAbortListener systemAbortListener, Registry registry) {
         CodeInvariants codeInvariants = new CompositeCodeInvariants(
                 LoggingCodeInvariants.getDefault(),
                 new SpectatorCodeInvariants(registry.createId("titus.runtime.invariant.violations"), registry)
         );
-        DefaultTitusRuntime titusRuntime = new DefaultTitusRuntime(codeInvariants, loggingSystemLogService, systemAbortListener, registry);
+        DefaultTitusRuntime titusRuntime = new DefaultTitusRuntime(codeInvariants, systemLogService, systemAbortListener, registry);
 
         // Setup FIT component hierarchy
         FitFramework fitFramework = titusRuntime.getFitFramework();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosSchedulerCallbackHandler.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosSchedulerCallbackHandler.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
+import rx.schedulers.Schedulers;
 
 import static com.netflix.titus.master.mesos.MesosTracer.logMesosCallbackDebug;
 import static com.netflix.titus.master.mesos.MesosTracer.logMesosCallbackError;
@@ -139,7 +140,7 @@ public class MesosSchedulerCallbackHandler implements Scheduler {
         this.config = config;
         this.mesosConfiguration = mesosConfiguration;
         this.registry = titusRuntime.getRegistry();
-        this.mesosStateTracker = new MesosStateTracker(config, titusRuntime);
+        this.mesosStateTracker = new MesosStateTracker(config, titusRuntime, Schedulers.computation());
 
         numMesosRegistered = registry.counter(MetricConstants.METRIC_MESOS + "numMesosRegistered");
         numMesosDisconnects = registry.counter(MetricConstants.METRIC_MESOS + "numMesosDisconnects");
@@ -166,6 +167,7 @@ public class MesosSchedulerCallbackHandler implements Scheduler {
     }
 
     public void shutdown() {
+        mesosStateTracker.shutdown();
         try {
             if (executor != null) {
                 executor.shutdown();


### PR DESCRIPTION
### Description of the Change

TitusMaster/Mesos state synchronization is eventually consistent, and this triggers many 
false positive orphaned containers alerts. To eliminate the false positives, we need to track
state for each unknown task, and emit alert only above certain duration threshold.
