### PR TITLE
Fix tasks by page number pagination

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -62,14 +62,6 @@ public final class JobFunctions {
         throw new IllegalStateException("Unexpected V3 task state: " + v3TaskState);
     }
 
-    public static boolean isV2JobId(String jobId) {
-        return jobId.startsWith("Titus-");
-    }
-
-    public static boolean isV2Task(String taskId) {
-        return isV2JobId(taskId);
-    }
-
     public static boolean isBatchJob(Job<?> job) {
         return job.getJobDescriptor().getExtensions() instanceof BatchJobExt;
     }

--- a/titus-common/src/main/java/com/netflix/titus/common/data/generator/DataGenerator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/data/generator/DataGenerator.java
@@ -40,6 +40,7 @@ import com.netflix.titus.common.data.generator.internal.LimitDataGenerator;
 import com.netflix.titus.common.data.generator.internal.LongRangeDataGenerator;
 import com.netflix.titus.common.data.generator.internal.LoopedDataGenerator;
 import com.netflix.titus.common.data.generator.internal.MappedDataGenerator;
+import com.netflix.titus.common.data.generator.internal.MappedWithIndexDataGenerator;
 import com.netflix.titus.common.data.generator.internal.MergeDataGenerator;
 import com.netflix.titus.common.data.generator.internal.RandomDataGenerator;
 import com.netflix.titus.common.data.generator.internal.SeqDataGenerator;
@@ -97,6 +98,10 @@ public abstract class DataGenerator<A> {
         return getOptionalValue().orElseThrow(() -> new IllegalStateException("No more values"));
     }
 
