### PR TITLE
CI: ensure docker-compose (as documented in README.md) works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,6 @@ matrix:
         - docker-compose build
       script:
         - docker-compose up -d
-        - curl --fail --max-time 10 --connect-timeout 5 --retry 100 --retry-max-time 600 --retry-connrefused localhost:7001/api/v2/status
+        - curl --fail --max-time 10 --connect-timeout 5 --retry 100 --retry-max-time 600 localhost:7001/api/v2/status
       after_script:
         - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: TITUS_INTEGRATION_TEST=true
-    - env: TITUS_DOCKER_COMPOSE=true
+    - language: generic
   include:
     - name: "Unit Tests"
       env: TITUS_INTEGRATION_TEST=false
@@ -31,11 +31,15 @@ matrix:
       services:
         - docker
       env:
-        - TITUS_DOCKER_COMPOSE=true
         - DOCKER_COMPOSE_VERSION=1.22.0
       before_install:
         - sudo rm /usr/local/bin/docker-compose
         - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
+      install:
         - docker-compose config
+        - docker-compose build
+      script:
+        - docker-compose up -d
+        - curl --fail --max-time 10 --connect-timeout 5 --retry 100 --retry-max-time 600 --retry-connrefused localhost:7001/api/v2/status

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: TITUS_INTEGRATION_TEST=true
-    - name: "Docker compose integration"
+    - env: TITUS_DOCKER_COMPOSE=true
   include:
     - name: "Unit Tests"
       env: TITUS_INTEGRATION_TEST=false
@@ -31,6 +31,7 @@ matrix:
       services:
         - docker
       env:
+        - TITUS_DOCKER_COMPOSE=true
         - DOCKER_COMPOSE_VERSION=1.22.0
       before_install:
         - sudo rm /usr/local/bin/docker-compose
@@ -38,6 +39,3 @@ matrix:
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
         - docker-compose config
-      script:
-        - docker-compose build
-        - docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ matrix:
         - docker-compose build
       script:
         - docker-compose up -d
-        - for i in {1..150}; do curl --fail --max-time 10 --connect-timeout 5 http://127.0.0.1:7001/api/v2/status && break || echo Retrying...; sleep 2; done
+        - for i in {1..150}; do curl --fail --max-time 10 --connect-timeout 5 http://127.0.0.1:7001/api/v2/status && exit 0 || echo Retrying...; sleep 2; done; exit 1
       after_script:
         - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
         - docker
       env:
         - DOCKER_COMPOSE_VERSION=1.22.0
+      cache: false
       before_install:
         - sudo rm /usr/local/bin/docker-compose
         - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,43 @@
 language: java
 jdk:
-- oraclejdk8
+  - oraclejdk8
 sudo: false
 install: "./installViaTravis.sh"
 script: travis_wait ./buildViaTravis.sh
 cache:
   directories:
-  - "$HOME/.gradle"
+    - "$HOME/.gradle"
 git:
   depth: false
 env:
-  matrix:
-  - TITUS_INTEGRATION_TEST=false
-  - TITUS_INTEGRATION_TEST=true
   global:
