### PR TITLE
Move job autoscaling AWS autoscale/cloudwatch clients to control-plane

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ subprojects {
         assertjVersion = '3.8.0'
         cassandraUnitVersion = '3.1.1.0'
         mockServerVersion = '3.10.4'
+        javaslangVersion = '2.0.6'
     }
 
     tasks.withType(JavaCompile) {

--- a/titus-ext/aws/build.gradle
+++ b/titus-ext/aws/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compile project(':titus-common')
     compile project(':titus-api')
 
-    compile "io.javaslang:javaslang:2.0.6"
+    compile "io.javaslang:javaslang:${javaslangVersion}"
     compile "com.amazonaws:aws-java-sdk-ec2:${awsSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-autoscaling:${awsSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-elasticloadbalancingv2:${awsSdkVersion}"

--- a/titus-ext/aws/build.gradle
+++ b/titus-ext/aws/build.gradle
@@ -18,9 +18,12 @@ dependencies {
     compile project(':titus-common')
     compile project(':titus-api')
 
+    compile "io.javaslang:javaslang:2.0.6"
     compile "com.amazonaws:aws-java-sdk-ec2:${awsSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-autoscaling:${awsSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-elasticloadbalancingv2:${awsSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-cloudwatch:${awsSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-applicationautoscaling:${awsSdkVersion}"
 
     testCompile project(':titus-testkit')
 }

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/AmazonAutoScalingProvider.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/AmazonAutoScalingProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.aws;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.AmazonAutoScalingAsyncClient;
+import com.amazonaws.services.autoscaling.AmazonAutoScalingAsyncClientBuilder;
+
+@Singleton
+class AmazonAutoScalingProvider implements Provider<AmazonAutoScaling> {
+
+    private final AmazonAutoScaling amazonAutoScaling;
+
+    @Inject
+    public AmazonAutoScalingProvider(AwsConfiguration coreConfiguration,
+                                     AWSCredentialsProvider credentialProvider) {
+        String region = coreConfiguration.getRegion().trim().toLowerCase();
+
+        // TODO We need both sync and async versions. Remove casting once sync is no longer needed.
+        AmazonAutoScalingAsyncClient amazonAutoScalingClient = (AmazonAutoScalingAsyncClient) AmazonAutoScalingAsyncClientBuilder.standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("autoscaling." + region + ".amazonaws.com", region))
+                .withCredentials(credentialProvider)
+                .build();
+        this.amazonAutoScaling = amazonAutoScalingClient;
+    }
+
+    @Override
+    public AmazonAutoScaling get() {
+        return amazonAutoScaling;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        amazonAutoScaling.shutdown();
+    }
+}

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/AwsModule.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/AwsModule.java
@@ -18,6 +18,7 @@ package com.netflix.titus.ext.aws;
 
 import javax.inject.Singleton;
 
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingAsync;
 import com.amazonaws.services.ec2.AmazonEC2Async;
 import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingAsync;
