### PR TITLE
Agent Management Improvements

### DIFF
--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/rest/AgentManagementResource.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/rest/AgentManagementResource.java
@@ -35,6 +35,7 @@ import com.google.common.base.Strings;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.gateway.endpoint.v3.rest.representation.TierWrapper;
 import com.netflix.titus.grpc.protogen.AgentInstance;
+import com.netflix.titus.grpc.protogen.AgentInstanceAttributesUpdate;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroup;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroups;
 import com.netflix.titus.grpc.protogen.AgentInstances;
@@ -129,5 +130,19 @@ public class AgentManagementResource {
         }
 
         return Responses.fromCompletable(agentManagementService.updateInstanceGroupAttributes(attributesUpdate));
+    }
+
+    @PUT
+    @ApiOperation("Update agent instance attributes")
+    @Path("/instances/{id}/attributes")
+    public Response updateAgentInstanceAttributes(@PathParam("id") String agentInstanceId, AgentInstanceAttributesUpdate attributesUpdate) {
+        if (Strings.isNullOrEmpty(attributesUpdate.getAgentInstanceId())) {
+            attributesUpdate = attributesUpdate.toBuilder().setAgentInstanceId(agentInstanceId).build();
+        } else if (!Objects.equals(agentInstanceId, attributesUpdate.getAgentInstanceId())) {
+            throw TitusServiceException.invalidArgument("Path parameter id: " + agentInstanceId + " must match payload agentInstanceId: "
+                    + attributesUpdate.getAgentInstanceId());
+        }
+
+        return Responses.fromCompletable(agentManagementService.updateAgentInstanceAttributes(attributesUpdate));
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/AgentAttributes.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/AgentAttributes.java
@@ -16,9 +16,6 @@
 
 package com.netflix.titus.master.agent;
 
-import com.netflix.titus.common.annotation.Experimental;
-
-@Experimental(deadline = "11/1/2018")
 public final class AgentAttributes {
 
     /**

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/endpoint/grpc/DefaultAgentManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/endpoint/grpc/DefaultAgentManagementServiceGrpc.java
@@ -33,6 +33,7 @@ import com.netflix.titus.api.agent.service.AgentStatusMonitor;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.grpc.protogen.AgentChangeEvent;
 import com.netflix.titus.grpc.protogen.AgentInstance;
+import com.netflix.titus.grpc.protogen.AgentInstanceAttributesUpdate;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroup;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroups;
 import com.netflix.titus.grpc.protogen.AgentInstances;
@@ -146,6 +147,17 @@ public class DefaultAgentManagementServiceGrpc extends AgentManagementServiceImp
     @Override
     public void updateInstanceGroupAttributes(InstanceGroupAttributesUpdate request, StreamObserver<Empty> responseObserver) {
         agentManagementService.updateInstanceGroupAttributes(request.getInstanceGroupId(), request.getAttributesMap()).subscribe(
+                () -> {
+                    responseObserver.onNext(Empty.getDefaultInstance());
+                    responseObserver.onCompleted();
+                },
+                responseObserver::onError
+        );
+    }
+
+    @Override
+    public void updateAgentInstanceAttributes(AgentInstanceAttributesUpdate request, StreamObserver<Empty> responseObserver) {
+        agentManagementService.updateAgentInstanceAttributes(request.getAgentInstanceId(), request.getAttributesMap()).subscribe(
                 () -> {
                     responseObserver.onNext(Empty.getDefaultInstance());
                     responseObserver.onCompleted();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
@@ -168,7 +168,6 @@ public class DefaultAgentManagementService implements AgentManagementService {
                 .flatMap(instanceGroup -> {
                     AgentInstanceGroup newInstanceGroup = instanceGroup.toBuilder().withAttributes(attributes).build();
                     return agentCache.updateInstanceGroupStore(newInstanceGroup).toObservable();
-
                 }).toCompletable();
     }
 
@@ -178,7 +177,6 @@ public class DefaultAgentManagementService implements AgentManagementService {
                 .flatMap(instance -> {
                     AgentInstance newAgentInstance = instance.toBuilder().withAttributes(attributes).build();
                     return agentCache.updateAgentInstanceStore(newAgentInstance).toObservable();
-
                 }).toCompletable();
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerConfiguration.java
@@ -118,6 +118,6 @@ public interface SchedulerConfiguration {
     /**
      * Whether to spread based on job in the Critical tier.
      */
-    @DefaultValue("false")
+    @DefaultValue("true")
     boolean isCriticalTierJobSpreadingEnabled();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/fitness/AgentManagementFitnessCalculator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/fitness/AgentManagementFitnessCalculator.java
@@ -31,6 +31,8 @@ import com.netflix.titus.master.scheduler.SchedulerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.netflix.titus.master.agent.AgentAttributes.PREFER_NO_PLACEMENT;
+
 /**
  *
  */
@@ -42,7 +44,7 @@ public class AgentManagementFitnessCalculator implements VMTaskFitnessCalculator
     private static final Logger logger = LoggerFactory.getLogger(AgentManagementFitnessCalculator.class);
 
     private static final double ACTIVE_INSTANCE_GROUP_SCORE = 1.0;
-    private static final double PREFER_NO_PLACEMENT_SCORE = 0.01;
+    private static final double PREFER_NO_PLACEMENT_SCORE = 0.000001;
     private static final double DEFAULT_SCORE = 0.01;
 
     private static final double QUALITY_OF_UNKNOWN_AGENT = 0.5;
@@ -83,7 +85,8 @@ public class AgentManagementFitnessCalculator implements VMTaskFitnessCalculator
 
             if (instanceGroup.getLifecycleStatus().getState() == InstanceGroupLifecycleState.Active) {
                 return quality * ACTIVE_INSTANCE_GROUP_SCORE;
-            } else if (instanceGroup.getLifecycleStatus().getState() == InstanceGroupLifecycleState.PhasedOut) {
+            } else if (instanceGroup.getLifecycleStatus().getState() == InstanceGroupLifecycleState.PhasedOut ||
+                    instanceGroup.getAttributes().containsKey(PREFER_NO_PLACEMENT)) {
                 return quality * PREFER_NO_PLACEMENT_SCORE;
             }
         }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScalerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScalerTest.java
@@ -120,6 +120,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(0)
                 .withCurrent(0)
                 .withMax(10)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 
@@ -149,6 +150,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(0)
                 .withCurrent(12)
                 .withMax(20)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 
@@ -191,6 +193,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(0)
                 .withCurrent(0)
                 .withMax(20)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 
@@ -224,6 +227,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(0)
                 .withCurrent(0)
                 .withMax(10)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 
@@ -273,6 +277,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(0)
                 .withCurrent(0)
                 .withMax(10)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 
@@ -302,6 +307,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(0)
                 .withCurrent(12)
                 .withMax(20)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 
@@ -334,6 +340,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(0)
                 .withCurrent(20)
                 .withMax(20)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 
@@ -374,6 +381,7 @@ public class ClusterAgentAutoScalerTest {
                 .withMin(13)
                 .withCurrent(20)
                 .withMax(20)
+                .withAttributes(Collections.emptyMap())
                 .build();
         when(agentManagementService.getInstanceGroups()).thenReturn(singletonList(instanceGroup));
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/agent/AgentManagementClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/agent/AgentManagementClient.java
@@ -18,6 +18,7 @@ package com.netflix.titus.runtime.connector.agent;
 
 import com.netflix.titus.grpc.protogen.AgentChangeEvent;
 import com.netflix.titus.grpc.protogen.AgentInstance;
+import com.netflix.titus.grpc.protogen.AgentInstanceAttributesUpdate;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroup;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroups;
 import com.netflix.titus.grpc.protogen.AgentInstances;
@@ -43,6 +44,8 @@ public interface AgentManagementClient {
     Completable updateInstanceGroupLifecycle(InstanceGroupLifecycleStateUpdate lifecycleStateUpdate);
 
     Completable updateInstanceGroupAttributes(InstanceGroupAttributesUpdate attributesUpdate);
+
+    Completable updateAgentInstanceAttributes(AgentInstanceAttributesUpdate attributesUpdate);
 
     Observable<AgentChangeEvent> observeAgents();
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/agent/client/GrpcAgentManagementClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/agent/client/GrpcAgentManagementClient.java
@@ -22,6 +22,7 @@ import javax.inject.Singleton;
 import com.google.protobuf.Empty;
 import com.netflix.titus.grpc.protogen.AgentChangeEvent;
 import com.netflix.titus.grpc.protogen.AgentInstance;
+import com.netflix.titus.grpc.protogen.AgentInstanceAttributesUpdate;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroup;
 import com.netflix.titus.grpc.protogen.AgentInstanceGroups;
 import com.netflix.titus.grpc.protogen.AgentInstances;
@@ -116,6 +117,13 @@ public class GrpcAgentManagementClient implements AgentManagementClient {
         }, configuration.getRequestTimeout());
     }
 
+    @Override
+    public Completable updateAgentInstanceAttributes(AgentInstanceAttributesUpdate attributesUpdate) {
+        return createRequestCompletable(emitter -> {
+            StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
+            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).updateAgentInstanceAttributes(attributesUpdate, streamObserver);
+        }, configuration.getRequestTimeout());
+    }
 
     @Override
     public Observable<AgentChangeEvent> observeAgents() {


### PR DESCRIPTION
### Description of the Change
* add API to update agent instance attributes
* add ability to add nonRemovable agent attribute to an instance group to prevent any instance from being scaled away
* reduce phased out score and also use the attribute preferNoPlacement
* make critical tier spreading by jobId the default behavior