-  - secure: hxROLyhmCI/zRYc8UQV244XboWRxGlKW33IVcbvbCNWjLp8UKQzAaKGnfaRUGNXYn+VmN43jagFBoBgMwiGGtHEbBDJH2UzlXWOlxY6dmsklwUnC1fMPwKqCGyeOyr+OxVhAffoRJOZ1CRDiV4VN0W7y0toFGa18aNp8qr1BCgXyvldFFUWT058AAZiG3+k/1qbgb2ndNyDDIo0wi9pp6yOUDIjUzy2QG2eBNZWcKZiPouqzyO96EMcV5eYf+UOhqabx5Q8YumPTV7cMTuAJ10ZAB0UfJYHWbt/e2aFJ5xQHFCWoJpo1Q724zI6iEfQoyjN3uj2g5HvXUXJRLD/RzQLimBPABwoVYdyRtTeuhhNTDW6078g7ONVups4pjW0U0tMdU9nO5PaojKVqqssPVsK10MU3+dcb8lpCA1z1DmAPJnlFoo4lTTDdP2zK+aDPF9YP04bxq9EjcxPf6gZ5qg/jR59dbPcuYel4YYMVNm+WCTqekAbgDvhnIEaS02gzMDmshEdgZAIc8YxTs4ZpYPTXzIGzvI5RW3WaMnjeCmrP2GUYKSWzinkVMI8nbgRfrGZrmbbQ/mFHMKpjeBRyzpVrZB2gFUiET43h35+td1lf3HDPS83DED8a5qMLeAhgHB6Tt6mR5S2n2dNUhMvpsTQgcLByvZn6ELMBX1UQqmg=
-  - secure: X6qdpnE+CDj2P73N1GNRFU46V825yVf7GYAIQu8kfqoMsd+3LC80Ri89yckJJr56m7ktPw+LITJ+QTKcfMpfwHJJ5RG8V6knM19qfgY/ANZpIpWf3fl55aEJMY1XkUMqsluw7pZJA2Zn/TnPmhwNCjYzZtXw++zXoxxs6NmEIQhiZvFOXH9kCVo1RjAYhk7ZmfPsvGEroXiU+YBLY0GeuuhIN0fAYCLvOwp3uNPZFWAbu+I68d1dFyKoJadqVol4wVDfIZtpjdPfn4Nk02bXAMKiZVHj61SnV1SfCfaxTpxeNoAEnnPrSsOeZHdFNeacaJa+5dURHzH34r+RSXPo0NcEDyknt17O9W0F7cfKM+qA1njhVLuHfPXRD+5a2orxsp7yVZip0JNgDHsqlejFuHxZpXzkqKDQJV6CE1KF+NW7KOKznXcdhIXJ1xmd4HL9hU3IME/UqCLm6X+z5g6rmnTBMUFF6Yf0AOFusy9n2Xz+OpoMK2tKc0PjF0qelqva42oDWp6L5CwGWOOTshhytq1YomaVyZAWbJde8JXJiuNvsyZHwMA5fxZnJNxw0oDDIN6l8GrlnsDHd75HHqfQcDTNlqOCnVEtODHPv/4rKg4h8X80eqMvJXoq02JLJBX7OemnH3SDaNbUF8a90u2VcZ+2hryDSze35OyGECGI7r8=
-  - secure: k7l9ERNnCJZ5vMGO6Dm0fVkyN+Vc7b/O8AIoDrwuwdfvfg0r9/vMykPOB0rRDl/OyWOGY7fbXrVdD49gHZ14IMQhcVQXYn/toAMnJDB8e2ZsjN8dIted3TXR6HgSADFzhmneVMMKffNmP7scrYYx6mc0TMeSgJ3IA+keFQp1Dbnvjez1xzv9T5Lw5i39G0JLkVUvFs9ABTgW526UBtwSA4t4vF69FYjnB+jTdbFRDmtQnGbNmH4mSMNm9IsD/Ma0ietM6C9vXenXzhuO/ROZimpvEdWWWBPCrvkNqjsdlg5ArWN86iyXjI46l28DeZ7AfLwrTFON913nzFmiAvNVFwFDid/b8+aUxNCt8H1LDonBoW+QaMoEjvgqhxDwCJ4jeHFO2fIgBgjYAW/E0ivOpEIUmof4d2rK0+6HNxI9zCZ3CJyB2pjX4nVS5bfEsdfl8/CP8RsCmKpbFLkY3LAsLEnRmgaxO5Cd1lb44XSOjRdwFWWMfZx2bqH2519A9/a4DlMxnahO7+4Az0iSUUZgqBkNq/Gz7v53t0Aw+vdan+yW/o7RBlvLHT75X+5i63NwsYEa9pLZLEcKdGe5GyjLJX46yYA0i6f87dKNZFwYLWealJwMnwP+uueEUZvVcu0Ig8KyI+Au9En7MxZkdNmNHqwlROOwCyt7Qtvnes+0Y5o=
-  - secure: FmOJ216vMYOvM/GgxUUU2w5SuIcHf3uP1CKpKNqblNWyqKiVwwJbOq9k/h4tR3HHMIZCm8WbP0FMZEcHLCj/QgWTKNtwgcwkBi47B3Pf2VsOZchnAopdkZQysRvsW4gOfhQQo/ktIuv3FoXZEqC/zOZwQ7fpLOULBWVwWAmT1OCakuuXmDxIBRMXynMM/xalNDcUbvGmPqbJeK+MmtSWAGLu+3ImGAUOGUVf0XXovpBoz6hqijJ1fscm6LbwhHeDa0rYe/Iu27NRHHuDmcCqJySwywDhzPjwXKsSgXXjcmEVzE/KihUWASZf3E2uQ74jJxmYMoj6FjWRKib6CX8DhGuyKcQF28hExwqrCNKjKJC+bD069OhaluEeOYP7HPUkip1rnjk5wC6VTCbH6Hj3GvecaIaipUq2H/dDbSAyejMpoqIgU/eH8u+HQ7M7y5qwXvT7lmZ+MF5Nq6mnrVwaunHlJrflWhLwMcCX5NMCn7xTQFqWFh2R1REpaBZC4TrLgLH1zTk+qMUeOdxyav3LyqPl52yuV8HWzsfQt237YmC+98Wz7qHGPLLUJz1ey+CEhpeWF3ftM7WMMP+x3F/rK9AsXm6qexYpi1HaO04wJm+mBWWdtP2iH3X9ZEwnl+MnnvZm1BjF0DfTliU8nYZw6uMvJOjXwlqP1hDI9HBmhDQ=
+    - secure: hxROLyhmCI/zRYc8UQV244XboWRxGlKW33IVcbvbCNWjLp8UKQzAaKGnfaRUGNXYn+VmN43jagFBoBgMwiGGtHEbBDJH2UzlXWOlxY6dmsklwUnC1fMPwKqCGyeOyr+OxVhAffoRJOZ1CRDiV4VN0W7y0toFGa18aNp8qr1BCgXyvldFFUWT058AAZiG3+k/1qbgb2ndNyDDIo0wi9pp6yOUDIjUzy2QG2eBNZWcKZiPouqzyO96EMcV5eYf+UOhqabx5Q8YumPTV7cMTuAJ10ZAB0UfJYHWbt/e2aFJ5xQHFCWoJpo1Q724zI6iEfQoyjN3uj2g5HvXUXJRLD/RzQLimBPABwoVYdyRtTeuhhNTDW6078g7ONVups4pjW0U0tMdU9nO5PaojKVqqssPVsK10MU3+dcb8lpCA1z1DmAPJnlFoo4lTTDdP2zK+aDPF9YP04bxq9EjcxPf6gZ5qg/jR59dbPcuYel4YYMVNm+WCTqekAbgDvhnIEaS02gzMDmshEdgZAIc8YxTs4ZpYPTXzIGzvI5RW3WaMnjeCmrP2GUYKSWzinkVMI8nbgRfrGZrmbbQ/mFHMKpjeBRyzpVrZB2gFUiET43h35+td1lf3HDPS83DED8a5qMLeAhgHB6Tt6mR5S2n2dNUhMvpsTQgcLByvZn6ELMBX1UQqmg=
+    - secure: X6qdpnE+CDj2P73N1GNRFU46V825yVf7GYAIQu8kfqoMsd+3LC80Ri89yckJJr56m7ktPw+LITJ+QTKcfMpfwHJJ5RG8V6knM19qfgY/ANZpIpWf3fl55aEJMY1XkUMqsluw7pZJA2Zn/TnPmhwNCjYzZtXw++zXoxxs6NmEIQhiZvFOXH9kCVo1RjAYhk7ZmfPsvGEroXiU+YBLY0GeuuhIN0fAYCLvOwp3uNPZFWAbu+I68d1dFyKoJadqVol4wVDfIZtpjdPfn4Nk02bXAMKiZVHj61SnV1SfCfaxTpxeNoAEnnPrSsOeZHdFNeacaJa+5dURHzH34r+RSXPo0NcEDyknt17O9W0F7cfKM+qA1njhVLuHfPXRD+5a2orxsp7yVZip0JNgDHsqlejFuHxZpXzkqKDQJV6CE1KF+NW7KOKznXcdhIXJ1xmd4HL9hU3IME/UqCLm6X+z5g6rmnTBMUFF6Yf0AOFusy9n2Xz+OpoMK2tKc0PjF0qelqva42oDWp6L5CwGWOOTshhytq1YomaVyZAWbJde8JXJiuNvsyZHwMA5fxZnJNxw0oDDIN6l8GrlnsDHd75HHqfQcDTNlqOCnVEtODHPv/4rKg4h8X80eqMvJXoq02JLJBX7OemnH3SDaNbUF8a90u2VcZ+2hryDSze35OyGECGI7r8=
+    - secure: k7l9ERNnCJZ5vMGO6Dm0fVkyN+Vc7b/O8AIoDrwuwdfvfg0r9/vMykPOB0rRDl/OyWOGY7fbXrVdD49gHZ14IMQhcVQXYn/toAMnJDB8e2ZsjN8dIted3TXR6HgSADFzhmneVMMKffNmP7scrYYx6mc0TMeSgJ3IA+keFQp1Dbnvjez1xzv9T5Lw5i39G0JLkVUvFs9ABTgW526UBtwSA4t4vF69FYjnB+jTdbFRDmtQnGbNmH4mSMNm9IsD/Ma0ietM6C9vXenXzhuO/ROZimpvEdWWWBPCrvkNqjsdlg5ArWN86iyXjI46l28DeZ7AfLwrTFON913nzFmiAvNVFwFDid/b8+aUxNCt8H1LDonBoW+QaMoEjvgqhxDwCJ4jeHFO2fIgBgjYAW/E0ivOpEIUmof4d2rK0+6HNxI9zCZ3CJyB2pjX4nVS5bfEsdfl8/CP8RsCmKpbFLkY3LAsLEnRmgaxO5Cd1lb44XSOjRdwFWWMfZx2bqH2519A9/a4DlMxnahO7+4Az0iSUUZgqBkNq/Gz7v53t0Aw+vdan+yW/o7RBlvLHT75X+5i63NwsYEa9pLZLEcKdGe5GyjLJX46yYA0i6f87dKNZFwYLWealJwMnwP+uueEUZvVcu0Ig8KyI+Au9En7MxZkdNmNHqwlROOwCyt7Qtvnes+0Y5o=
+    - secure: FmOJ216vMYOvM/GgxUUU2w5SuIcHf3uP1CKpKNqblNWyqKiVwwJbOq9k/h4tR3HHMIZCm8WbP0FMZEcHLCj/QgWTKNtwgcwkBi47B3Pf2VsOZchnAopdkZQysRvsW4gOfhQQo/ktIuv3FoXZEqC/zOZwQ7fpLOULBWVwWAmT1OCakuuXmDxIBRMXynMM/xalNDcUbvGmPqbJeK+MmtSWAGLu+3ImGAUOGUVf0XXovpBoz6hqijJ1fscm6LbwhHeDa0rYe/Iu27NRHHuDmcCqJySwywDhzPjwXKsSgXXjcmEVzE/KihUWASZf3E2uQ74jJxmYMoj6FjWRKib6CX8DhGuyKcQF28hExwqrCNKjKJC+bD069OhaluEeOYP7HPUkip1rnjk5wC6VTCbH6Hj3GvecaIaipUq2H/dDbSAyejMpoqIgU/eH8u+HQ7M7y5qwXvT7lmZ+MF5Nq6mnrVwaunHlJrflWhLwMcCX5NMCn7xTQFqWFh2R1REpaBZC4TrLgLH1zTk+qMUeOdxyav3LyqPl52yuV8HWzsfQt237YmC+98Wz7qHGPLLUJz1ey+CEhpeWF3ftM7WMMP+x3F/rK9AsXm6qexYpi1HaO04wJm+mBWWdtP2iH3X9ZEwnl+MnnvZm1BjF0DfTliU8nYZw6uMvJOjXwlqP1hDI9HBmhDQ=
 matrix:
   fast_finish: true
   allow_failures:
