### PR TITLE
Signal that a task has been moved in TaskUpdateEvents

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobManagerEvent.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobManagerEvent.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.api.jobmanager.model.job.event;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import com.netflix.titus.api.jobmanager.model.job.Job;
@@ -45,23 +46,17 @@ public abstract class JobManagerEvent<TYPE> {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof JobManagerEvent)) {
             return false;
         }
-
         JobManagerEvent<?> that = (JobManagerEvent<?>) o;
-
-        if (current != null ? !current.equals(that.current) : that.current != null) {
-            return false;
-        }
-        return previous != null ? previous.equals(that.previous) : that.previous == null;
+        return current.equals(that.current) &&
+                previous.equals(that.previous);
     }
 
     @Override
     public int hashCode() {
-        int result = current != null ? current.hashCode() : 0;
-        result = 31 * result + (previous != null ? previous.hashCode() : 0);
-        return result;
+        return Objects.hash(current, previous);
     }
 
     public static JobManagerEvent<Job> snapshotMarker() {

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/TaskUpdateEvent.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/TaskUpdateEvent.java
@@ -25,8 +25,6 @@ import com.netflix.titus.api.jobmanager.model.job.Task;
 public class TaskUpdateEvent extends JobManagerEvent<Task> {
 
     private final Job<?> currentJob;
-    private final Task currentTask;
-    private final Optional<Task> previousTask;
     private final boolean movedFromAnotherJob;
 
     private TaskUpdateEvent(Job<?> currentJob, Task currentTask, Optional<Task> previousTask) {
@@ -36,8 +34,6 @@ public class TaskUpdateEvent extends JobManagerEvent<Task> {
     private TaskUpdateEvent(Job<?> currentJob, Task currentTask, Optional<Task> previousTask, boolean moved) {
         super(currentTask, previousTask);
         this.currentJob = currentJob;
-        this.currentTask = currentTask;
-        this.previousTask = previousTask;
         this.movedFromAnotherJob = moved;
     }
 
@@ -46,11 +42,11 @@ public class TaskUpdateEvent extends JobManagerEvent<Task> {
     }
 
     public Task getCurrentTask() {
-        return currentTask;
+        return getCurrent();
     }
 
     public Optional<Task> getPreviousTask() {
-        return previousTask;
+        return getPrevious();
     }
 
     public boolean isMovedFromAnotherJob() {
@@ -70,22 +66,20 @@ public class TaskUpdateEvent extends JobManagerEvent<Task> {
         }
         TaskUpdateEvent that = (TaskUpdateEvent) o;
         return movedFromAnotherJob == that.movedFromAnotherJob &&
-                currentJob.equals(that.currentJob) &&
-                currentTask.equals(that.currentTask) &&
-                previousTask.equals(that.previousTask);
+                currentJob.equals(that.currentJob);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), currentJob, currentTask, previousTask, movedFromAnotherJob);
+        return Objects.hash(super.hashCode(), currentJob, movedFromAnotherJob);
     }
 
     @Override
     public String toString() {
         return "TaskUpdateEvent{" +
                 "currentJob=" + currentJob +
-                ", currentTask=" + currentTask +
-                ", previousTask=" + previousTask +
+                ", currentTask=" + getCurrent() +
+                ", previousTask=" + getPrevious() +
                 ", movedFromAnotherJob=" + movedFromAnotherJob +
                 '}';
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/loadbalancer/model/JobLoadBalancer.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/loadbalancer/model/JobLoadBalancer.java
@@ -81,4 +81,11 @@ public class JobLoadBalancer implements Comparable<JobLoadBalancer> {
         }
         return loadBalancerId.compareTo(o.getLoadBalancerId());
     }
+
+    /**
+     * {@link java.util.function.BiPredicate} that compares <tt>loadBalancerIds</tt>.
+     */
+    public static boolean byLoadBalancerId(JobLoadBalancer one, JobLoadBalancer other) {
+        return one.loadBalancerId.equals(other.loadBalancerId);
+    }
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -505,6 +506,16 @@ public final class CollectionsExt {
      */
     public static <T, I> Map<I, T> indexBy(List<T> items, Function<T, I> keyMapper) {
         return items.stream().collect(Collectors.toMap(keyMapper, Function.identity(), (v1, v2) -> v1));
+    }
+
+    /**
+     * @param equal custom logic for equality between items from both <tt>Collections</tt>
+     * @return items present in <tt>one</tt> that are not present in <tt>other</tt>, according to a custom predicate for each pair
+     */
+    public static <T> Collection<T> difference(Collection<T> one, Collection<T> other, BiPredicate<T, T> equal) {
+        return one.stream()
+                .filter(it -> other.stream().noneMatch(ot -> equal.test(it, ot)))
+                .collect(Collectors.toSet());
     }
 
     public static class MapBuilder<K, V> {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerService.java
@@ -176,11 +176,6 @@ public class DefaultLoadBalancerService implements LoadBalancerService {
                         e -> logger.error("Error while processing load balancer batch", e),
                         () -> logger.info("Load balancer batch stream closed")
                 );
-
-        // TODO(fabio): reconciliation
-        // TODO(fabio): watch job updates stream for garbage collection
-        // TODO(fabio): garbage collect removed jobs and loadbalancers
-        // TODO(fabio): integrate with the V2 engine
     }
 
     private void logBatchInfo(Batch<TargetStateBatchable, String> batch) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/loadbalancer/service/LoadBalancerEngine.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/loadbalancer/service/LoadBalancerEngine.java
@@ -17,8 +17,11 @@
 package com.netflix.titus.master.loadbalancer.service;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -33,13 +36,13 @@ import com.netflix.titus.api.loadbalancer.model.TargetState;
 import com.netflix.titus.api.loadbalancer.store.LoadBalancerStore;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.limiter.tokenbucket.TokenBucket;
 import com.netflix.titus.common.util.rx.ObservableExt;
 import com.netflix.titus.common.util.rx.batch.Batch;
 import com.netflix.titus.common.util.rx.batch.LargestPerTimeBucket;
 import com.netflix.titus.common.util.rx.batch.Priority;
 import com.netflix.titus.common.util.rx.batch.RateLimitedBatcher;
-import com.netflix.titus.common.util.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Completable;
@@ -102,17 +105,19 @@ class LoadBalancerEngine {
                 reconciler.events().doOnError(e -> logger.error("Reconciliation error", e))
         );
 
-        Observable<TaskUpdateEvent> stateTransitions = jobOperations.observeJobs()
+        Observable<TaskUpdateEvent> taskEvents = jobOperations.observeJobs()
                 .filter(TaskUpdateEvent.class::isInstance)
-                .cast(TaskUpdateEvent.class)
-                .filter(TaskHelpers::isStateTransition);
+                .cast(TaskUpdateEvent.class);
+        Observable<TaskUpdateEvent> stateTransitions = taskEvents.filter(TaskHelpers::isStateTransition);
+        Observable<TaskUpdateEvent> tasksMoved = taskEvents.filter(TaskUpdateEvent::isMovedFromAnotherJob);
 
         final Observable<TargetStateBatchable> updates = Observable.merge(
                 reconcilerEvents,
                 pendingAssociations.compose(targetsForJobLoadBalancers(State.Registered)),
                 pendingDissociations.compose(targetsForJobLoadBalancers(State.Deregistered)),
                 registerFromEvents(stateTransitions),
-                deregisterFromEvents(stateTransitions)
+                deregisterFromEvents(stateTransitions),
+                moveFromEvents(tasksMoved)
         ).compose(disableReconciliationTemporarily());
 
         return updates
@@ -163,33 +168,78 @@ class LoadBalancerEngine {
     }
 
     private Observable<TargetStateBatchable> registerFromEvents(Observable<TaskUpdateEvent> events) {
-        Observable<Task> tasks = events.map(TaskUpdateEvent::getCurrentTask)
-                .filter(TaskHelpers::isStartedWithIp);
-        return targetsForTrackedTasks(tasks)
-                .map(target -> new TargetStateBatchable(Priority.High, now(), new TargetState(target, State.Registered)));
+        return events.map(TaskUpdateEvent::getCurrentTask)
+                .filter(TaskHelpers::isStartedWithIp)
+                .flatMapIterable(task -> {
+                    Set<JobLoadBalancer> loadBalancers = store.getAssociatedLoadBalancersSetForJob(task.getJobId());
+                    if (!loadBalancers.isEmpty()) {
+                        logger.info("Task update in job associated to one or more load balancers, registering {} load balancer targets: {}",
+                                loadBalancers.size(), task.getJobId());
+                    }
+                    return updatesForLoadBalancers(loadBalancers, task, State.Registered);
+                });
     }
 
     private Observable<TargetStateBatchable> deregisterFromEvents(Observable<TaskUpdateEvent> events) {
-        Observable<Task> tasks = events.map(TaskUpdateEvent::getCurrentTask)
-                .filter(TaskHelpers::isTerminalWithIp);
-        return targetsForTrackedTasks(tasks)
-                .map(target -> new TargetStateBatchable(Priority.High, now(), new TargetState(target, State.Deregistered)));
+        return events.map(TaskUpdateEvent::getCurrentTask)
+                .filter(TaskHelpers::isTerminalWithIp)
+                .flatMapIterable(task -> {
+                    Set<JobLoadBalancer> loadBalancers = store.getAssociatedLoadBalancersSetForJob(task.getJobId());
+                    if (!loadBalancers.isEmpty()) {
+                        logger.info("Task update in job associated to one or more load balancers, deregistering {} load balancer targets: {}",
+                                loadBalancers.size(), task.getJobId());
+                    }
+                    return updatesForLoadBalancers(loadBalancers, task, State.Deregistered);
+                });
     }
 
-    private Observable<LoadBalancerTarget> targetsForTrackedTasks(Observable<Task> tasks) {
-        return tasks.doOnNext(task -> logger.debug("Checking if task in job is being tracked: {}", task.getId()))
-                .map(task -> Pair.of(task, store.getAssociatedLoadBalancersSetForJob(task.getJobId())))
-                // A task with an empty set is not tracked by any load balancer
-                .filter(pair -> !pair.getRight().isEmpty())
-                .doOnNext(pair -> logger.info("Task update in job being tracked, enqueuing {} load balancer updates: {}",
-                        pair.getRight().size(), pair.getLeft()))
-                .flatMap(pair -> Observable.from(
-                        pair.getRight().stream().map(association -> new LoadBalancerTarget(
-                                association,
-                                pair.getLeft().getId(),
-                                pair.getLeft().getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP)
-                        )).collect(Collectors.toList()))
-                );
+    private Observable<TargetStateBatchable> moveFromEvents(Observable<TaskUpdateEvent> taskMovedEvents) {
+        return taskMovedEvents.flatMapIterable(taskMoved -> {
+            ArrayList<TargetStateBatchable> changes = new ArrayList<>();
+            Task task = taskMoved.getCurrentTask();
+            String targetJobId = task.getJobId();
+            Set<JobLoadBalancer> targetJobLoadBalancers = store.getAssociatedLoadBalancersSetForJob(targetJobId);
+            String sourceJobId = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_MOVED_FROM_JOB);
+            if (StringExt.isEmpty(sourceJobId)) {
+                logger.warn("Task moved to {} does not include the source job id: {}", task.getJobId(), task.getId());
+                return Collections.emptyList();
+            }
+            Set<JobLoadBalancer> sourceJobLoadBalancers = store.getAssociatedLoadBalancersSetForJob(sourceJobId);
+
+            // operations below will dedup load balancers present in both source and target Sets, so we avoid
+            // unnecessary churn by deregistering and registering the same targets on the same loadBalancerId
+
+            // register on load balancers associated with the target job
+            if (TaskHelpers.isStartedWithIp(task)) {
+                // targetJobLoadBalancers - sourceJobLoadBalancers
+                Set<JobLoadBalancer> toRegister = targetJobLoadBalancers.stream()
+                        .filter(target -> sourceJobLoadBalancers.stream().noneMatch(
+                                source -> source.getLoadBalancerId().equalsIgnoreCase(target.getLoadBalancerId())
+                        ))
+                        .collect(Collectors.toSet());
+                changes.addAll(updatesForLoadBalancers(toRegister, task, State.Registered));
+            }
+            // deregister from load balancers associated with the source job
+            // sourceJobLoadBalancers - targetJobLoadBalancers
+            Set<JobLoadBalancer> toDeregister = sourceJobLoadBalancers.stream()
+                    .filter(source -> targetJobLoadBalancers.stream().noneMatch(
+                            target -> target.getLoadBalancerId().equalsIgnoreCase(source.getLoadBalancerId())
+                    ))
+                    .collect(Collectors.toSet());
+            changes.addAll(updatesForLoadBalancers(toDeregister, task, State.Deregistered));
+            if (!changes.isEmpty()) {
+                logger.info("Task moved to {} from {}. Jobs are associated with one or more load balancers, generating {} load balancer updates",
+                        targetJobId, sourceJobId, changes.size());
+            }
+            return changes;
+        });
+    }
+
+    private List<TargetStateBatchable> updatesForLoadBalancers(Set<JobLoadBalancer> loadBalancers, Task task, State desired) {
+        return loadBalancers.stream()
+                .map(association -> toLoadBalancerTarget(association, task))
+                .map(target -> new TargetStateBatchable(Priority.High, now(), new TargetState(target, desired)))
+                .collect(Collectors.toList());
     }
 
     private Observable.Transformer<JobLoadBalancer, TargetStateBatchable> targetsForJobLoadBalancers(State state) {
@@ -201,6 +251,11 @@ class LoadBalancerEngine {
                 .map(target -> new TargetStateBatchable(Priority.High, now(), new TargetState(target, state)))
                 .doOnError(e -> logger.error("Error fetching targets to {}", state, e))
                 .retry();
+    }
+
+    private static LoadBalancerTarget toLoadBalancerTarget(JobLoadBalancer association, Task task) {
+        return new LoadBalancerTarget(association, task.getId(),
+                task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP));
     }
 
     private RateLimitedBatcher<TargetStateBatchable, String> buildBatcher() {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerServiceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerServiceTest.java
@@ -877,7 +877,7 @@ public class DefaultLoadBalancerServiceTest {
                         TaskAttributes.TASK_ATTRIBUTES_MOVED_FROM_JOB, sourceJobId
                 )).build();
 
-        // detect the task is moved and gets registered on the target
+        // detect the task is moved and gets deregistered from the source
         taskEvents.onNext(TaskUpdateEvent.newTaskFromAnotherJob(null, moved));
         testScheduler.advanceTimeBy(FLUSH_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerServiceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/loadbalancer/service/DefaultLoadBalancerServiceTest.java
@@ -718,6 +718,175 @@ public class DefaultLoadBalancerServiceTest {
         verifyReconcilerIgnore(jobId, loadBalancerId, "3.3.3.3");
     }
 
+    @Test
+    public void movedTasks() {
+        final String taskId = UUID.randomUUID().toString();
+        final String sourceJobId = UUID.randomUUID().toString();
+        final String targetJobId = UUID.randomUUID().toString();
+        final String sourceLoadBalancerId = "lb-" + UUID.randomUUID().toString();
+        final String targetLoadBalancerId = "lb-" + UUID.randomUUID().toString();
+        final String commonLoadBalancerId = "lb-" + UUID.randomUUID().toString();
+        final PublishSubject<JobManagerEvent<?>> taskEvents = PublishSubject.create();
+
+        when(client.registerAll(any(), any())).thenReturn(Completable.complete());
+        when(client.deregisterAll(any(), any())).thenReturn(Completable.complete());
+        when(v3JobOperations.observeJobs()).thenReturn(taskEvents);
+        LoadBalancerTests.applyValidGetJobMock(v3JobOperations, sourceJobId);
+        LoadBalancerTests.applyValidGetJobMock(v3JobOperations, targetJobId);
+
+        LoadBalancerConfiguration configuration = LoadBalancerTests.mockConfiguration(MIN_TIME_IN_QUEUE_MS);
+        DefaultLoadBalancerService service = new DefaultLoadBalancerService(
+                runtime, configuration, client, loadBalancerStore, loadBalancerJobOperations, reconciler, validator, testScheduler);
+
+        final AssertableSubscriber<Batch<TargetStateBatchable, String>> testSubscriber = service.events().test();
+
+        assertTrue(service.addLoadBalancer(sourceJobId, sourceLoadBalancerId).await(100, TimeUnit.MILLISECONDS));
+        assertTrue(service.addLoadBalancer(sourceJobId, commonLoadBalancerId).await(100, TimeUnit.MILLISECONDS));
+        assertThat(service.getJobLoadBalancers(sourceJobId).toBlocking().toIterable())
+                .containsExactlyInAnyOrder(sourceLoadBalancerId, commonLoadBalancerId);
+
+        assertTrue(service.addLoadBalancer(targetJobId, targetLoadBalancerId).await(100, TimeUnit.MILLISECONDS));
+        assertTrue(service.addLoadBalancer(targetJobId, commonLoadBalancerId).await(100, TimeUnit.MILLISECONDS));
+        assertThat(service.getJobLoadBalancers(targetJobId).toBlocking().toIterable())
+                .containsExactlyInAnyOrder(targetLoadBalancerId, commonLoadBalancerId);
+
+        testScheduler.advanceTimeBy(FLUSH_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+
+        testSubscriber.assertNoErrors().assertValueCount(0);
+        verify(client, never()).registerAll(any(), any());
+        verify(client, never()).deregisterAll(any(), any());
+        verifyNoReconcilerIgnore();
+
+        Task moved = ServiceJobTask.newBuilder()
+                .withJobId(targetJobId)
+                .withId(taskId)
+                .withStatus(TaskStatus.newBuilder().withState(TaskState.Started).build())
+                .withTaskContext(CollectionsExt.asMap(
+                        TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, "1.2.3.4",
+                        TaskAttributes.TASK_ATTRIBUTES_MOVED_FROM_JOB, sourceJobId
+                )).build();
+
+        // detect the task is moved, gets deregistered from the source and registered on the target
+        taskEvents.onNext(TaskUpdateEvent.newTaskFromAnotherJob(null, moved));
+        testScheduler.advanceTimeBy(FLUSH_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+
+        testSubscriber.assertNoErrors().assertValueCount(2);
+        verify(client).registerAll(eq(targetLoadBalancerId), argThat(set -> set.contains("1.2.3.4")));
+        verify(client).deregisterAll(eq(sourceLoadBalancerId), argThat(set -> set.contains("1.2.3.4")));
+        verifyReconcilerIgnore(targetJobId, targetLoadBalancerId, "1.2.3.4");
+        verifyReconcilerIgnore(sourceJobId, sourceLoadBalancerId, "1.2.3.4");
+
+        // load balancers associated with both source and target jobs are not changed
+        verify(client, never()).registerAll(eq(commonLoadBalancerId), any());
+        verify(client, never()).deregisterAll(eq(commonLoadBalancerId), any());
+        verifyNoReconcilerIgnore(targetJobId, commonLoadBalancerId);
+        verifyNoReconcilerIgnore(sourceJobId, commonLoadBalancerId);
+    }
+
+    @Test
+    public void movedTaskOnlyTargetAssociatedWithLoadBalancer() {
+        final String taskId = UUID.randomUUID().toString();
+        final String sourceJobId = UUID.randomUUID().toString();
+        final String targetJobId = UUID.randomUUID().toString();
+        final String targetLoadBalancerId = "lb-" + UUID.randomUUID().toString();
+        final PublishSubject<JobManagerEvent<?>> taskEvents = PublishSubject.create();
+
+        when(client.registerAll(any(), any())).thenReturn(Completable.complete());
+        when(client.deregisterAll(any(), any())).thenReturn(Completable.complete());
+        when(v3JobOperations.observeJobs()).thenReturn(taskEvents);
+        LoadBalancerTests.applyValidGetJobMock(v3JobOperations, sourceJobId);
+        LoadBalancerTests.applyValidGetJobMock(v3JobOperations, targetJobId);
+
+        LoadBalancerConfiguration configuration = LoadBalancerTests.mockConfiguration(MIN_TIME_IN_QUEUE_MS);
+        DefaultLoadBalancerService service = new DefaultLoadBalancerService(
+                runtime, configuration, client, loadBalancerStore, loadBalancerJobOperations, reconciler, validator, testScheduler);
+
+        final AssertableSubscriber<Batch<TargetStateBatchable, String>> testSubscriber = service.events().test();
+
+        assertThat(service.getJobLoadBalancers(sourceJobId).toBlocking().toIterable()).isEmpty();
+
+        assertTrue(service.addLoadBalancer(targetJobId, targetLoadBalancerId).await(100, TimeUnit.MILLISECONDS));
+        assertThat(service.getJobLoadBalancers(targetJobId).toBlocking().toIterable())
+                .containsExactlyInAnyOrder(targetLoadBalancerId);
+
+        testScheduler.advanceTimeBy(FLUSH_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+
+        testSubscriber.assertNoErrors().assertValueCount(0);
+        verify(client, never()).registerAll(any(), any());
+        verify(client, never()).deregisterAll(any(), any());
+        verifyNoReconcilerIgnore();
+
+        Task moved = ServiceJobTask.newBuilder()
+                .withJobId(targetJobId)
+                .withId(taskId)
+                .withStatus(TaskStatus.newBuilder().withState(TaskState.Started).build())
+                .withTaskContext(CollectionsExt.asMap(
+                        TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, "1.2.3.4",
+                        TaskAttributes.TASK_ATTRIBUTES_MOVED_FROM_JOB, sourceJobId
+                )).build();
+
+        // detect the task is moved and gets registered on the target
+        taskEvents.onNext(TaskUpdateEvent.newTaskFromAnotherJob(null, moved));
+        testScheduler.advanceTimeBy(FLUSH_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+
+        testSubscriber.assertNoErrors().assertValueCount(1);
+        verify(client).registerAll(eq(targetLoadBalancerId), argThat(set -> set.contains("1.2.3.4")));
+        verify(client, never()).deregisterAll(any(), any());
+        verifyReconcilerIgnore(targetJobId, targetLoadBalancerId, "1.2.3.4");
+    }
+
+    @Test
+    public void movedTaskOnlySourceAssociatedWithLoadBalancer() {
+        final String taskId = UUID.randomUUID().toString();
+        final String sourceJobId = UUID.randomUUID().toString();
+        final String targetJobId = UUID.randomUUID().toString();
+        final String sourceLoadBalancerId = "lb-" + UUID.randomUUID().toString();
+        final PublishSubject<JobManagerEvent<?>> taskEvents = PublishSubject.create();
+
+        when(client.registerAll(any(), any())).thenReturn(Completable.complete());
+        when(client.deregisterAll(any(), any())).thenReturn(Completable.complete());
+        when(v3JobOperations.observeJobs()).thenReturn(taskEvents);
+        LoadBalancerTests.applyValidGetJobMock(v3JobOperations, sourceJobId);
+        LoadBalancerTests.applyValidGetJobMock(v3JobOperations, targetJobId);
+
+        LoadBalancerConfiguration configuration = LoadBalancerTests.mockConfiguration(MIN_TIME_IN_QUEUE_MS);
+        DefaultLoadBalancerService service = new DefaultLoadBalancerService(
+                runtime, configuration, client, loadBalancerStore, loadBalancerJobOperations, reconciler, validator, testScheduler);
+
+        final AssertableSubscriber<Batch<TargetStateBatchable, String>> testSubscriber = service.events().test();
+
+        assertTrue(service.addLoadBalancer(sourceJobId, sourceLoadBalancerId).await(100, TimeUnit.MILLISECONDS));
+        assertThat(service.getJobLoadBalancers(sourceJobId).toBlocking().toIterable())
+                .containsExactlyInAnyOrder(sourceLoadBalancerId);
+
+        assertThat(service.getJobLoadBalancers(targetJobId).toBlocking().toIterable()).isEmpty();
+
+        testScheduler.advanceTimeBy(FLUSH_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+
+        testSubscriber.assertNoErrors().assertValueCount(0);
+        verify(client, never()).registerAll(any(), any());
+        verify(client, never()).deregisterAll(any(), any());
+        verifyNoReconcilerIgnore();
+
+        Task moved = ServiceJobTask.newBuilder()
+                .withJobId(targetJobId)
+                .withId(taskId)
+                .withStatus(TaskStatus.newBuilder().withState(TaskState.Started).build())
+                .withTaskContext(CollectionsExt.asMap(
+                        TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, "1.2.3.4",
+                        TaskAttributes.TASK_ATTRIBUTES_MOVED_FROM_JOB, sourceJobId
+                )).build();
+
+        // detect the task is moved and gets registered on the target
+        taskEvents.onNext(TaskUpdateEvent.newTaskFromAnotherJob(null, moved));
+        testScheduler.advanceTimeBy(FLUSH_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+
+        testSubscriber.assertNoErrors().assertValueCount(1);
+        verify(client).deregisterAll(eq(sourceLoadBalancerId), argThat(set -> set.contains("1.2.3.4")));
+        verify(client, never()).registerAll(any(), any());
+        verifyReconcilerIgnore(sourceJobId, sourceLoadBalancerId, "1.2.3.4");
+    }
+
     private void verifyReconcilerIgnore(String jobId, String loadBalancerId, String... ipAddresses) {
         final Set<String> ipSet = CollectionsExt.asSet(ipAddresses);
         verify(reconciler, times(ipAddresses.length)).activateCooldownFor(argThat(target ->

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
@@ -151,11 +151,12 @@ public class GrpcJobReplicatorEventStream extends AbstractReplicatorEventStream<
                 case TASKUPDATE:
                     //TODO(fabio): handle task moved when it is added to the gRPC API definition
                     com.netflix.titus.grpc.protogen.Task task = event.getTaskUpdate().getTask();
-                    Optional<Job<?>> taskJob = lastSnapshot.findJob(task.getJobId());
-                    if (taskJob.isPresent()) {
-                        Task coreTask = V3GrpcModelConverters.toCoreTask(taskJob.get(), task);
+                    Optional<Job<?>> taskJobOpt = lastSnapshot.findJob(task.getJobId());
+                    if (taskJobOpt.isPresent()) {
+                        Job<?> taskJob = taskJobOpt.get();
+                        Task coreTask = V3GrpcModelConverters.toCoreTask(taskJob, task);
                         newSnapshot = lastSnapshot.updateTask(coreTask);
-                        coreEvent = toTaskCoreEvent(taskJob.get(), coreTask);
+                        coreEvent = toTaskCoreEvent(taskJob, coreTask);
                     } else {
                         titusRuntime.getCodeInvariants().inconsistent("Job record not found: jobId=%s, taskId=%s", task.getJobId(), task.getId());
                         newSnapshot = Optional.empty();

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
@@ -898,6 +898,7 @@ public final class V3GrpcModelConverters {
 
         TaskUpdateEvent taskUpdateEvent = (TaskUpdateEvent) event;
         return JobChangeNotification.newBuilder()
+                // TODO(fabio): propagate isMovedFromAnotherJob
                 .setTaskUpdate(
                         JobChangeNotification.TaskUpdate.newBuilder().
                                 setTask(toGrpcTask(taskUpdateEvent.getCurrent(), logStorageInfo))

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/client/V3ClientUtils.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/client/V3ClientUtils.java
@@ -60,6 +60,7 @@ public class V3ClientUtils {
         state.put(task.getId(), task);
 
         if (previous == null) {
+            // TODO(fabio): handle isTaskMoved once added to the gRPC API
             return Pair.of(TaskUpdateEvent.newTask(job, task), state);
         }
         return Pair.of(TaskUpdateEvent.taskChange(job, task, (Task) previous), state);


### PR DESCRIPTION
Task events from `JobOperations` will now have a flag indicating when a task moved from another job. This allows subscribers to update their indexes and act accordingly.

This PR also adds handling of tasks being moved to the `LoadBalancerEngine`, so IPs get properly deregistered/registered as tasks move to a different Job.

The information about tasks moving is not being added to the public gRPC APIs yet. That will come in another PR, along with changes to some components already using the gRPC event stream. I added some `TODOs` where changes will be required.