### PR TITLE
Read the GRPC port from configuration

### DIFF
--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/TitusFederationGrpcServer.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/TitusFederationGrpcServer.java
@@ -81,6 +81,7 @@ public class TitusFederationGrpcServer {
     @PostConstruct
     public void start() {
         if (!started.getAndSet(true)) {
+            this.port = config.getGrpcPort();
             ServerBuilder serverBuilder = configure(ServerBuilder.forPort(port));
             serverBuilder.addService(ServerInterceptors.intercept(
                     healthService,

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/grpc/TitusGatewayGrpcServer.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/grpc/TitusGatewayGrpcServer.java
@@ -91,6 +91,7 @@ public class TitusGatewayGrpcServer {
     @PostConstruct
     public void start() {
         if (!started.getAndSet(true)) {
+            this.port = config.getPort();
             ServerBuilder serverBuilder = configure(ServerBuilder.forPort(port));
             serverBuilder.addService(ServerInterceptors.intercept(
                     healthService,

--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/grpc/TitusMasterGrpcServer.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/grpc/TitusMasterGrpcServer.java
@@ -105,7 +105,8 @@ public class TitusMasterGrpcServer {
     @PostConstruct
     public void start() {
         if (!started.getAndSet(true)) {
-            ServerBuilder serverBuilder = configure(ServerBuilder.forPort(config.getPort()));
+            this.port = config.getPort();
+            ServerBuilder serverBuilder = configure(ServerBuilder.forPort(port));
             serverBuilder.addService(ServerInterceptors.intercept(
                     healthService,
                     createInterceptors(HealthGrpc.getServiceDescriptor())


### PR DESCRIPTION
### Description of the Change

In the recent change that improves the ephemeral port allocation for the embedded GRPC servers
accidentally there was removed code reading the GRPC port from configuration. As a result, the
GRPC servers were always run on a random ephemeral ports.