### PR TITLE
moving policyName, resourceId in a util class

### DIFF
--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
@@ -65,6 +65,10 @@ import static com.netflix.titus.ext.aws.appscale.AWSAppAutoScalingUtil.buildScal
 @Singleton
 public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     private static Logger logger = LoggerFactory.getLogger(AWSAppAutoScalingClient.class);
+    public static String SERVICE_NAMESPACE = "custom-resource";
+    // AWS requires this field be set to this specific value for all application-autoscaling calls.
+    public static String SCALABLE_DIMENSION = "custom-resource:ResourceType:Property";
+
     private final AWSApplicationAutoScalingAsync awsAppAutoScalingClientAsync;
     private final AWSAppScalingConfig awsAppScalingConfig;
     private final AWSAppAutoScalingMetrics awsAppAutoScalingMetrics;
@@ -95,8 +99,8 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
                 awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
                 awsAppScalingConfig.getRegion(),
                 awsAppScalingConfig.getStack()));
-        registerScalableTargetRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
-        registerScalableTargetRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
+        registerScalableTargetRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        registerScalableTargetRequest.setScalableDimension(SCALABLE_DIMENSION);
         logger.info("RegisterScalableTargetRequest {}", registerScalableTargetRequest);
 
         return RetryWrapper.wrapWithExponentialRetry(String.format("createScalableTarget for job %s", jobId),
@@ -121,8 +125,8 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     @Override
     public Observable<AutoScalableTarget> getScalableTargetsForJob(String jobId) {
         DescribeScalableTargetsRequest describeScalableTargetsRequest = new DescribeScalableTargetsRequest();
-        describeScalableTargetsRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
-        describeScalableTargetsRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
+        describeScalableTargetsRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        describeScalableTargetsRequest.setScalableDimension(SCALABLE_DIMENSION);
         describeScalableTargetsRequest.setResourceIds(Collections.singletonList(
                 AWSAppAutoScalingUtil.buildGatewayResourceId(jobId,
                         awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
@@ -163,8 +167,8 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
                         awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
                         awsAppScalingConfig.getRegion(),
                         awsAppScalingConfig.getStack()));
-        putScalingPolicyRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
-        putScalingPolicyRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
+        putScalingPolicyRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        putScalingPolicyRequest.setScalableDimension(SCALABLE_DIMENSION);
 
         if (policyConfiguration.getPolicyType() == PolicyType.StepScaling) {
             StepScalingPolicyConfiguration stepScalingPolicyConfiguration = new StepScalingPolicyConfiguration();
@@ -272,8 +276,8 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
                         awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
                         awsAppScalingConfig.getRegion(),
                         awsAppScalingConfig.getStack()));
-        deRegisterRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
-        deRegisterRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
+        deRegisterRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        deRegisterRequest.setScalableDimension(SCALABLE_DIMENSION);
 
         return RetryWrapper.wrapWithExponentialRetry(String.format("deleteScalableTarget for job %s", jobId),
                 Observable.create(emitter -> awsAppAutoScalingClientAsync.deregisterScalableTargetAsync(deRegisterRequest, new AsyncHandler<DeregisterScalableTargetRequest, DeregisterScalableTargetResult>() {
@@ -307,8 +311,8 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
                         awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
                         awsAppScalingConfig.getRegion(),
                         awsAppScalingConfig.getStack()));
-        deleteScalingPolicyRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
-        deleteScalingPolicyRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
+        deleteScalingPolicyRequest.setServiceNamespace(SERVICE_NAMESPACE);
+        deleteScalingPolicyRequest.setScalableDimension(SCALABLE_DIMENSION);
         deleteScalingPolicyRequest.setPolicyName(buildScalingPolicyName(policyRefId, jobId));
 
         return RetryWrapper.wrapWithExponentialRetry(String.format("deleteScalingPolicy %s for job %s", policyRefId, jobId),

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
@@ -16,7 +16,7 @@
 
 package com.netflix.titus.ext.aws.appscale;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -59,14 +59,12 @@ import rx.Completable;
 import rx.Emitter;
 import rx.Observable;
 
+import static com.netflix.titus.ext.aws.appscale.AWSAppAutoScalingUtil.buildScalingPolicyName;
+
 
 @Singleton
 public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     private static Logger logger = LoggerFactory.getLogger(AWSAppAutoScalingClient.class);
-    private static final String SERVICE_NAMESPACE = "custom-resource";
-    // AWS requires this field be set to this specific value for all application-autoscaling calls.
-    private static final String SCALABLE_DIMENSION = "custom-resource:ResourceType:Property";
-
     private final AWSApplicationAutoScalingAsync awsAppAutoScalingClientAsync;
     private final AWSAppScalingConfig awsAppScalingConfig;
     private final AWSAppAutoScalingMetrics awsAppAutoScalingMetrics;
@@ -93,9 +91,12 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
         RegisterScalableTargetRequest registerScalableTargetRequest = new RegisterScalableTargetRequest();
         registerScalableTargetRequest.setMinCapacity(minCapacity);
         registerScalableTargetRequest.setMaxCapacity(maxCapacity);
-        registerScalableTargetRequest.setResourceId(buildAPIGatewayResource(jobId));
-        registerScalableTargetRequest.setServiceNamespace(SERVICE_NAMESPACE);
-        registerScalableTargetRequest.setScalableDimension(SCALABLE_DIMENSION);
+        registerScalableTargetRequest.setResourceId(AWSAppAutoScalingUtil.buildGatewayResourceId(jobId,
+                awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
+                awsAppScalingConfig.getRegion(),
+                awsAppScalingConfig.getStack()));
+        registerScalableTargetRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
+        registerScalableTargetRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
         logger.info("RegisterScalableTargetRequest {}", registerScalableTargetRequest);
 
         return RetryWrapper.wrapWithExponentialRetry(String.format("createScalableTarget for job %s", jobId),
@@ -120,9 +121,13 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     @Override
     public Observable<AutoScalableTarget> getScalableTargetsForJob(String jobId) {
         DescribeScalableTargetsRequest describeScalableTargetsRequest = new DescribeScalableTargetsRequest();
-        describeScalableTargetsRequest.setServiceNamespace(SERVICE_NAMESPACE);
-        describeScalableTargetsRequest.setScalableDimension(SCALABLE_DIMENSION);
-        describeScalableTargetsRequest.setResourceIds(Arrays.asList(buildAPIGatewayResource(jobId)));
+        describeScalableTargetsRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
+        describeScalableTargetsRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
+        describeScalableTargetsRequest.setResourceIds(Collections.singletonList(
+                AWSAppAutoScalingUtil.buildGatewayResourceId(jobId,
+                        awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
+                        awsAppScalingConfig.getRegion(),
+                        awsAppScalingConfig.getStack())));
 
         return RetryWrapper.wrapWithExponentialRetry(String.format("getScalableTargetsForJob for job %s", jobId),
                 Observable.create(emitter -> awsAppAutoScalingClientAsync.describeScalableTargetsAsync(describeScalableTargetsRequest,
@@ -139,8 +144,8 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
                                 awsAppAutoScalingMetrics.registerAwsGetTargetSuccess();
                                 List<ScalableTarget> scalableTargets = describeScalableTargetsResult.getScalableTargets();
                                 scalableTargets.stream()
-                                        .map(scalableTarget -> toAutoScalableTarget(scalableTarget))
-                                        .forEach(autoScalableTarget -> emitter.onNext(autoScalableTarget));
+                                        .map(AWSAppAutoScalingUtil::toAutoScalableTarget)
+                                        .forEach(emitter::onNext);
                                 emitter.onCompleted();
                             }
                         }), Emitter.BackpressureMode.NONE));
@@ -153,9 +158,13 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
         putScalingPolicyRequest.setPolicyName(buildScalingPolicyName(policyRefId, jobId));
 
         putScalingPolicyRequest.setPolicyType(policyConfiguration.getPolicyType().name());
-        putScalingPolicyRequest.setResourceId(buildAPIGatewayResource(jobId));
-        putScalingPolicyRequest.setServiceNamespace(SERVICE_NAMESPACE);
-        putScalingPolicyRequest.setScalableDimension(SCALABLE_DIMENSION);
+        putScalingPolicyRequest.setResourceId(
+                AWSAppAutoScalingUtil.buildGatewayResourceId(jobId,
+                        awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
+                        awsAppScalingConfig.getRegion(),
+                        awsAppScalingConfig.getStack()));
+        putScalingPolicyRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
+        putScalingPolicyRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
 
         if (policyConfiguration.getPolicyType() == PolicyType.StepScaling) {
             StepScalingPolicyConfiguration stepScalingPolicyConfiguration = new StepScalingPolicyConfiguration();
@@ -258,9 +267,13 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     @Override
     public Completable deleteScalableTarget(String jobId) {
         DeregisterScalableTargetRequest deRegisterRequest = new DeregisterScalableTargetRequest();
-        deRegisterRequest.setResourceId(buildAPIGatewayResource(jobId));
-        deRegisterRequest.setServiceNamespace(SERVICE_NAMESPACE);
-        deRegisterRequest.setScalableDimension(SCALABLE_DIMENSION);
+        deRegisterRequest.setResourceId(
+                AWSAppAutoScalingUtil.buildGatewayResourceId(jobId,
+                        awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
+                        awsAppScalingConfig.getRegion(),
+                        awsAppScalingConfig.getStack()));
+        deRegisterRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
+        deRegisterRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
 
         return RetryWrapper.wrapWithExponentialRetry(String.format("deleteScalableTarget for job %s", jobId),
                 Observable.create(emitter -> awsAppAutoScalingClientAsync.deregisterScalableTargetAsync(deRegisterRequest, new AsyncHandler<DeregisterScalableTargetRequest, DeregisterScalableTargetResult>() {
@@ -289,9 +302,13 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     @Override
     public Completable deleteScalingPolicy(String policyRefId, String jobId) {
         DeleteScalingPolicyRequest deleteScalingPolicyRequest = new DeleteScalingPolicyRequest();
-        deleteScalingPolicyRequest.setResourceId(buildAPIGatewayResource(jobId));
-        deleteScalingPolicyRequest.setServiceNamespace(SERVICE_NAMESPACE);
-        deleteScalingPolicyRequest.setScalableDimension(SCALABLE_DIMENSION);
+        deleteScalingPolicyRequest.setResourceId(
+                AWSAppAutoScalingUtil.buildGatewayResourceId(jobId,
+                        awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
+                        awsAppScalingConfig.getRegion(),
+                        awsAppScalingConfig.getStack()));
+        deleteScalingPolicyRequest.setServiceNamespace(AWSAppScalingConfig.SERVICE_NAMESPACE);
+        deleteScalingPolicyRequest.setScalableDimension(AWSAppScalingConfig.SCALABLE_DIMENSION);
         deleteScalingPolicyRequest.setPolicyName(buildScalingPolicyName(policyRefId, jobId));
 
         return RetryWrapper.wrapWithExponentialRetry(String.format("deleteScalingPolicy %s for job %s", policyRefId, jobId),
@@ -317,25 +334,5 @@ public class AWSAppAutoScalingClient implements AppAutoScalingClient {
 
                     }
                 }), Emitter.BackpressureMode.NONE)).toCompletable();
-    }
-
-    private String buildAPIGatewayResource(String jobId) {
-        return String.format("https://%s.execute-api.%s.amazonaws.com/%s/scalableTargetDimensions/%s",
-                awsAppScalingConfig.getAWSGatewayEndpointPrefix(),
-                awsAppScalingConfig.getRegion(),
-                awsAppScalingConfig.getStack(),
-                jobId);
-    }
-
-    private String buildScalingPolicyName(String policyRefId, String jobId) {
-        return String.format("%s/%s", jobId, policyRefId);
-    }
-
-    private AutoScalableTarget toAutoScalableTarget(ScalableTarget scalableTarget) {
-        return AutoScalableTarget.newBuilder()
-                .withResourceId(scalableTarget.getResourceId())
-                .withMinCapacity(scalableTarget.getMinCapacity())
-                .withMaxCapacity(scalableTarget.getMaxCapacity())
-                .build();
     }
 }

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingClient.java
@@ -65,9 +65,9 @@ import static com.netflix.titus.ext.aws.appscale.AWSAppAutoScalingUtil.buildScal
 @Singleton
 public class AWSAppAutoScalingClient implements AppAutoScalingClient {
     private static Logger logger = LoggerFactory.getLogger(AWSAppAutoScalingClient.class);
-    public static String SERVICE_NAMESPACE = "custom-resource";
+    public final static String SERVICE_NAMESPACE = "custom-resource";
     // AWS requires this field be set to this specific value for all application-autoscaling calls.
-    public static String SCALABLE_DIMENSION = "custom-resource:ResourceType:Property";
+    public final static String SCALABLE_DIMENSION = "custom-resource:ResourceType:Property";
 
     private final AWSApplicationAutoScalingAsync awsAppAutoScalingClientAsync;
     private final AWSAppScalingConfig awsAppScalingConfig;

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingUtil.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.titus.ext.aws.appscale;
+
+import com.amazonaws.services.applicationautoscaling.model.ScalableTarget;
+import com.netflix.titus.api.appscale.model.AutoScalableTarget;
+
+public class AWSAppAutoScalingUtil {
+    public static String buildGatewayResourceId(String jobId, String awsGatewayEndpointPrefix, String region, String stack) {
+        return String.format("https://%s.execute-api.%s.amazonaws.com/%s/scalableTargetDimensions/%s",
+                awsGatewayEndpointPrefix, region, stack, jobId);
+    }
+
+    public static String buildScalingPolicyName(String policyRefId, String jobId) {
+        return String.format("%s/%s", jobId, policyRefId);
+    }
+
+    public static AutoScalableTarget toAutoScalableTarget(ScalableTarget scalableTarget) {
+        return AutoScalableTarget.newBuilder()
+                .withResourceId(scalableTarget.getResourceId())
+                .withMinCapacity(scalableTarget.getMinCapacity())
+                .withMaxCapacity(scalableTarget.getMaxCapacity())
+                .build();
+    }
+}

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
@@ -19,10 +19,6 @@ package com.netflix.titus.ext.aws.appscale;
 import com.netflix.archaius.api.annotations.PropertyName;
 
 public interface AWSAppScalingConfig {
-    String SERVICE_NAMESPACE = "custom-resource";
-    // AWS requires this field be set to this specific value for all application-autoscaling calls.
-    String SCALABLE_DIMENSION = "custom-resource:ResourceType:Property";
-
     @PropertyName(name = "region")
     String getRegion();
 

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AWSAppScalingConfig.java
@@ -19,6 +19,9 @@ package com.netflix.titus.ext.aws.appscale;
 import com.netflix.archaius.api.annotations.PropertyName;
 
 public interface AWSAppScalingConfig {
+    String SERVICE_NAMESPACE = "custom-resource";
+    // AWS requires this field be set to this specific value for all application-autoscaling calls.
+    String SCALABLE_DIMENSION = "custom-resource:ResourceType:Property";
 
     @PropertyName(name = "region")
     String getRegion();

--- a/titus-ext/aws/src/test/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingUtilTest.java
+++ b/titus-ext/aws/src/test/java/com/netflix/titus/ext/aws/appscale/AWSAppAutoScalingUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.titus.ext.aws.appscale;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class AWSAppAutoScalingUtilTest {
+    @Test
+    public void testGatewayResourceId() {
+        final String gatewayResourceId = AWSAppAutoScalingUtil.buildGatewayResourceId(
+                "job1", "Titus", "us-east-1", "stack1");
+        assertThat(gatewayResourceId).isEqualTo("https://Titus.execute-api.us-east-1.amazonaws.com/stack1/scalableTargetDimensions/job1");
+    }
+
+    @Test
+    public void testPolicyName() {
+        final String policyName = AWSAppAutoScalingUtil.buildScalingPolicyName("policy1", "job1");
+        assertThat(policyName).isEqualTo("job1/policy1");
+    }
+}


### PR DESCRIPTION
### Minor Refactoring

refactoring AWSAppAutoScalingClient in order to isolate logic for building entities such as policy name, resource Id. Also removes service namespace and scalable dimension into a publicly accessible location.