### PR TITLE
Do not pass unused IAM role to AWS App Autoscaling

### DIFF
--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
@@ -94,7 +94,6 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
         registerScalableTargetRequest.setMinCapacity(minCapacity);
         registerScalableTargetRequest.setMaxCapacity(maxCapacity);
         registerScalableTargetRequest.setResourceId(buildAPIGatewayResource(jobId));
-        registerScalableTargetRequest.setRoleARN(buildRoleARN());
         registerScalableTargetRequest.setServiceNamespace(SERVICE_NAMESPACE);
         registerScalableTargetRequest.setScalableDimension(SCALABLE_DIMENSION);
         logger.info("RegisterScalableTargetRequest {}", registerScalableTargetRequest);
@@ -318,10 +317,6 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
 
                     }
                 }), Emitter.BackpressureMode.NONE)).toCompletable();
-    }
-
-    private String buildRoleARN() {
-        return String.format("arn:aws:iam::%s:role/%s", awsAppScalingConfig.getAccountId(), awsAppScalingConfig.getAWSAPIGatewayRole());
     }
 
     private String buildAPIGatewayResource(String jobId) {

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
@@ -26,14 +26,7 @@ public interface AWSAppScalingConfig {
     @PropertyName(name = "netflix.stack")
     String getStack();
 
-    @PropertyName(name = "netflix.accountId")
-    String getAccountId();
-
     @PropertyName(name = "aws.gateway.api.prefix")
     String getAWSGatewayEndpointPrefix();
-
-    // TODO(Andrew L): Remove this or change the value
-    @PropertyName(name = "aws.gateway.api.role")
-    String getAWSAPIGatewayRole();
 }
 


### PR DESCRIPTION
### Description of the Change

This PR removes passing of legacy IAM roles to AWS Application Autoscaling. These IAM roles were replaced by Service Linked Roles back in June and have been extraneous since then.