@@ -25,6 +26,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.titus.api.connector.cloud.InstanceCloudConnector;
+import com.netflix.titus.ext.aws.appscale.AWSAppScalingConfig;
 
 public class AwsModule extends AbstractModule {
     @Override
@@ -32,6 +34,7 @@ public class AwsModule extends AbstractModule {
         bind(AmazonEC2Async.class).toProvider(AmazonEC2AsyncProvider.class);
         bind(AmazonAutoScalingAsync.class).toProvider(AmazonAutoScalingAsyncProvider.class);
         bind(AmazonElasticLoadBalancingAsync.class).toProvider(AmazonElasticLoadBalancingAsyncProvider.class);
+        bind(AmazonAutoScaling.class).toProvider(AmazonAutoScalingProvider.class);
         bind(InstanceCloudConnector.class).to(AwsInstanceCloudConnector.class);
         bind(InstanceReaper.class).asEagerSingleton();
     }
@@ -40,5 +43,11 @@ public class AwsModule extends AbstractModule {
     @Singleton
     public AwsConfiguration getAwsConfiguration(ConfigProxyFactory factory) {
         return factory.newProxy(AwsConfiguration.class);
+    }
+
+    @Provides
+    @Singleton
+    public AWSAppScalingConfig getAWSAppScalingConfig(ConfigProxyFactory factory) {
+        return factory.newProxy(AWSAppScalingConfig.class);
     }
 }

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/RetryWrapper.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/RetryWrapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.aws;
+
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+
+import static com.netflix.titus.common.util.rx.RetryHandlerBuilder.retryHandler;
+
+public class RetryWrapper {
+    private static Logger log = LoggerFactory.getLogger(RetryWrapper.class);
+
+    private static final int RETRY_COUNT = 3;
+    private static final int RETRY_DELAY_SECONDS = 2;
+
+    public static <T> Observable<T> wrapWithExponentialRetry(String retryHandlerTitle, Observable<T> sourceObservable) {
+
+        return wrapWithExponentialRetry(retryHandlerTitle, RETRY_COUNT, RETRY_DELAY_SECONDS, sourceObservable);
+    }
+
+    public static <T> Observable<T> wrapWithExponentialRetry(String retryHandlerTitle, int retryCount, int retryDelaySeconds,
+                                                             Observable<T> sourceObservable) {
+        return sourceObservable.retryWhen(
+                retryHandler()
+                        .withTitle(retryHandlerTitle)
+                        .withRetryCount(retryCount)
+                        .withRetryDelay(retryDelaySeconds, TimeUnit.SECONDS)
+                        .buildExponentialBackoff());
+
+    }
+
+
+}

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
@@ -78,7 +78,7 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     private final Counter deleteTargetErrorCounter;
     private final Counter deletePolicyErrorCounter;
     private final Counter getPolicyErrorCounter;
-    private AWSAppScalingConfig awsAppScalingConfig;
+    private final AWSAppScalingConfig awsAppScalingConfig;
 
 
     private static final String METRIC_APP_SCALE_GET_POLICY_ERROR = "titus.appscale.getPolicy.error";
@@ -133,7 +133,7 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
                 Observable.create(emitter -> awsAppAutoScalingClientAsync.registerScalableTargetAsync(registerScalableTargetRequest, new AsyncHandler<RegisterScalableTargetRequest, RegisterScalableTargetResult>() {
                     @Override
                     public void onError(Exception exception) {
-                        log.info("RegisterScalableTarget exception {}", exception.getMessage());
+                        log.error("RegisterScalableTarget exception {}", exception.getMessage());
                         createTargetErrorCounter.increment();
                         emitter.onError(exception);
                     }

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.aws.appscale;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScalingAsync;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScalingAsyncClientBuilder;
+import com.amazonaws.services.applicationautoscaling.model.CustomizedMetricSpecification;
+import com.amazonaws.services.applicationautoscaling.model.DeleteScalingPolicyRequest;
+import com.amazonaws.services.applicationautoscaling.model.DeleteScalingPolicyResult;
+import com.amazonaws.services.applicationautoscaling.model.DeregisterScalableTargetRequest;
+import com.amazonaws.services.applicationautoscaling.model.DeregisterScalableTargetResult;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsRequest;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsResult;
+import com.amazonaws.services.applicationautoscaling.model.MetricDimension;
+import com.amazonaws.services.applicationautoscaling.model.ObjectNotFoundException;
+import com.amazonaws.services.applicationautoscaling.model.PutScalingPolicyRequest;
+import com.amazonaws.services.applicationautoscaling.model.PutScalingPolicyResult;
+import com.amazonaws.services.applicationautoscaling.model.RegisterScalableTargetRequest;
+import com.amazonaws.services.applicationautoscaling.model.RegisterScalableTargetResult;
+import com.amazonaws.services.applicationautoscaling.model.ScalableTarget;
+import com.amazonaws.services.applicationautoscaling.model.StepAdjustment;
+import com.amazonaws.services.applicationautoscaling.model.StepScalingPolicyConfiguration;
+import com.amazonaws.services.applicationautoscaling.model.TargetTrackingScalingPolicyConfiguration;
+import com.amazonaws.services.applicationautoscaling.model.ValidationException;
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.titus.api.appscale.model.AutoScalableTarget;
+import com.netflix.titus.api.appscale.model.PolicyConfiguration;
+import com.netflix.titus.api.appscale.model.PolicyType;
+import com.netflix.titus.api.appscale.model.TargetTrackingPolicy;
+import com.netflix.titus.api.appscale.service.AutoScalePolicyException;
+import com.netflix.titus.api.connector.cloud.AppAutoScalingClient;
+import com.netflix.titus.ext.aws.RetryWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Completable;
+import rx.Emitter;
+import rx.Observable;
+
+
+@Singleton
+public class AWSAppAutoScalingClient implements AppAutoScalingClient {
+    private static Logger log = LoggerFactory.getLogger(AWSAppAutoScalingClient.class);
+    private static final String SERVICE_NAMESPACE = "custom-resource";
+    // AWS requires this field be set to this specific value for all application-autoscaling calls.
+    private static final String SCALABLE_DIMENSION = "custom-resource:ResourceType:Property";
+
+    private final AWSApplicationAutoScalingAsync awsAppAutoScalingClientAsync;
+    private final Counter createTargetCounter;
+    private final Counter createPolicyCounter;
+    private final Counter deleteTargetCounter;
+    private final Counter deletePolicyCounter;
+    private final Counter createTargetErrorCounter;
+    private final Counter createPolicyErrorCounter;
+    private final Counter deleteTargetErrorCounter;
+    private final Counter deletePolicyErrorCounter;
+    private final Counter getPolicyErrorCounter;
+    private AWSAppScalingConfig awsAppScalingConfig;
+
+
+    private static final String METRIC_APP_SCALE_GET_POLICY_ERROR = "titus.appscale.getPolicy.error";
+    private static final String METRIC_APP_SCALE_CREATE_TARGET = "titus.appscale.create.target";
+    private static final String METRIC_APP_SCALE_CREATE_POLICY = "titus.appscale.create.policy";
+    private static final String METRIC_APP_SCALE_DELETE_TARGET = "titus.appscale.delete.target";
+    private static final String METRIC_APP_SCALE_DELETE_POLICY = "titus.appscale.delete.policy";
+    private static final String METRIC_APP_SCALE_CREATE_TARGET_ERROR = "titus.appscale.create.target.error";
+    private static final String METRIC_APP_SCALE_CREATE_POLICY_ERROR = "titus.appscale.create.policy.error";
+    private static final String METRIC_APP_SCALE_DELETE_TARGET_ERROR = "titus.appscale.delete.target.error";
+    private static final String METRIC_APP_SCALE_DELETE_POLICY_ERROR = "titus.appscale.delete.policy.error";
+
+
+    @Inject
+    public AWSAppAutoScalingClient(AWSCredentialsProvider awsCredentialsProvider,
+                                   AWSAppScalingConfig awsAppScalingConfig,
+                                   Registry registry) {
+        this(AWSApplicationAutoScalingAsyncClientBuilder.standard()
+                        .withCredentials(awsCredentialsProvider)
+                        .withRegion(awsAppScalingConfig.getRegion()).build(),
+                awsAppScalingConfig, registry);
+    }
+
+    @VisibleForTesting
+    AWSAppAutoScalingClient(AWSApplicationAutoScalingAsync awsAppAutoScalingClientAsync, AWSAppScalingConfig awsAppScalingConfig, Registry registry) {
+        this.awsAppAutoScalingClientAsync = awsAppAutoScalingClientAsync;
+        this.awsAppScalingConfig = awsAppScalingConfig;
+
+        createTargetCounter = registry.counter(METRIC_APP_SCALE_CREATE_TARGET);
+        createPolicyCounter = registry.counter(METRIC_APP_SCALE_CREATE_POLICY);
+        deleteTargetCounter = registry.counter(METRIC_APP_SCALE_DELETE_TARGET);
+        deletePolicyCounter = registry.counter(METRIC_APP_SCALE_DELETE_POLICY);
+        createTargetErrorCounter = registry.counter(METRIC_APP_SCALE_CREATE_TARGET_ERROR);
+        createPolicyErrorCounter = registry.counter(METRIC_APP_SCALE_CREATE_POLICY_ERROR);
+        deleteTargetErrorCounter = registry.counter(METRIC_APP_SCALE_DELETE_TARGET_ERROR);
+        deletePolicyErrorCounter = registry.counter(METRIC_APP_SCALE_DELETE_POLICY_ERROR);
+        getPolicyErrorCounter = registry.counter(METRIC_APP_SCALE_GET_POLICY_ERROR);
+    }
+
+    @Override
+    public Completable createScalableTarget(String jobId, int minCapacity, int maxCapacity) {
+        RegisterScalableTargetRequest registerScalableTargetRequest = new RegisterScalableTargetRequest();
+        registerScalableTargetRequest.setMinCapacity(minCapacity);
+        registerScalableTargetRequest.setMaxCapacity(maxCapacity);
+        registerScalableTargetRequest.setResourceId(buildAPIGatewayResource(jobId));
+        registerScalableTargetRequest.setRoleARN(buildRoleARN());
+        registerScalableTargetRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        registerScalableTargetRequest.setScalableDimension(SCALABLE_DIMENSION);
+        log.info("RegisterScalableTargetRequest {}", registerScalableTargetRequest);
+
+        return RetryWrapper.wrapWithExponentialRetry(String.format("createScalableTarget for job %s", jobId),
+                Observable.create(emitter -> awsAppAutoScalingClientAsync.registerScalableTargetAsync(registerScalableTargetRequest, new AsyncHandler<RegisterScalableTargetRequest, RegisterScalableTargetResult>() {
+                    @Override
+                    public void onError(Exception exception) {
+                        log.info("RegisterScalableTarget exception {}", exception.getMessage());
+                        createTargetErrorCounter.increment();
+                        emitter.onError(exception);
+                    }
+
+                    @Override
+                    public void onSuccess(RegisterScalableTargetRequest request, RegisterScalableTargetResult registerScalableTargetResult) {
+                        int httpStatusCode = registerScalableTargetResult.getSdkHttpMetadata().getHttpStatusCode();
+                        log.info("Registered scalable target for {} - status {}", jobId, httpStatusCode);
+                        createTargetCounter.increment();
+                        emitter.onCompleted();
+                    }
+                }), Emitter.BackpressureMode.NONE)).toCompletable();
+    }
+
+    @Override
+    public Observable<AutoScalableTarget> getScalableTargetsForJob(String jobId) {
+        DescribeScalableTargetsRequest describeScalableTargetsRequest = new DescribeScalableTargetsRequest();
+        describeScalableTargetsRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        describeScalableTargetsRequest.setScalableDimension(SCALABLE_DIMENSION);
+        describeScalableTargetsRequest.setResourceIds(Arrays.asList(buildAPIGatewayResource(jobId)));
+
+        return RetryWrapper.wrapWithExponentialRetry(String.format("getScalableTargetsForJob for job %s", jobId),
+                Observable.create(emitter -> awsAppAutoScalingClientAsync.describeScalableTargetsAsync(describeScalableTargetsRequest,
+                        new AsyncHandler<DescribeScalableTargetsRequest, DescribeScalableTargetsResult>() {
+                            @Override
+                            public void onError(Exception exception) {
+                                getPolicyErrorCounter.increment();
+                                emitter.onError(exception);
+                            }
+
+                            @Override
+                            public void onSuccess(DescribeScalableTargetsRequest request, DescribeScalableTargetsResult describeScalableTargetsResult) {
+                                List<ScalableTarget> scalableTargets = describeScalableTargetsResult.getScalableTargets();
+                                scalableTargets.stream()
+                                        .map(scalableTarget -> toAutoScalableTarget(scalableTarget))
+                                        .forEach(autoScalableTarget -> emitter.onNext(autoScalableTarget));
+                                emitter.onCompleted();
+                            }
+                        }), Emitter.BackpressureMode.NONE));
+    }
+
+    @Override
+    public Observable<String> createOrUpdateScalingPolicy(String policyRefId, String jobId, PolicyConfiguration policyConfiguration) {
+        PutScalingPolicyRequest putScalingPolicyRequest = new PutScalingPolicyRequest();
+
+        putScalingPolicyRequest.setPolicyName(buildScalingPolicyName(policyRefId, jobId));
+
+        putScalingPolicyRequest.setPolicyType(policyConfiguration.getPolicyType().name());
+        putScalingPolicyRequest.setResourceId(buildAPIGatewayResource(jobId));
+        putScalingPolicyRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        putScalingPolicyRequest.setScalableDimension(SCALABLE_DIMENSION);
+
+        if (policyConfiguration.getPolicyType() == PolicyType.StepScaling) {
+            StepScalingPolicyConfiguration stepScalingPolicyConfiguration = new StepScalingPolicyConfiguration();
+            if (policyConfiguration.getStepScalingPolicyConfiguration().getMetricAggregationType().isPresent()) {
+                stepScalingPolicyConfiguration.setMetricAggregationType(policyConfiguration.getStepScalingPolicyConfiguration().getMetricAggregationType().get().name());
+            }
+
+            if (policyConfiguration.getStepScalingPolicyConfiguration().getCoolDownSec().isPresent()) {
+                stepScalingPolicyConfiguration.setCooldown(policyConfiguration.getStepScalingPolicyConfiguration().getCoolDownSec().get());
+            }
+
+            List<com.netflix.titus.api.appscale.model.StepAdjustment> steps = policyConfiguration.getStepScalingPolicyConfiguration().getSteps();
+            List<StepAdjustment> stepAdjustments = steps.stream()
+                    .map(step -> {
+                        StepAdjustment stepAdjustment = new StepAdjustment();
+                        if (step.getMetricIntervalUpperBound() != null && step.getMetricIntervalUpperBound().isPresent()) {
+                            stepAdjustment.setMetricIntervalUpperBound(step.getMetricIntervalUpperBound().get());
+                        }
+                        if (step.getMetricIntervalLowerBound() != null && step.getMetricIntervalLowerBound().isPresent()) {
+                            stepAdjustment.setMetricIntervalLowerBound(step.getMetricIntervalLowerBound().get());
+                        }
+                        stepAdjustment.setScalingAdjustment(step.getScalingAdjustment());
+                        return stepAdjustment;
+                    })
+                    .collect(Collectors.toList());
+
+            stepScalingPolicyConfiguration.setStepAdjustments(stepAdjustments);
+            if (policyConfiguration.getStepScalingPolicyConfiguration().getAdjustmentType().isPresent()) {
+                stepScalingPolicyConfiguration.setAdjustmentType(policyConfiguration.getStepScalingPolicyConfiguration().getAdjustmentType().get().name());
+            }
+
+            putScalingPolicyRequest.setStepScalingPolicyConfiguration(stepScalingPolicyConfiguration);
+        } else if (policyConfiguration.getPolicyType() == PolicyType.TargetTrackingScaling) {
+            TargetTrackingScalingPolicyConfiguration targetTrackingConfigAws = new TargetTrackingScalingPolicyConfiguration();
+            TargetTrackingPolicy targetTrackingPolicyInt = policyConfiguration.getTargetTrackingPolicy();
+
+            targetTrackingConfigAws.setTargetValue(targetTrackingPolicyInt.getTargetValue());
+            if (targetTrackingPolicyInt.getDisableScaleIn().isPresent()) {
+                targetTrackingConfigAws.setDisableScaleIn(targetTrackingPolicyInt.getDisableScaleIn().get());
+            }
+            if (targetTrackingPolicyInt.getScaleInCooldownSec().isPresent()) {
+                targetTrackingConfigAws.setScaleInCooldown(targetTrackingPolicyInt.getScaleInCooldownSec().get());
+            }
+            if (targetTrackingPolicyInt.getScaleOutCooldownSec().isPresent()) {
+                targetTrackingConfigAws.setScaleOutCooldown(targetTrackingPolicyInt.getScaleOutCooldownSec().get());
+            }
+            if (targetTrackingPolicyInt.getCustomizedMetricSpecification().isPresent()) {
+                com.netflix.titus.api.appscale.model.CustomizedMetricSpecification customizedMetricSpecInt =
+                        targetTrackingPolicyInt.getCustomizedMetricSpecification().get();
+                CustomizedMetricSpecification customizedMetricSpecAws = new CustomizedMetricSpecification();
+
+                customizedMetricSpecAws.setDimensions(customizedMetricSpecInt.getMetricDimensionList()
+                        .stream()
+                        .map(metricDimensionInt -> {
+                            MetricDimension metricDimensionAws = new MetricDimension()
+                                    .withName(metricDimensionInt.getName())
+                                    .withValue(metricDimensionInt.getValue());
+                            return metricDimensionAws;
+                        })
+                        .collect(Collectors.toList()));
+                customizedMetricSpecAws.setMetricName(customizedMetricSpecInt.getMetricName());
+                customizedMetricSpecAws.setNamespace(customizedMetricSpecInt.getNamespace());
+                customizedMetricSpecAws.setStatistic(customizedMetricSpecInt.getStatistic().name());
+                if (customizedMetricSpecInt.getUnit().isPresent()) {
+                    customizedMetricSpecAws.setUnit(customizedMetricSpecInt.getUnit().get());
+                }
+
+                targetTrackingConfigAws.setCustomizedMetricSpecification(customizedMetricSpecAws);
+            }
+
+            putScalingPolicyRequest.setTargetTrackingScalingPolicyConfiguration(targetTrackingConfigAws);
+        } else {
+            return Observable.error(new UnsupportedOperationException("Scaling policy type " + policyConfiguration.getPolicyType().name() + " is not supported."));
+        }
+
+        return RetryWrapper.wrapWithExponentialRetry(String.format("createOrUpdateScalingPolicy %s for job %s", policyRefId, jobId),
+                Observable.create(emitter -> awsAppAutoScalingClientAsync.putScalingPolicyAsync(putScalingPolicyRequest, new AsyncHandler<PutScalingPolicyRequest, PutScalingPolicyResult>() {
+                    @Override
+                    public void onError(Exception exception) {
+                        createPolicyErrorCounter.increment();
+                        log.error("Exception creating scaling policy ", exception);
+                        if (exception instanceof ValidationException) {
+                            emitter.onError(AutoScalePolicyException.invalidScalingPolicy(policyRefId, exception.getMessage()));
+                        } else {
+                            emitter.onError(AutoScalePolicyException.errorCreatingPolicy(policyRefId, exception.getMessage()));
+                        }
+                    }
+
+                    @Override
+                    public void onSuccess(PutScalingPolicyRequest request, PutScalingPolicyResult putScalingPolicyResult) {
+                        createPolicyCounter.increment();
+                        String policyARN = putScalingPolicyResult.getPolicyARN();
+                        log.info("New Scaling policy {} created {} for Job {}", request, policyARN, jobId);
+                        emitter.onNext(policyARN);
+                        emitter.onCompleted();
+                    }
+                }), Emitter.BackpressureMode.NONE));
+    }
+
+    @Override
+    public Completable deleteScalableTarget(String jobId) {
+        DeregisterScalableTargetRequest deRegisterRequest = new DeregisterScalableTargetRequest();
+        deRegisterRequest.setResourceId(buildAPIGatewayResource(jobId));
+        deRegisterRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        deRegisterRequest.setScalableDimension(SCALABLE_DIMENSION);
+
+        return RetryWrapper.wrapWithExponentialRetry(String.format("deleteScalableTarget for job %s", jobId),
+                Observable.create(emitter -> awsAppAutoScalingClientAsync.deregisterScalableTargetAsync(deRegisterRequest, new AsyncHandler<DeregisterScalableTargetRequest, DeregisterScalableTargetResult>() {
+                    @Override
+                    public void onError(Exception exception) {
+                        if (exception instanceof ObjectNotFoundException) {
+                            log.info("Scalable target does not exist anymore for job {}", jobId);
+                            emitter.onCompleted();
+                        } else {
+                            deleteTargetErrorCounter.increment();
+                            emitter.onError(exception);
+                        }
+                    }
+
+                    @Override
+                    public void onSuccess(DeregisterScalableTargetRequest request, DeregisterScalableTargetResult deregisterScalableTargetResult) {
+                        deleteTargetCounter.increment();
+                        int httpStatusCode = deregisterScalableTargetResult.getSdkHttpMetadata().getHttpStatusCode();
+                        log.info("De-registered scalable target for {}, status {}", jobId, httpStatusCode);
+                        emitter.onCompleted();
+                    }
+                }), Emitter.BackpressureMode.NONE)).toCompletable();
+    }
+
+    @Override
+    public Completable deleteScalingPolicy(String policyRefId, String jobId) {
+        DeleteScalingPolicyRequest deleteScalingPolicyRequest = new DeleteScalingPolicyRequest();
+        deleteScalingPolicyRequest.setResourceId(buildAPIGatewayResource(jobId));
+        deleteScalingPolicyRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        deleteScalingPolicyRequest.setScalableDimension(SCALABLE_DIMENSION);
+        deleteScalingPolicyRequest.setPolicyName(buildScalingPolicyName(policyRefId, jobId));
+
+        return RetryWrapper.wrapWithExponentialRetry(String.format("deleteScalingPolicy %s for job %s", policyRefId, jobId),
+                Observable.create(emitter -> awsAppAutoScalingClientAsync.deleteScalingPolicyAsync(deleteScalingPolicyRequest, new AsyncHandler<DeleteScalingPolicyRequest, DeleteScalingPolicyResult>() {
+                    @Override
+                    public void onError(Exception exception) {
+                        if (exception instanceof ObjectNotFoundException) {
+                            log.info("Scaling policy does not exist anymore for job/policyRefId {}/{}", jobId, policyRefId);
+                            emitter.onCompleted();
+                        } else {
+                            deletePolicyErrorCounter.increment();
+                            emitter.onError(AutoScalePolicyException.errorDeletingPolicy(policyRefId, exception.getMessage()));
+                        }
+                    }
+
+                    @Override
+                    public void onSuccess(DeleteScalingPolicyRequest request, DeleteScalingPolicyResult deleteScalingPolicyResult) {
+                        deletePolicyCounter.increment();
+                        int httpStatusCode = deleteScalingPolicyResult.getSdkHttpMetadata().getHttpStatusCode();
+                        log.info("Deleted scaling policy for job/policyRefId {}/{}, status - {}", jobId, policyRefId, httpStatusCode);
+                        emitter.onCompleted();
+
+                    }
+                }), Emitter.BackpressureMode.NONE)).toCompletable();
+    }
+
+    private String buildRoleARN() {
+        return String.format("arn:aws:iam::%s:role/%s", awsAppScalingConfig.getAccountId(), awsAppScalingConfig.getAWSAPIGatewayRole());
+    }
+
+    private String buildAPIGatewayResource(String jobId) {
+        return String.format("https://%s.execute-api.%s.amazonaws.com/%s/scalableTargetDimensions/%s",
+                awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
+                awsAppScalingConfig.getRegion(),
+                awsAppScalingConfig.getStack(),
+                jobId);
+    }
+
+    private String buildScalingPolicyName(String policyRefId, String jobId) {
+        return String.format("%s/%s", jobId, policyRefId);
+    }
+
+    private AutoScalableTarget toAutoScalableTarget(ScalableTarget scalableTarget) {
+        return AutoScalableTarget.newBuilder()
+                .withResourceId(scalableTarget.getResourceId())
+                .withMinCapacity(scalableTarget.getMinCapacity())
+                .withMaxCapacity(scalableTarget.getMaxCapacity())
+                .build();
+    }
+}

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.aws.appscale;
+
+import com.netflix.archaius.api.annotations.PropertyName;
+
+public interface AWSAppScalingConfig {
+
+    @PropertyName(name = "region")
+    String getRegion();
+
+    @PropertyName(name = "netflix.stack")
+    String getStack();
+
+    @PropertyName(name = "netflix.accountId")
+    String getAccountId();
+
+    @PropertyName(name = "aws.gateway.api.prefix")
+    String getAWSGatewayEndpointPrefix();
+
+    // TODO(Andrew L): Remove this or change the value
+    @PropertyName(name = "aws.gateway.api.role")
+    String getAWSAPIGatewayRole();
+}
+

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/cloudwatch/CloudWatchClient.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/cloudwatch/CloudWatchClient.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.aws.cloudwatch;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClientBuilder;
+import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest;
+import com.amazonaws.services.cloudwatch.model.DeleteAlarmsResult;
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest;
+import com.amazonaws.services.cloudwatch.model.PutMetricAlarmResult;
+import com.amazonaws.services.cloudwatch.model.ResourceNotFoundException;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.titus.api.appscale.model.AlarmConfiguration;
+import com.netflix.titus.api.appscale.service.AutoScalePolicyException;
+import com.netflix.titus.api.connector.cloud.CloudAlarmClient;
+import com.netflix.titus.ext.aws.AwsConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Completable;
+import rx.Emitter;
+import rx.Observable;
+
+import static com.netflix.titus.ext.aws.RetryWrapper.wrapWithExponentialRetry;
+
+
+@Singleton
+public class CloudWatchClient implements CloudAlarmClient {
+    public static final String AUTO_SCALING_GROUP_NAME = "AutoScalingGroupName";
+    private static Logger log = LoggerFactory.getLogger(CloudWatchClient.class);
+    private final AmazonCloudWatchAsync awsCloudWatch;
+
+    public static final String METRIC_CLOUD_WATCH_CREATE_ERROR = "titus.cloudwatch.create.error";
+    public static final String METRIC_CLOUD_WATCH_CREATE_ALARM = "titus.cloudwatch.create.alarm";
+    public static final String METRIC_CLOUD_WATCH_DELETE_ALARM = "titus.cloudwatch.delete.alarm";
+    public static final String METRIC_CLOUD_WATCH_DELETE_ERROR = "titus.cloudwatch.delete.error";
+
+    private final Counter createAlarmCounter;
+    private final Counter deleteAlarmCounter;
+    private final Counter deleteErrorCounter;
+    private final Counter createErrorCounter;
+
+
+    @Inject
+    public CloudWatchClient(AWSCredentialsProvider awsCredentialsProvider,
+                            AwsConfiguration awsConfiguration,
+                            Registry registry) {
+
+        awsCloudWatch = AmazonCloudWatchAsyncClientBuilder.standard().withCredentials(awsCredentialsProvider)
+                .withRegion(awsConfiguration.getRegion()).build();
+
+        createAlarmCounter = registry.counter(METRIC_CLOUD_WATCH_CREATE_ALARM);
+        deleteAlarmCounter = registry.counter(METRIC_CLOUD_WATCH_DELETE_ALARM);
+        deleteErrorCounter = registry.counter(METRIC_CLOUD_WATCH_DELETE_ERROR);
+        createErrorCounter = registry.counter(METRIC_CLOUD_WATCH_CREATE_ERROR);
+    }
+
+
+    @Override
+    public Observable<String> createOrUpdateAlarm(String policyRefId,
+                                                  String jobId,
+                                                  AlarmConfiguration alarmConfiguration,
+                                                  String autoScalingGroup,
+                                                  List<String> actions) {
+        Dimension dimension = new Dimension();
+        dimension.setName(AUTO_SCALING_GROUP_NAME);
+        dimension.setValue(autoScalingGroup);
+
+        String cloudWatchName = buildCloudWatchName(policyRefId, jobId);
+
+        PutMetricAlarmRequest putMetricAlarmRequest = new PutMetricAlarmRequest();
+        if (alarmConfiguration.getActionsEnabled().isPresent()) {
+            putMetricAlarmRequest.setActionsEnabled(alarmConfiguration.getActionsEnabled().get());
+        }
+        putMetricAlarmRequest.setAlarmActions(actions);
+        putMetricAlarmRequest.setAlarmName(cloudWatchName);
+        putMetricAlarmRequest.setDimensions(Arrays.asList(dimension));
+        putMetricAlarmRequest.setNamespace(alarmConfiguration.getMetricNamespace());
+        putMetricAlarmRequest.setComparisonOperator(alarmConfiguration.getComparisonOperator().name());
+        putMetricAlarmRequest.setStatistic(alarmConfiguration.getStatistic().name());
+        putMetricAlarmRequest.setEvaluationPeriods(alarmConfiguration.getEvaluationPeriods());
+        putMetricAlarmRequest.setPeriod(alarmConfiguration.getPeriodSec());
+        putMetricAlarmRequest.setThreshold(alarmConfiguration.getThreshold());
+        putMetricAlarmRequest.setMetricName(alarmConfiguration.getMetricName());
+
+        return wrapWithExponentialRetry(String.format("createOrUpdateAlarm in policy %s for job %s", policyRefId, jobId),
+                Observable.create(emitter ->
+                        awsCloudWatch.putMetricAlarmAsync(putMetricAlarmRequest, new AsyncHandler<PutMetricAlarmRequest, PutMetricAlarmResult>() {
+                            @Override
+                            public void onError(Exception exception) {
+                                createErrorCounter.increment();
+                                emitter.onError(AutoScalePolicyException.errorCreatingAlarm(policyRefId, exception.getMessage()));
+                            }
+
+                            @Override
+                            public void onSuccess(PutMetricAlarmRequest request, PutMetricAlarmResult putMetricAlarmResult) {
+                                int httpStatusCode = putMetricAlarmResult.getSdkHttpMetadata().getHttpStatusCode();
+                                log.info("Created Cloud Watch Alarm {} for {} - status {}", request, jobId, httpStatusCode);
+                                // TODO : how to get ARN created by AWS for this resource ? returning cloudWatchName for now
+                                createAlarmCounter.increment();
+                                emitter.onNext(cloudWatchName);
+                                emitter.onCompleted();
+                            }
+                        }), Emitter.BackpressureMode.NONE));
+    }
+
+    @Override
+    public Completable deleteAlarm(String policyRefId, String jobId) {
+        DeleteAlarmsRequest deleteAlarmsRequest = new DeleteAlarmsRequest();
+        deleteAlarmsRequest.setAlarmNames(Arrays.asList(buildCloudWatchName(policyRefId, jobId)));
+
+
+        return wrapWithExponentialRetry(String.format("deleteAlarm in policy %s for job %s", policyRefId, jobId),
+                Observable.create(emitter ->
+                        awsCloudWatch.deleteAlarmsAsync(deleteAlarmsRequest, new AsyncHandler<DeleteAlarmsRequest, DeleteAlarmsResult>() {
+                            @Override
+                            public void onError(Exception exception) {
+                                deleteErrorCounter.increment();
+                                if (exception instanceof ResourceNotFoundException) {
+                                    emitter.onError(AutoScalePolicyException.unknownScalingPolicy(policyRefId, exception.getMessage()));
+                                } else {
+                                    emitter.onError(AutoScalePolicyException.errorDeletingAlarm(policyRefId, exception.getMessage()));
+                                }
+                            }
+
+                            @Override
+                            public void onSuccess(DeleteAlarmsRequest request, DeleteAlarmsResult deleteAlarmsResult) {
+                                int httpStatusCode = deleteAlarmsResult.getSdkHttpMetadata().getHttpStatusCode();
+                                log.info("Deleted cloud watch alarm for job-id {}, status {}", jobId, httpStatusCode);
+                                deleteAlarmCounter.increment();
+                                emitter.onCompleted();
+                            }
+                        }), Emitter.BackpressureMode.NONE)).toCompletable();
+    }
+
+    private String buildCloudWatchName(String policyRefId, String jobId) {
+        return String.format("%s/%s", jobId, policyRefId);
+    }
+
+
+}

--- a/titus-ext/aws/src/test/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClientTest.java
+++ b/titus-ext/aws/src/test/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClientTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.aws.appscale;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.http.HttpResponse;
+import com.amazonaws.http.SdkHttpMetadata;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScalingAsync;
+import com.amazonaws.services.applicationautoscaling.model.DeleteScalingPolicyRequest;
+import com.amazonaws.services.applicationautoscaling.model.DeleteScalingPolicyResult;
+import com.amazonaws.services.applicationautoscaling.model.DeregisterScalableTargetRequest;
+import com.amazonaws.services.applicationautoscaling.model.DeregisterScalableTargetResult;
+import com.amazonaws.services.applicationautoscaling.model.ObjectNotFoundException;
+import com.netflix.spectator.api.NoopRegistry;
+import javaslang.concurrent.Future;
+import org.junit.Test;
+import rx.observers.AssertableSubscriber;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AWSAppAutoScalingClientTest {
+
+    @Test
+    public void deleteScalingPolicyIsIdempotent() {
+        String jobId = UUID.randomUUID().toString();
+        String policyId = UUID.randomUUID().toString();
+
+        AWSApplicationAutoScalingAsync clientAsync = mock(AWSApplicationAutoScalingAsync.class);
+        AWSAppScalingConfig config = mock(AWSAppScalingConfig.class);
+        AWSAppAutoScalingClient autoScalingClient = new AWSAppAutoScalingClient(clientAsync, config, new NoopRegistry());
+
+        // delete happens successfully on the first attempt
+        AtomicBoolean isDeleted = new AtomicBoolean(false);
+        when(clientAsync.deleteScalingPolicyAsync(any(), any())).thenAnswer(invocation -> {
+            DeleteScalingPolicyRequest request = invocation.getArgument(0);
+            AsyncHandler<DeleteScalingPolicyRequest, DeleteScalingPolicyResult> handler = invocation.getArgument(1);
+
+            if (isDeleted.get()) {
+                ObjectNotFoundException notFoundException = new ObjectNotFoundException(policyId + " does not exist");
+                handler.onError(notFoundException);
+                return Future.failed(notFoundException);
+            }
+
+            DeleteScalingPolicyResult resultSuccess = new DeleteScalingPolicyResult();
+            HttpResponse successResponse = new HttpResponse(null, null);
+            successResponse.setStatusCode(200);
+            resultSuccess.setSdkHttpMetadata(SdkHttpMetadata.from(successResponse));
+
+            isDeleted.set(true);
+            handler.onSuccess(request, resultSuccess);
+            return Future.successful(resultSuccess);
+        });
+
+        AssertableSubscriber<Void> firstCall = autoScalingClient.deleteScalingPolicy(policyId, jobId).test();
+        firstCall.awaitTerminalEvent(2, TimeUnit.SECONDS);
+        firstCall.assertNoErrors();
+        firstCall.assertCompleted();
+        verify(clientAsync, times(1)).deleteScalingPolicyAsync(any(), any());
+
+        // second should complete fast when NotFound and not retry with exponential backoff
+        AssertableSubscriber<Void> secondCall = autoScalingClient.deleteScalingPolicy(policyId, jobId).test();
+        secondCall.awaitTerminalEvent(2, TimeUnit.SECONDS);
+        secondCall.assertNoErrors();
+        secondCall.assertCompleted();
+        verify(clientAsync, times(2)).deleteScalingPolicyAsync(any(), any());
+    }
+
+    @Test
+    public void deleteScalableTargetIsIdempotent() {
+        String jobId = UUID.randomUUID().toString();
+        String policyId = UUID.randomUUID().toString();
+
+        AWSApplicationAutoScalingAsync clientAsync = mock(AWSApplicationAutoScalingAsync.class);
+        AWSAppScalingConfig config = mock(AWSAppScalingConfig.class);
+        AWSAppAutoScalingClient autoScalingClient = new AWSAppAutoScalingClient(clientAsync, config, new NoopRegistry());
+
+        AtomicBoolean isDeleted = new AtomicBoolean(false);
+        when(clientAsync.deregisterScalableTargetAsync(any(), any())).thenAnswer(invocation -> {
+            DeregisterScalableTargetRequest request = invocation.getArgument(0);
+            AsyncHandler<DeregisterScalableTargetRequest, DeregisterScalableTargetResult> handler = invocation.getArgument(1);
+            if (isDeleted.get()) {
+                ObjectNotFoundException notFoundException = new ObjectNotFoundException(policyId + " does not exist");
+                handler.onError(notFoundException);
+                return Future.failed(notFoundException);
+            }
+
+            DeregisterScalableTargetResult resultSuccess = new DeregisterScalableTargetResult();
+            HttpResponse successResponse = new HttpResponse(null, null);
+            successResponse.setStatusCode(200);
+            resultSuccess.setSdkHttpMetadata(SdkHttpMetadata.from(successResponse));
+
+            isDeleted.set(true);
+            handler.onSuccess(request, resultSuccess);
+            return Future.successful(resultSuccess);
+        });
+
+        AssertableSubscriber<Void> firstCall = autoScalingClient.deleteScalableTarget(jobId).test();
+        firstCall.awaitTerminalEvent(2, TimeUnit.SECONDS);
+        firstCall.assertNoErrors();
+        firstCall.assertCompleted();
+        verify(clientAsync, times(1)).deregisterScalableTargetAsync(any(), any());
+
+        // second should complete fast when NotFound and not retry with exponential backoff
+        AssertableSubscriber<Void> secondCall = autoScalingClient.deleteScalableTarget(jobId).test();
+        secondCall.awaitTerminalEvent(2, TimeUnit.SECONDS);
+        secondCall.assertNoErrors();
+        secondCall.assertCompleted();
+        verify(clientAsync, times(2)).deregisterScalableTargetAsync(any(), any());
+    }
+
+}


### PR DESCRIPTION
### Description of the Change

This PR moves the Job Autoscaling AWS clients to control-plane. Any new files in the PR were simply moved with only modifications to cleanup imports and add headers.

Additionally, we are now relying on the normal AWS Java SDK for application autoscaling.