### PR TITLE
fix ip target details on logs

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/loadbalancer/service/TargetStateBatchable.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/loadbalancer/service/TargetStateBatchable.java
@@ -74,4 +74,13 @@ class TargetStateBatchable implements Batchable<LoadBalancerTarget> {
         TargetStateBatchable o = (TargetStateBatchable) other;
         return targetState.equals(o.targetState);
     }
+
+    @Override
+    public String toString() {
+        return "TargetStateBatchable{" +
+                "priority=" + priority +
+                ", timestamp=" + timestamp +
+                ", targetState=" + targetState +
+                '}';
+    }
 }


### PR DESCRIPTION
### Description of the Change

Really small change, right now objects being logged by the `LoadBalancerEngine` are being shown as Java reference ids.