### PR TITLE
Flaky tests in AbstractSimulatedMesosSchedulerDriverTest and JobRetryTest classes

### DIFF
--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobRetryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobRetryTest.java
@@ -79,7 +79,8 @@ public class JobRetryTest extends BaseIntegrationTest {
 
     @Test(timeout = 30_000)
     public void testBatchJobRetry() throws Exception {
-        jobsScenarioBuilder.schedule(ONE_TASK_BATCH_JOB, jobScenarioBuilder -> jobScenarioBuilder
+        JobDescriptor<BatchJobExt> jobDescriptor = ONE_TASK_BATCH_JOB.toBuilder().withApplicationName("testBatchJobRetry").build();
+        jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .inTask(0, TaskScenarioBuilder::failTaskExecution)
                 .inTask(0, taskScenarioBuilder -> taskScenarioBuilder.expectStateUpdateSkipOther(TaskState.Finished))
@@ -94,7 +95,8 @@ public class JobRetryTest extends BaseIntegrationTest {
 
     @Test(timeout = 30_000)
     public void testServiceJobRetry() throws Exception {
-        jobsScenarioBuilder.schedule(ONE_TASK_SERVICE_JOB, jobScenarioBuilder -> jobScenarioBuilder
+        JobDescriptor<ServiceJobExt> jobDescriptor = ONE_TASK_SERVICE_JOB.toBuilder().withApplicationName("testServiceJobRetry").build();
+        jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .inTask(0, taskScenarioBuilder -> taskScenarioBuilder.transitionUntil(TaskState.Finished))
                 .inTask(0, taskScenarioBuilder -> taskScenarioBuilder.expectStateUpdateSkipOther(TaskState.Finished))
@@ -109,7 +111,8 @@ public class JobRetryTest extends BaseIntegrationTest {
 
     @Test(timeout = 30_000)
     public void testBatchJobFailsAfterRetrying() throws Exception {
-        jobsScenarioBuilder.schedule(ONE_TASK_BATCH_JOB, jobScenarioBuilder -> jobScenarioBuilder
+        JobDescriptor<BatchJobExt> jobDescriptor = ONE_TASK_BATCH_JOB.toBuilder().withApplicationName("testBatchJobFailsAfterRetrying").build();
+        jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .inTask(0, TaskScenarioBuilder::failTaskExecution)
                 .inTask(0, taskScenarioBuilder -> taskScenarioBuilder.expectStateUpdateSkipOther(TaskState.Finished))
@@ -122,7 +125,8 @@ public class JobRetryTest extends BaseIntegrationTest {
 
     @Test(timeout = 30_000)
     public void testServiceJobFailsAfterRetrying() throws Exception {
-        jobsScenarioBuilder.schedule(ONE_TASK_SERVICE_JOB, jobScenarioBuilder -> jobScenarioBuilder
+        JobDescriptor<ServiceJobExt> jobDescriptor = ONE_TASK_SERVICE_JOB.toBuilder().withApplicationName("testServiceJobFailsAfterRetrying").build();
+        jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .inTask(0, TaskScenarioBuilder::failTaskExecution)
                 .inTask(0, taskScenarioBuilder -> taskScenarioBuilder.expectStateUpdateSkipOther(TaskState.Finished))

--- a/titus-testkit/src/test/java/com/netflix/titus/testkit/embedded/cloud/connector/AbstractSimulatedMesosSchedulerDriverTest.java
+++ b/titus-testkit/src/test/java/com/netflix/titus/testkit/embedded/cloud/connector/AbstractSimulatedMesosSchedulerDriverTest.java
@@ -89,13 +89,12 @@ public abstract class AbstractSimulatedMesosSchedulerDriverTest {
     public void testTaskKill() throws Exception {
         Protos.TaskInfo taskInfo = newTaskInfo();
 
-        Protos.Offer offer = offers().takeNext(TIMEOUT_MS, TimeUnit.MILLISECONDS).getOffer();
+        Protos.Offer offer = offers().takeNext(3, TIMEOUT_MS, TimeUnit.MILLISECONDS).get(0).getOffer();
         mesosDriver.launchTasks(singletonList(offer.getId()), singletonList(taskInfo));
 
         Protos.TaskState afterLaunch = taskStatusUpdates().takeNext(TIMEOUT_MS, TimeUnit.MILLISECONDS).getState();
         assertThat(afterLaunch).isEqualTo(Protos.TaskState.TASK_STAGING);
 
-        offers().skipAvailable();
         mesosDriver.killTask(taskInfo.getTaskId());
 
         Protos.TaskStatus afterKill = taskStatusUpdates().takeNext(TIMEOUT_MS, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
In `JobRetryTest` all tests used the same application name/job group info which somtimes caused
job create errors:

`
com.netflix.titus.master.integration.v3.job.JobRetryTest > testServiceJobFailsAfterRetrying FAILED
    java.lang.RuntimeException: GRPC status Status{code=INVALID_ARGUMENT, description=JobManagerException: Constraint violation - job with group sequence v3App-main-GA-v000 exists (7e4d6e5b-1522-4021-81b9-542df881cfe6), cause=null}: JobManagerException: Constraint violation - job with group sequence v3App-main-GA-v000 exists (7e4d6e5b-1522-4021-81b9-542df881cfe6)
`

`AbstractSimulatedMesosSchedulerDriverTest` incorrectly handled offers in the `testTaskKill` test.
