### PR TITLE
Enable tag to digest resolution by default

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidatorConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidatorConfiguration.java
@@ -21,6 +21,6 @@ import com.netflix.archaius.api.annotations.DefaultValue;
 
 @Configuration(prefix = "titus.validate.job.image")
 public interface JobImageValidatorConfiguration {
-    @DefaultValue("false")
+    @DefaultValue("true")
     boolean isEnabled();
 }


### PR DESCRIPTION
### Description of the Change
This PR enables tag to digest resolution by default. The previous PR was defaulted to disabled as we were waiting for a Platform Security Metatron server change to roll out. That Metatron change is now deployed to all regions so this resolution change can be enabled in all regions.

Even when enabled, the resolution still fails open. That means that a job is reject only when we can confirm the image does not exist. Any other error (e.g., failure to talk to registry, timeouts, etc...) fail open and allow the job to proceed with no digest.