-  - env: TITUS_INTEGRATION_TEST=true
+    - env: TITUS_INTEGRATION_TEST=true
+    - name: "Docker compose integration"
+  include:
+    - name: "Unit Tests"
+      env: TITUS_INTEGRATION_TEST=false
+    - name: "Integration Tests"
+      env: TITUS_INTEGRATION_TEST=true
+    - name: "Docker Compose Integration"
+      sudo: required
+      language: generic
+      services:
+        - docker
+      env:
+        - DOCKER_COMPOSE_VERSION=1.22.0
+      before_install:
+        - sudo rm /usr/local/bin/docker-compose
+        - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
+        - docker-compose config
+      script:
+        - docker-compose build
+        - docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ matrix:
         - docker-compose build
       script:
         - docker-compose up -d
-        - curl --fail --max-time 10 --connect-timeout 5 --retry 100 --retry-max-time 600 localhost:7001/api/v2/status
+        - for i in {1..150}; do curl --fail --max-time 10 --connect-timeout 5 http://127.0.0.1:7001/api/v2/status && break || echo Retrying...; sleep 2; done
       after_script:
         - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,5 @@ matrix:
       script:
         - docker-compose up -d
         - curl --fail --max-time 10 --connect-timeout 5 --retry 100 --retry-max-time 600 --retry-connrefused localhost:7001/api/v2/status