+    public List<A> getValues(int count) {
+        return getAndApply(count).getRight();
+    }
+
     public abstract Optional<A> getOptionalValue();
 
     public <B> DataGenerator<B> cast(Class<B> newType) {
@@ -151,6 +156,10 @@ public abstract class DataGenerator<A> {
 
     public <B> DataGenerator<B> map(Function<A, B> transformer) {
         return MappedDataGenerator.newInstance(this, transformer);
+    }
+
+    public <B> DataGenerator<B> map(BiFunction<Long, A, B> transformer) {
+        return MappedWithIndexDataGenerator.newInstance(this, transformer);
     }
 
     public DataGenerator<A> random() {

--- a/titus-common/src/main/java/com/netflix/titus/common/data/generator/internal/MappedWithIndexDataGenerator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/data/generator/internal/MappedWithIndexDataGenerator.java
@@ -1,0 +1,38 @@
+package com.netflix.titus.common.data.generator.internal;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import com.netflix.titus.common.data.generator.DataGenerator;
+
+public class MappedWithIndexDataGenerator<A, B> extends DataGenerator<B> {
+
+    private final DataGenerator<A> sourceGenerator;
+    private final BiFunction<Long, A, B> transformer;
+    private final long index;
+    private final Optional<B> currentValue;
+
+    private MappedWithIndexDataGenerator(DataGenerator<A> sourceGenerator, BiFunction<Long, A, B> transformer, long index) {
+        this.sourceGenerator = sourceGenerator;
+        this.transformer = transformer;
+        this.index = index;
+        this.currentValue = sourceGenerator.getOptionalValue().map(t -> transformer.apply(index, t));
+    }
+
+    @Override
+    public DataGenerator<B> apply() {
+        return currentValue.isPresent() ? new MappedWithIndexDataGenerator<>(sourceGenerator.apply(), transformer, index + 1) : (DataGenerator<B>) EOS;
+    }
+
+    @Override
+    public Optional<B> getOptionalValue() {
+        return currentValue;
+    }
+
+    public static <A, B> DataGenerator<B> newInstance(DataGenerator<A> sourceGenerator, BiFunction<Long, A, B> transformer) {
+        if (sourceGenerator.isClosed()) {
+            return (DataGenerator<B>) EOS;
+        }
+        return new MappedWithIndexDataGenerator<>(sourceGenerator, transformer, 0);
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/util/Evaluators.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/Evaluators.java
@@ -16,8 +16,13 @@
 
 package com.netflix.titus.common.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
 
 /**
  * A collection of higher order functions helping in conditional expression evaluations.
@@ -69,5 +74,17 @@ public final class Evaluators {
         for (int i = 0; i < count; i++) {
             task.accept(i);
         }
+    }
+
+    public static <T> List<T> evaluateTimes(int count, Function<Integer, T> transformer) {
+        Preconditions.checkArgument(count >= 0);
+        if (count == 0) {
+            return Collections.emptyList();
+        }
+        List<T> result = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            result.add(transformer.apply(i));
+        }
+        return result;
     }
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobManagementClient.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobManagementClient.java
@@ -205,7 +205,7 @@ public class GatewayJobManagementClient extends JobManagementClientDelegate {
                 Page page = taskQuery.getPage();
                 boolean nextPageByNumber = StringExt.isEmpty(page.getCursor()) && page.getPageNumber() > 0;
 
-                if (taskStates.size() > 1 && nextPageByNumber) {
+                if (nextPageByNumber) {
                     // In this case we ask for active and archived tasks using a page number > 0. Because of that
                     // we have to fetch as much tasks from master as we can. Tasks that we do not fetch, will not be
                     // visible to the client.

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/WorkerStateMonitor.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/WorkerStateMonitor.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.netflix.titus.api.jobmanager.model.job.Job;
-import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.JobModel;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
@@ -65,10 +64,9 @@ public class WorkerStateMonitor {
 
             @Override
             public void onNext(ContainerEvent containerEvent) {
-                // V3
                 try {
                     V3ContainerEvent args = (V3ContainerEvent) containerEvent;
-                    if (args.getTaskId() != null && !JobFunctions.isV2Task(args.getTaskId())) {
+                    if (args.getTaskId() != null) {
                         Optional<Pair<Job<?>, Task>> jobAndTaskOpt = v3JobOperations.findTaskById(args.getTaskId());
                         if (jobAndTaskOpt.isPresent()) {
                             Task task = jobAndTaskOpt.get().getRight();

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/GrpcClientConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/GrpcClientConfiguration.java
@@ -27,4 +27,10 @@ public interface GrpcClientConfiguration {
      */
     @DefaultValue("10000")
     long getRequestTimeout();
+
+    /**
+     * Maximum number of tasks in a page. This limit exists due to the GRPC buffer limits.
+     */
+    @DefaultValue("5000")
+    int getMaxTaskPageSize();
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/SimulatedTitusAgent.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/SimulatedTitusAgent.java
@@ -33,9 +33,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.model.EfsMount;
-import com.netflix.titus.api.model.v2.WorkerNaming;
 import com.netflix.titus.common.aws.AwsInstanceType;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.rx.ObservableExt;
@@ -413,10 +411,6 @@ public class SimulatedTitusAgent {
     }
 
     private String extractJobId(Protos.TaskInfo task) {
-        String v2TaskId = task.getTaskId().getValue();
-        if (JobFunctions.isV2Task(v2TaskId)) {
-            return WorkerNaming.getJobAndWorkerId(v2TaskId).jobId;
-        }
         ContainerInfo containerInfo;
         try {
             containerInfo = ContainerInfo.parseFrom(task.getData());

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobGenerator.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.JobModel;
 import com.netflix.titus.api.jobmanager.model.job.JobState;
 import com.netflix.titus.api.jobmanager.model.job.JobStatus;
@@ -96,6 +97,10 @@ public class JobGenerator {
                         .withState(JobState.Accepted).build())
                 .withJobDescriptor(jobDescriptor)
                 .build());
+    }
+
+    public static DataGenerator<Job<BatchJobExt>> batchJobsOfSize(int size) {
+        return batchJobs(JobFunctions.changeBatchJobSize(JobDescriptorGenerator.oneTaskBatchJobDescriptor(), size));
     }
 
     /**


### PR DESCRIPTION
### Description of the Change

In a specific scenario tasks search pagination was broken. When user:
* executed findTasks query
* with job ids as query parameter
* with task states that included both active and archived states
only the first page of the active data would be returned correctly.
The pagination was not broken if cursor was used.
