### PR TITLE
Remove unneeded usage of first()

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/registry/DefaultDockerRegistryClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/registry/DefaultDockerRegistryClient.java
@@ -101,7 +101,7 @@ public class DefaultDockerRegistryClient implements RegistryClient {
                         return Observable.from(stringListMap.get(dockerDigestHeaderKey));
                     }
                     return Observable.error(new TitusRegistryException(TitusRegistryException.ErrorCode.MISSING_HEADER, "Missing required header " + dockerDigestHeaderKey));
-                }).first().toSingle();
+                }).toSingle();
     }
 
     private String buildRegistryUri(String repository, String reference) {


### PR DESCRIPTION
### Description of the Change

This PR removes an unneeded usage of `first()`. In addition to not being needed, `first()` unsubscribes from the source observable after the first item is emitted, which led to the RxNettyRestClient not emitting `.doOnTerminate()` metrics.