### PR TITLE
Job toBuilder method does not copy the statusHistory field

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/Job.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/Job.java
@@ -132,18 +132,15 @@ public class Job<E extends JobDescriptor.JobDescriptorExt> {
     }
 
     public Builder<E> toBuilder() {
-        return newBuilder(this);
+        return new Builder<E>()
+                .withId(id)
+                .withJobDescriptor(jobDescriptor)
+                .withStatus(status)
+                .withStatusHistory(statusHistory);
     }
 
     public static <E extends JobDescriptor.JobDescriptorExt> Builder<E> newBuilder() {
         return new Builder<>();
-    }
-
-    public static <E extends JobDescriptor.JobDescriptorExt> Builder<E> newBuilder(Job<E> job) {
-        return new Builder<E>()
-                .withId(job.getId())
-                .withJobDescriptor(job.getJobDescriptor())
-                .withStatus(job.getStatus());
     }
 
     public static final class Builder<E extends JobDescriptor.JobDescriptorExt> {

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
@@ -143,10 +143,6 @@ public final class JobModel {
         return Job.newBuilder();
     }
 
-    public static <E extends JobDescriptor.JobDescriptorExt> Job.Builder<E> newJob(Job<E> job) {
-        return Job.newBuilder(job);
-    }
-
     public static BatchJobExt.Builder newBatchJobExt() {
         return BatchJobExt.newBuilder();
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobStatus.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobStatus.java
@@ -20,9 +20,13 @@ package com.netflix.titus.api.jobmanager.model.job;
 import com.netflix.titus.common.model.sanitizer.ClassFieldsNotNull;
 
 /**
+ *
  */
 @ClassFieldsNotNull
 public class JobStatus extends ExecutableStatus<JobState> {
+
+    public static final String REASON_UNKNOWN = "unknown";
+
     public JobStatus(JobState state, String reasonCode, String reasonMessage, long timestamp) {
         super(state, reasonCode, reasonMessage, timestamp);
     }
@@ -46,7 +50,12 @@ public class JobStatus extends ExecutableStatus<JobState> {
 
         @Override
         public JobStatus build() {
-            return new JobStatus(state, reasonCode, toCompleteReasonMessage(), timestamp);
+            return new JobStatus(
+                    state,
+                    reasonCode == null ? REASON_UNKNOWN : reasonCode,
+                    toCompleteReasonMessage(),
+                    timestamp
+            );
         }
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/TaskStatus.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/TaskStatus.java
@@ -24,6 +24,7 @@ import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.StringExt;
 
 /**
+ *
  */
 @ClassFieldsNotNull
 public class TaskStatus extends ExecutableStatus<TaskState> {
@@ -150,7 +151,12 @@ public class TaskStatus extends ExecutableStatus<TaskState> {
 
         @Override
         public TaskStatus build() {
-            return new TaskStatus(state, reasonCode, toCompleteReasonMessage(), timestamp);
+            return new TaskStatus(
+                    state,
+                    reasonCode == null ? TaskStatus.REASON_UNKNOWN : reasonCode,
+                    toCompleteReasonMessage(),
+                    timestamp
+            );
         }
     }
 }

--- a/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
+++ b/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
@@ -205,7 +205,7 @@ public class CassandraJobStoreTest {
         store.storeJob(job).await();
         Pair<List<Job<?>>, Integer> jobsAndErrors = store.retrieveJobs().toBlocking().first();
         assertThat(jobsAndErrors.getLeft().get(0)).isEqualTo(job);
-        Job<BatchJobExt> newJob = Job.newBuilder(job)
+        Job<BatchJobExt> newJob = job.toBuilder()
                 .withStatus(JobStatus.newBuilder().withState(JobState.Finished).build())
                 .build();
         store.updateJob(newJob).await();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
@@ -19,8 +19,10 @@ package com.netflix.titus.master.jobmanager.service.service.action;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.JobState;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
 import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
+import com.netflix.titus.api.jobmanager.service.JobManagerException;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.api.jobmanager.store.JobStore;
 import com.netflix.titus.common.framework.reconciler.ModelActionHolder;
@@ -42,6 +44,10 @@ public class BasicServiceJobActions {
                 .summary("Changing job capacity to: %s", capacity)
                 .changeWithModelUpdates(self -> {
                     Job<ServiceJobExt> serviceJob = engine.getReferenceView().getEntity();
+                    if (serviceJob.getStatus().getState() != JobState.Accepted) {
+                        return Observable.error(JobManagerException.jobTerminating(serviceJob));
+                    }
+
                     Job<ServiceJobExt> updatedJob = JobFunctions.changeServiceJobCapacity(serviceJob, capacity);
 
                     TitusModelAction modelAction = TitusModelAction.newModelUpdate(self).jobUpdate(jobHolder -> jobHolder.setEntity(updatedJob));
@@ -60,6 +66,10 @@ public class BasicServiceJobActions {
                 .summary("Changing job enable status to: %s", enabled)
                 .changeWithModelUpdates(self -> {
                     Job<ServiceJobExt> serviceJob = engine.getReferenceView().getEntity();
+                    if (serviceJob.getStatus().getState() != JobState.Accepted) {
+                        return Observable.error(JobManagerException.jobTerminating(serviceJob));
+                    }
+
                     Job<ServiceJobExt> updatedJob = JobFunctions.changeJobEnabledStatus(serviceJob, enabled);
 
                     TitusModelAction modelAction = TitusModelAction.newModelUpdate(self).jobUpdate(jobHolder -> jobHolder.setEntity(updatedJob));
@@ -78,6 +88,10 @@ public class BasicServiceJobActions {
                 .summary("Changing job service processes to: %s", processes)
                 .changeWithModelUpdates(self -> {
                     Job<ServiceJobExt> serviceJob = engine.getReferenceView().getEntity();
+                    if (serviceJob.getStatus().getState() != JobState.Accepted) {
+                        return Observable.error(JobManagerException.jobTerminating(serviceJob));
+                    }
+
                     Job<ServiceJobExt> updatedJob = JobFunctions.changeServiceJobProcesses(serviceJob, processes);
 
                     TitusModelAction modelAction = TitusModelAction.newModelUpdate(self).jobUpdate(jobHolder -> jobHolder.setEntity(updatedJob));

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
@@ -39,6 +39,7 @@ import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.JobModel;
+import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
@@ -207,6 +208,15 @@ public class JobScenarioBuilder<E extends JobDescriptor.JobDescriptorExt> {
     public JobScenarioBuilder<E> changeJobEnabledStatus(boolean enabled) {
         ExtTestSubscriber<Void> subscriber = new ExtTestSubscriber<>();
         jobOperations.updateJobStatus(jobId, enabled).subscribe(subscriber);
+
+        autoAdvanceUntilSuccessful(() -> checkOperationSubscriberAndThrowExceptionIfError(subscriber));
+
+        return this;
+    }
+
+    public JobScenarioBuilder<E> changServiceJobProcesses(ServiceJobProcesses processes) {
+        ExtTestSubscriber<Void> subscriber = new ExtTestSubscriber<>();
+        jobOperations.updateServiceJobProcesses(jobId, processes).subscribe(subscriber);
 
         autoAdvanceUntilSuccessful(() -> checkOperationSubscriberAndThrowExceptionIfError(subscriber));
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
@@ -109,6 +109,7 @@ public final class V3GrpcModelConverters {
                 .withId(grpcJob.getId())
                 .withJobDescriptor(toCoreJobDescriptor(grpcJob.getJobDescriptor()))
                 .withStatus(toCoreJobStatus(grpcJob.getStatus()))
+                .withStatusHistory(grpcJob.getStatusHistoryList().stream().map(V3GrpcModelConverters::toCoreJobStatus).collect(Collectors.toList()))
                 .build();
     }
 


### PR DESCRIPTION
The most likely scenario in which the status history would be erased:
- a job was finished, and the finished state was persisted in the active jobs table
- a new scale up request was handled, which changed the job record, at which point we lost the status history
- the archive reconcilation process moved the job from the active to the archive table

The second step was possible, as we do not check if the job is in finished state in the `updateJobCapacity` method.
