### PR TITLE
Increase test timeout to accomodate clow CI machines

### DIFF
--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/validator/ParallelValidatorTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/validator/ParallelValidatorTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
  */
 public class ParallelValidatorTest {
     private static final JobDescriptor MOCK_JOB = mock(JobDescriptor.class);
-    private static final Duration TIMEOUT = Duration.ofMillis(10);
+    private static final Duration TIMEOUT = Duration.ofMillis(20);
 
     // Hard validation tests
 


### PR DESCRIPTION
In Travis, it can take more than `10 ms` for even the PassValidator to return.  This causes test flakiness.