### PR TITLE
ignore task lost status updates from mesos in specific cases

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosSchedulerCallbackHandler.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosSchedulerCallbackHandler.java
@@ -377,6 +377,10 @@ public class MesosSchedulerCallbackHandler implements Scheduler {
             TaskStatus effectiveTaskStatus = taskStatusUpdateFitInjection.map(i -> i.afterImmediate("update", taskStatus)).orElse(taskStatus);
 
             if (isReconcilerUpdateForUnknownTask(effectiveTaskStatus)) {
+                if (taskStatus.getState() == TaskState.TASK_LOST) {
+                    logger.info("Ignoring reconciler TASK_LOST status update for task: {}", taskId);
+                    return;
+                }
                 mesosStateTracker.unknownTaskStatusUpdate(taskStatus);
                 if (!mesosConfiguration.isAllowReconcilerUpdatesForUnknownTasks()) {
                     logger.info("Ignoring reconciler triggered task status update: {}", taskId);


### PR DESCRIPTION
### Description of the Change

Ignore task lost status updates from mesos if it is a reconciliation message and the job management component does not know about the task.