### PR TITLE
Rely on RxRestClient timeouts and add/cleanup RxRestClient metrics

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/network/client/internal/RetryableRestClient.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/network/client/internal/RetryableRestClient.java
@@ -124,6 +124,7 @@ public class RetryableRestClient implements RxRestClient {
                                 "Retry limit reached for %s REST call. Last error: %s. Returning an error to the caller",
                                 reqSignature, retryItem.cause.getMessage()
                         );
+                        rxClientMetric.incrementRetriesExhausted(retryId);
                         return Observable.error(new IOException(errorMessage, retryItem.cause));
                     }
                     long expDelay = Math.min(MAX_DELAY_MS, (2 << retryItem.retry) * retryDelayMs);


### PR DESCRIPTION
### Description of the Change
This PR does 2 key things:

1. Fixes a bug where DefaultDockerRegistryClient had a extraneous timeout check. It should instead just rely on how it has configured its RxRestClient.
2. It makes the RxRestClient metric tags a bit more consistent and adds a retriesExhausted value.