+      after_script:
+        - docker-compose down

--- a/README.md
+++ b/README.md
@@ -1,32 +1,41 @@
 # Titus Control Plane
+
 [![Build Status](https://travis-ci.org/Netflix/titus-control-plane.svg?branch=master)](https://travis-ci.org/Netflix/titus-control-plane)
 [![Apache 2.0](https://img.shields.io/github/license/nebula-plugins/gradle-lint-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 ## Overview
+
 Titus is the Netflix Container Management Platform that manages containers and provides integrations to the infrastructure
 ecosystem. This repository contains the control plane components which are responsible for accepting job requests and
 scheduling containers on agents.
 
 ## Documentation & Getting Started
+
 [netflix.github.io/titus](http://netflix.github.io/titus/)
 
 ## Building and Testing
-**Building**
-```
+
+### Building
+
+```sh-session
 ./gradlew build
 ```
-**Run Tests**
-```
+
+### Run Tests
+
+```sh-session
 ./gradlew test
 ```
 
-**Run Integration Tests**
-```
+### Run Integration Tests
+
+```sh-session
 ./gradlew integrationTest
 ```
 
-**Run All Tests**
-```
+### Run All Tests
+
+```sh-session
 ./gradlew testAll
 ```
 
@@ -36,6 +45,7 @@ these extensions, a wrapper project that reconfigures the guice bindings is need
 the different implementations is coming soon.
 
 ## Local testing with docker-compose
+
 [`docker-compose`](https://docs.docker.com/compose/install/) together with [`docker-engine`](https://docs.docker.com/engine/)
 can be used to stand up a local cluster with all components necessary to run titus containers. Each component
 (titus-master, titus-gateway, mesos-master, zookeeper, titus-agent) will run as a separate docker container, and Titus
@@ -79,7 +89,7 @@ Before any tasks can be scheduled, that cluster needs to be activated. Note that
 this is necessary *every time the Titus master is restarted*, since `instanceGroup`
 state is not being persisted:
 
-```
+```sh-session
 curl localhost:7001/api/v3/agent/instanceGroups/unknown-instanceGroup/lifecycle \
   -X PUT -H "Content-type: application/json" -d \
   '{"instanceGroupId": "unknown-instanceGroup", "lifecycleState": "Active"}'
@@ -142,7 +152,7 @@ Note that it can take ~10s for a new titus-agent to be detected and registered w
 
 After you are done:
 
-```
+```sh-session
 # tear everything down
 docker-compose down
 

--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 # This script will build the project.
 
-if [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
+if [ "$TITUS_DOCKER_COMPOSE" == "true" ]; then
+  echo -e "Running docker-compose (PR $TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
+  set -eux
+  docker-compose build
+  docker-compose -d up
+
+elif [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
   echo -e "Running integration tests (PR $TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
   ./gradlew integrationTest --stacktrace
+
 elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build --stacktrace
+
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew -Prelease.travisci=true build --stacktrace
+
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
@@ -20,6 +29,7 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
     ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final --stacktrace
     ;;
   esac
+
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
   ./gradlew build --stacktrace

--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -1,28 +1,15 @@
 #!/bin/bash
 # This script will build the project.
 
-if [ "$TITUS_DOCKER_COMPOSE" == "true" ]; then
-  echo -e "Running docker-compose (PR $TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
-  set -eux
-  docker-compose build
-  docker-compose -d up
-  curl --fail \
-    --max-time 10 --connect-timeout 5 \
-    --retry 100 --retry-max-time 600 --retry-connrefused \
-    localhost:7001/api/v2/status
-
-elif [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
+if [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
   echo -e "Running integration tests (PR $TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
   ./gradlew integrationTest --stacktrace
-
 elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build --stacktrace
-
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew -Prelease.travisci=true build --stacktrace
-
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
@@ -33,7 +20,6 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
     ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final --stacktrace
     ;;
   esac
-
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
   ./gradlew build --stacktrace

--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -6,6 +6,10 @@ if [ "$TITUS_DOCKER_COMPOSE" == "true" ]; then
   set -eux
   docker-compose build
   docker-compose -d up
+  curl --fail \
+    --max-time 10 --connect-timeout 5 \
+    --retry 100 --retry-max-time 600 --retry-connrefused \
+    localhost:7001/api/v2/status
 
 elif [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
   echo -e "Running integration tests (PR $TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"


### PR DESCRIPTION
Followup of #392. Run `docker-compose up` on every build (as a separate travis job), and ensure the control plane comes up and is ready to serve requests.

This doesn't currently try to run any tasks (as nested containers), but that can be a simple addition in the future. PRs will not be gated on failures for now, we can enable that later if/when we get some confidence it will not be flaky.

Example execution: https://travis-ci.org/Netflix/titus-control-plane/builds/441950564