### PR TITLE
use openjdk 8 on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 sudo: false
 install: "./installViaTravis.sh"
 script: travis_wait ./buildViaTravis.sh

--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/grpc/GrpcEndpointConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/grpc/GrpcEndpointConfiguration.java
@@ -28,24 +28,6 @@ public interface GrpcEndpointConfiguration {
     @DefaultValue("7104")
     int getPort();
 
-    /**
-     * Application name regular expression for identifying V3 enabled applications.
-     */
-    @DefaultValue(".*")
-    String getV3EnabledApps();
-
-    /**
-     * Application name regular expression for identifying applications that should not be running on V3 engine.
-     */
-    @DefaultValue("NOT_V3_ENABLED")
-    String getNotV3EnabledApps();
-
-    /**
-     * Image name regular expression for identifying applications that should not be running on V3 engine.
-     */
-    @DefaultValue("NOT_V3_ENABLED")
-    String getNotV3EnabledImages();
-
     @PropertyName(name = "loadbalancer.enabled")
     @DefaultValue("true")
     boolean getLoadBalancerGrpcEnabled();


### PR DESCRIPTION
### Description of the Change

Use OpenJDK 8 on Travis CI