### PR TITLE
remove google-truth

### DIFF
--- a/titus-api/dependencies.lock
+++ b/titus-api/dependencies.lock
@@ -56,18 +56,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -79,23 +70,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -131,18 +115,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -151,31 +127,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -269,23 +220,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -294,28 +253,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -323,21 +289,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -345,14 +314,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -377,13 +346,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -444,12 +413,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -462,37 +425,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -643,18 +579,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -666,23 +593,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -718,18 +638,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -738,31 +650,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -856,23 +743,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -881,28 +776,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -910,21 +812,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -932,14 +837,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -964,13 +869,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1031,12 +936,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1049,37 +948,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1230,18 +1102,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1253,23 +1116,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1305,18 +1161,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1325,31 +1173,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1443,23 +1266,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1468,28 +1299,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1497,21 +1335,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1519,14 +1360,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1551,13 +1392,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1618,12 +1459,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1636,37 +1471,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1881,18 +1689,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1904,23 +1703,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1956,18 +1748,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1976,31 +1760,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2094,23 +1853,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2119,28 +1886,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2148,21 +1922,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2170,14 +1947,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2202,13 +1979,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2269,12 +2046,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2287,37 +2058,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2469,18 +2213,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2492,23 +2227,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2544,18 +2272,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2564,31 +2284,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2682,23 +2377,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2707,28 +2410,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2736,21 +2446,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2758,14 +2471,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2790,13 +2503,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2857,12 +2570,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2875,37 +2582,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -3253,14 +2933,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3268,7 +2940,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3276,7 +2948,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3290,17 +2961,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -3308,9 +2975,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3374,18 +3038,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3399,25 +3055,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -3428,12 +3065,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -3910,27 +3541,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3941,30 +3580,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -3976,21 +3622,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4000,14 +3649,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4032,14 +3681,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4049,7 +3698,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -4196,7 +3845,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -4403,21 +4051,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -4429,12 +4062,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -5193,14 +4820,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5208,7 +4827,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5216,7 +4835,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5230,17 +4848,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -5248,9 +4862,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5314,18 +4925,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5339,25 +4942,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -5368,12 +4952,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -5850,27 +5428,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5881,30 +5467,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -5916,21 +5509,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5940,14 +5536,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5972,14 +5568,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5989,7 +5585,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -6136,7 +5732,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -6343,21 +5938,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -6369,12 +5949,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -7133,14 +6707,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7148,7 +6714,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7156,7 +6722,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -7170,17 +6735,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -7188,9 +6749,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7254,18 +6812,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7279,25 +6829,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -7308,12 +6839,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7790,27 +7315,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7821,30 +7354,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7856,21 +7396,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7880,14 +7423,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7912,14 +7455,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7929,7 +7472,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -8076,7 +7619,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -8283,21 +7825,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -8309,12 +7836,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -9074,14 +8595,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -9089,7 +8602,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -9097,7 +8610,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -9111,17 +8623,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -9129,9 +8637,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9195,18 +8700,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9220,25 +8717,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -9249,12 +8727,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9731,27 +9203,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -9762,30 +9242,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9797,21 +9284,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9821,14 +9311,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9853,14 +9343,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9870,7 +9360,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -10017,7 +9507,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -10224,21 +9713,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -10250,12 +9724,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-common/build.gradle
+++ b/titus-common/build.gradle
@@ -35,8 +35,6 @@ dependencies {
     compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
-    // Protobuf validation
-    compile "com.google.truth.extensions:truth-proto-extension:${googleTruthVersion}"
 
     compile "com.github.akarnokd:rxjava2-interop:${rxJavaInteropVersion}"
 

--- a/titus-common/dependencies.lock
+++ b/titus-common/dependencies.lock
@@ -50,18 +50,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -73,24 +64,17 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -125,19 +109,11 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -145,29 +121,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+"
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -242,23 +195,31 @@
             "requested": "1.10.+"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -267,28 +228,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -296,21 +264,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -318,14 +289,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -348,11 +319,11 @@
             "requested": "3.1.+"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "io.projectreactor.addons:reactor-adapter",
@@ -405,48 +376,15 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -572,18 +510,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -595,24 +524,17 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -647,19 +569,11 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -667,29 +581,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+"
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -764,23 +655,31 @@
             "requested": "1.10.+"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -789,28 +688,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -818,21 +724,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -840,14 +749,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -870,11 +779,11 @@
             "requested": "3.1.+"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "io.projectreactor.addons:reactor-adapter",
@@ -927,48 +836,15 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -1094,18 +970,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1117,24 +984,17 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -1169,19 +1029,11 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -1189,29 +1041,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+"
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1286,23 +1115,31 @@
             "requested": "1.10.+"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1311,28 +1148,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1340,21 +1184,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1362,14 +1209,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1392,11 +1239,11 @@
             "requested": "3.1.+"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "io.projectreactor.addons:reactor-adapter",
@@ -1449,12 +1296,6 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1467,36 +1308,9 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -1690,18 +1504,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1713,24 +1518,17 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -1765,19 +1563,11 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -1785,29 +1575,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+"
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1882,23 +1649,31 @@
             "requested": "1.10.+"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1907,28 +1682,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1936,21 +1718,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1958,14 +1743,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1988,11 +1773,11 @@
             "requested": "3.1.+"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "io.projectreactor.addons:reactor-adapter",
@@ -2045,12 +1830,6 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2063,36 +1842,9 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -2223,18 +1975,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2246,24 +1989,17 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -2298,19 +2034,11 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -2318,29 +2046,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+"
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2415,23 +2120,31 @@
             "requested": "1.10.+"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2440,28 +2153,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2469,21 +2189,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2491,14 +2214,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2521,11 +2244,11 @@
             "requested": "3.1.+"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "io.projectreactor.addons:reactor-adapter",
@@ -2578,12 +2301,6 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2596,36 +2313,9 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
-            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -2962,14 +2652,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2977,7 +2659,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2985,7 +2667,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2999,17 +2680,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
@@ -3018,9 +2695,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3084,19 +2758,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3110,26 +2776,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -3140,12 +2786,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -3635,27 +3275,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3666,30 +3314,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -3701,21 +3356,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3725,14 +3383,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3758,7 +3416,7 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -3766,7 +3424,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -3777,7 +3435,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -3929,7 +3587,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -4138,21 +3795,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -4164,12 +3806,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -4938,14 +4574,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4953,7 +4581,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4961,7 +4589,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -4975,17 +4602,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
@@ -4994,9 +4617,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5060,19 +4680,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5086,26 +4698,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -5116,12 +4708,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -5611,27 +5197,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5642,30 +5236,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -5677,21 +5278,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5701,14 +5305,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5734,7 +5338,7 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -5742,7 +5346,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -5753,7 +5357,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -5905,7 +5509,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -6114,21 +5717,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -6140,12 +5728,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -6914,14 +6496,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6929,7 +6503,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6937,7 +6511,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6951,17 +6524,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
@@ -6970,9 +6539,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7036,19 +6602,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7062,26 +6620,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -7092,12 +6630,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7587,27 +7119,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7618,30 +7158,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7653,21 +7200,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7677,14 +7227,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7710,7 +7260,7 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -7718,7 +7268,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -7729,7 +7279,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7881,7 +7431,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -8090,21 +7639,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -8116,12 +7650,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8891,14 +8419,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -8906,7 +8426,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -8914,7 +8434,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -8928,17 +8447,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "requested": "20.+",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
@@ -8947,9 +8462,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9013,19 +8525,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9039,26 +8543,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "requested": "0.42+",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -9069,12 +8553,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9564,27 +9042,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -9595,30 +9081,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9630,21 +9123,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9654,14 +9150,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9687,7 +9183,7 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "requested": "0.8.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -9695,7 +9191,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
@@ -9706,7 +9202,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9858,7 +9354,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -10067,21 +9562,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -10093,12 +9573,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-common/src/main/java/com/netflix/titus/common/util/ProtobufExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/ProtobufExt.java
@@ -25,9 +25,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.truth.FailureStrategy;
-import com.google.common.truth.StandardSubjectBuilder;
-import com.google.common.truth.extensions.proto.ProtoTruth;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.MapEntry;
 import com.google.protobuf.Message;
@@ -100,26 +97,10 @@ public final class ProtobufExt {
      * @throws NullPointerException     when any of the messages are <tt>null</tt>
      */
     public static <T extends Message> Optional<String> diffReport(T one, T other) {
-        ErrorCollector collector = new ErrorCollector();
-        StandardSubjectBuilder.forCustomFailureStrategy(collector)
-                .about(ProtoTruth.protos())
-                .that(other)
-                .named(one.getDescriptorForType().getName())
-                .reportingMismatchesOnly()
-                .isEqualTo(one);
-        return collector.getFailure().map(AssertionError::getMessage);
-    }
-
-    private static class ErrorCollector implements FailureStrategy {
-        private volatile Optional<AssertionError> failure = Optional.empty();
-
-        @Override
-        public void fail(AssertionError failure) {
-            this.failure = Optional.of(failure);
+        if (one.equals(other)) {
+            return Optional.empty();
         }
-
-        public Optional<AssertionError> getFailure() {
-            return failure;
-        }
+        // TODO(fabio): implementation temporarily removed due to transitive dependency mismatches with guava
+        return Optional.of(String.format("Differences:\n>>>\n%s\n<<<\n%s", one.toString(), other.toString()));
     }
 }

--- a/titus-common/src/test/java/com/netflix/titus/common/util/ProtobufDiffTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/ProtobufDiffTest.java
@@ -19,6 +19,7 @@ package com.netflix.titus.common.util;
 import java.util.Optional;
 
 import com.google.protobuf.Message;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +36,8 @@ public class ProtobufDiffTest {
         assertThat(ProtobufExt.diffReport(composed1, composed2)).isNotPresent();
     }
 
+    // TODO(fabio): re-enable with a proper diff-ing implementation
+    @Ignore
     @Test
     public void testTopLevelDifferences() {
         Message one = ProtoMessageBuilder.newInner("value1", "value2");
@@ -54,6 +57,8 @@ public class ProtobufDiffTest {
         );
     }
 
+    // TODO(fabio): re-enable with a proper diff-ing implementation
+    @Ignore
     @Test
     public void testNestedDifferences() {
         Message one = ProtoMessageBuilder.newInner("value1", "value2");

--- a/titus-ext/aws/dependencies.lock
+++ b/titus-ext/aws/dependencies.lock
@@ -15,11 +15,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -37,7 +37,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -105,18 +105,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -128,23 +119,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -180,18 +164,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -200,31 +176,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -347,23 +298,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -372,28 +331,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -401,21 +367,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -423,14 +392,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -455,13 +424,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -528,12 +497,6 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -558,37 +521,10 @@
                 "org.apache.httpcomponents:httpclient"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -706,11 +642,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -728,7 +664,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -796,18 +732,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -819,23 +746,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -871,18 +791,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -891,31 +803,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1038,23 +925,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1063,28 +958,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1092,21 +994,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1114,14 +1019,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1146,13 +1051,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1219,12 +1124,6 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1249,37 +1148,10 @@
                 "org.apache.httpcomponents:httpclient"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1397,11 +1269,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1419,7 +1291,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1487,18 +1359,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1510,23 +1373,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1562,18 +1418,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1582,31 +1430,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1729,23 +1552,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1754,28 +1585,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1783,21 +1621,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1805,14 +1646,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1837,13 +1678,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1910,12 +1751,6 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1940,37 +1775,10 @@
                 "org.apache.httpcomponents:httpclient"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2152,11 +1960,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2174,7 +1982,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2242,18 +2050,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2265,23 +2064,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2317,18 +2109,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2337,31 +2121,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2484,23 +2243,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2509,28 +2276,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2538,21 +2312,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2560,14 +2337,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2592,13 +2369,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2665,12 +2442,6 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2695,37 +2466,10 @@
                 "org.apache.httpcomponents:httpclient"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2844,11 +2588,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2866,7 +2610,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2934,18 +2678,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2957,23 +2692,16 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -3009,18 +2737,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -3029,31 +2749,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -3176,23 +2871,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3201,28 +2904,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3230,21 +2940,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3252,14 +2965,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3284,13 +2997,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3357,12 +3070,6 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -3387,37 +3094,10 @@
                 "org.apache.httpcomponents:httpclient"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -3576,11 +3256,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3598,7 +3278,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3822,14 +3502,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3837,7 +3509,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3845,7 +3517,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3859,17 +3530,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -3877,9 +3544,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3943,18 +3607,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3968,25 +3624,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -3997,12 +3634,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -4497,27 +4128,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4528,30 +4167,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -4563,21 +4209,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4587,14 +4236,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4619,14 +4268,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4636,7 +4285,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -4784,7 +4433,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -5003,21 +4651,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -5029,12 +4662,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -5602,11 +5229,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -5624,7 +5251,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -5848,14 +5475,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5863,7 +5482,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5871,7 +5490,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5885,17 +5503,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -5903,9 +5517,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5969,18 +5580,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5994,25 +5597,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6023,12 +5607,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -6523,27 +6101,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6554,30 +6140,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -6589,21 +6182,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -6613,14 +6209,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -6645,14 +6241,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -6662,7 +6258,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -6810,7 +6406,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7029,21 +6624,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7055,12 +6635,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -7628,11 +7202,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7650,7 +7224,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7874,14 +7448,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7889,7 +7455,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7897,7 +7463,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -7911,17 +7476,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -7929,9 +7490,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7995,18 +7553,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8020,25 +7570,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8049,12 +7580,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -8549,27 +8074,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8580,30 +8113,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -8615,21 +8155,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -8639,14 +8182,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -8671,14 +8214,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -8688,7 +8231,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -8836,7 +8379,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9055,21 +8597,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9081,12 +8608,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -9655,11 +9176,11 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9677,7 +9198,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.495",
+            "locked": "1.11.496",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9901,14 +9422,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -9916,7 +9429,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -9924,7 +9437,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -9938,17 +9450,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -9956,9 +9464,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10022,18 +9527,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10047,25 +9544,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10076,12 +9554,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -10576,27 +10048,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -10607,30 +10087,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -10642,21 +10129,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -10666,14 +10156,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -10698,14 +10188,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -10715,7 +10205,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -10863,7 +10353,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11082,21 +10571,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11108,12 +10582,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-ext/cassandra-testkit/dependencies.lock
+++ b/titus-ext/cassandra-testkit/dependencies.lock
@@ -143,18 +143,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -166,25 +157,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -223,18 +207,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -243,25 +219,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -274,12 +231,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -444,23 +395,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -469,28 +428,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -500,21 +466,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -522,14 +491,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -554,13 +523,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -636,7 +605,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -732,21 +700,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -758,12 +711,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -1105,18 +1052,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1128,25 +1066,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1185,18 +1116,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1205,25 +1128,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -1236,12 +1140,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -1406,23 +1304,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1431,28 +1337,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -1462,21 +1375,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1484,14 +1400,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1516,13 +1432,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1598,7 +1514,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -1694,21 +1609,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -1720,12 +1620,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -2067,18 +1961,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2090,25 +1975,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2147,18 +2025,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2167,25 +2037,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -2198,12 +2049,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -2368,23 +2213,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2393,28 +2246,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -2424,21 +2284,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2446,14 +2309,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2478,13 +2341,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2560,7 +2423,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -2656,21 +2518,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -2682,12 +2529,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -3093,18 +2934,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3116,25 +2948,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -3173,18 +2998,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -3193,25 +3010,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -3224,12 +3022,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -3394,23 +3186,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3419,28 +3219,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -3450,21 +3257,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3472,14 +3282,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3504,13 +3314,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3586,7 +3396,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -3682,21 +3491,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -3708,12 +3502,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -4056,18 +3844,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4079,25 +3858,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -4136,18 +3908,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -4156,25 +3920,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -4187,12 +3932,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -4357,23 +4096,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4382,28 +4129,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -4413,21 +4167,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4435,14 +4192,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4467,13 +4224,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4549,7 +4306,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -4645,21 +4401,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -4671,12 +4412,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -5025,18 +4760,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5048,25 +4774,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -5105,18 +4824,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -5125,25 +4836,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -5156,12 +4848,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -5330,23 +5016,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5355,28 +5049,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -5386,21 +5087,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5408,14 +5112,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5440,13 +5144,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5456,7 +5160,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -5527,7 +5231,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -5643,21 +5346,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -5669,12 +5357,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -6037,18 +5719,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6060,25 +5733,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -6117,18 +5783,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -6137,25 +5795,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -6168,12 +5807,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -6342,23 +5975,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6367,28 +6008,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -6398,21 +6046,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -6420,14 +6071,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -6452,13 +6103,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -6468,7 +6119,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -6539,7 +6190,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -6655,21 +6305,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -6681,12 +6316,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -7049,18 +6678,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7072,25 +6692,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -7129,18 +6742,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -7149,25 +6754,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7180,12 +6766,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7354,23 +6934,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7379,28 +6967,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7410,21 +7005,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7432,14 +7030,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7464,13 +7062,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7480,7 +7078,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7551,7 +7149,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -7667,21 +7264,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7693,12 +7275,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8062,18 +7638,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8085,25 +7652,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -8142,18 +7702,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -8162,25 +7714,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8193,12 +7726,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -8367,23 +7894,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8392,28 +7927,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -8423,21 +7965,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -8445,14 +7990,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -8477,13 +8022,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -8493,7 +8038,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -8564,7 +8109,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -8680,21 +8224,6 @@
             "locked": "3.1.1.0",
             "requested": "3.1.1.0"
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -8706,12 +8235,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-ext/cassandra/dependencies.lock
+++ b/titus-ext/cassandra/dependencies.lock
@@ -98,18 +98,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -121,25 +112,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -175,18 +159,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -195,31 +171,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -329,23 +280,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -354,28 +313,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -383,21 +349,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -405,14 +374,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -437,13 +406,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -504,12 +473,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -522,37 +485,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -783,18 +719,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -806,25 +733,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -860,18 +780,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -880,31 +792,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1014,23 +901,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1039,28 +934,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1068,21 +970,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1090,14 +995,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1122,13 +1027,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1189,12 +1094,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1207,37 +1106,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1468,18 +1340,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1491,25 +1354,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1545,18 +1401,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1565,31 +1413,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1699,23 +1522,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1724,28 +1555,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1753,21 +1591,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1775,14 +1616,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1807,13 +1648,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1874,12 +1715,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1892,37 +1727,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2217,18 +2025,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2240,25 +2039,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2294,18 +2086,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2314,31 +2098,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2448,23 +2207,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2473,28 +2240,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2502,21 +2276,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2524,14 +2301,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2556,13 +2333,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2623,12 +2400,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2641,37 +2412,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2903,18 +2647,9 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
-                "com.google.guava:guava",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2926,25 +2661,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2980,18 +2708,10 @@
                 "com.netflix.governator:governator-core"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -3000,31 +2720,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -3134,23 +2829,31 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
-                "io.netty:netty-transport-native-epoll"
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
-                "io.netty:netty-handler"
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3159,28 +2862,35 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3188,21 +2898,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3210,14 +2923,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3242,13 +2955,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3309,12 +3022,6 @@
                 "com.netflix.titus:titus-common"
             ]
         },
-        "junit:junit": {
-            "locked": "4.12",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -3327,37 +3034,10 @@
                 "com.netflix.archaius:archaius2-core"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
-            ]
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -3745,14 +3425,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3760,7 +3432,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3768,7 +3440,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3782,17 +3453,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -3800,9 +3467,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3866,18 +3530,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3891,25 +3547,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -3920,12 +3557,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -4403,27 +4034,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4434,30 +4073,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4468,21 +4114,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4492,14 +4141,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4524,14 +4173,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4541,7 +4190,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -4688,7 +4337,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -4896,21 +4544,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -4922,12 +4555,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -5688,14 +5315,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5703,7 +5322,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5711,7 +5330,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5725,17 +5343,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -5743,9 +5357,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5809,18 +5420,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5834,25 +5437,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -5863,12 +5447,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -6346,27 +5924,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6377,30 +5963,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -6411,21 +6004,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -6435,14 +6031,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -6467,14 +6063,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -6484,7 +6080,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -6631,7 +6227,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -6839,21 +6434,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -6865,12 +6445,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -7631,14 +7205,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7646,7 +7212,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7654,7 +7220,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -7668,17 +7233,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -7686,9 +7247,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7752,18 +7310,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7777,25 +7327,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -7806,12 +7337,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -8289,27 +7814,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8320,30 +7853,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -8354,21 +7894,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -8378,14 +7921,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -8410,14 +7953,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -8427,7 +7970,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -8574,7 +8117,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -8782,21 +8324,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -8808,12 +8335,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -9575,14 +9096,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -9590,7 +9103,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -9598,7 +9111,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -9612,17 +9124,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -9630,9 +9138,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9696,18 +9201,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9721,25 +9218,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -9750,12 +9228,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -10233,27 +9705,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -10264,30 +9744,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -10298,21 +9785,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -10322,14 +9812,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -10354,14 +9844,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -10371,7 +9861,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -10518,7 +10008,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -10726,21 +10215,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -10752,12 +10226,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-ext/elasticsearch/dependencies.lock
+++ b/titus-ext/elasticsearch/dependencies.lock
@@ -159,14 +159,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -174,7 +166,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -182,7 +174,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -196,25 +187,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -276,18 +260,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -299,31 +275,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -727,27 +678,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -758,30 +717,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -791,21 +757,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -815,14 +784,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -847,13 +816,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -989,7 +958,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1175,27 +1143,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1678,14 +1625,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1693,7 +1632,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1701,7 +1640,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1715,25 +1653,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1795,18 +1726,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -1818,31 +1741,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2246,27 +2144,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2277,30 +2183,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2310,21 +2223,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2334,14 +2250,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2366,13 +2282,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2508,7 +2424,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2694,27 +2609,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -3197,14 +3091,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3212,7 +3098,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3220,7 +3106,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3234,25 +3119,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3314,18 +3192,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3337,31 +3207,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3765,27 +3610,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3796,30 +3649,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3829,21 +3689,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3853,14 +3716,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3885,13 +3748,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4027,7 +3890,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4213,27 +4075,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -4780,14 +4621,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4795,7 +4628,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4803,7 +4636,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -4817,25 +4649,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4897,18 +4722,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4920,31 +4737,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5348,27 +5140,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5379,30 +5179,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -5412,21 +5219,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5436,14 +5246,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5468,13 +5278,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5610,7 +5420,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5796,27 +5605,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6300,14 +6088,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6315,7 +6095,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6323,7 +6103,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6337,25 +6116,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6417,18 +6189,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6440,31 +6204,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6868,27 +6607,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6899,30 +6646,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -6932,21 +6686,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -6956,14 +6713,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -6988,13 +6745,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7130,7 +6887,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -7316,27 +7072,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -7826,14 +7561,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7841,7 +7568,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7849,7 +7576,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -7863,25 +7589,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7943,18 +7662,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7966,31 +7677,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -8398,27 +8084,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8429,30 +8123,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -8462,21 +8163,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -8486,14 +8190,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -8518,13 +8222,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -8534,7 +8238,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -8665,7 +8369,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -8871,27 +8574,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -9401,14 +9083,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -9416,7 +9090,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -9424,7 +9098,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -9438,25 +9111,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9518,18 +9184,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9541,31 +9199,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -9973,27 +9606,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -10004,30 +9645,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -10037,21 +9685,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -10061,14 +9712,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -10093,13 +9744,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -10109,7 +9760,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -10240,7 +9891,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -10446,27 +10096,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -10976,14 +10605,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10991,7 +10612,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10999,7 +10620,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -11013,25 +10633,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11093,18 +10706,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11116,31 +10721,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -11548,27 +11128,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -11579,30 +11167,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -11612,21 +11207,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -11636,14 +11234,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -11668,13 +11266,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -11684,7 +11282,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11815,7 +11413,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -12021,27 +11618,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -12552,14 +12128,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12567,7 +12135,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12575,7 +12143,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12589,25 +12156,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12669,18 +12229,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12692,31 +12244,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -13124,27 +12651,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -13155,30 +12690,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -13188,21 +12730,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -13212,14 +12757,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -13244,13 +12789,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -13260,7 +12805,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13391,7 +12936,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -13597,27 +13141,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {

--- a/titus-ext/eureka/dependencies.lock
+++ b/titus-ext/eureka/dependencies.lock
@@ -162,14 +162,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -177,7 +169,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -185,7 +177,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -202,25 +193,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -285,18 +269,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -308,31 +284,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -782,27 +733,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -813,30 +772,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -846,21 +812,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -870,14 +839,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -902,13 +871,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1045,7 +1014,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1162,31 +1130,10 @@
                 "org.mock-server:mockserver-netty"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jettison:jettison": {
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1682,14 +1629,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1697,7 +1636,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1705,7 +1644,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -1722,25 +1660,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -1805,18 +1736,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -1828,31 +1751,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2302,27 +2200,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2333,30 +2239,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2366,21 +2279,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2390,14 +2306,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2422,13 +2338,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2565,7 +2481,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2682,31 +2597,10 @@
                 "org.mock-server:mockserver-netty"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jettison:jettison": {
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -3202,14 +3096,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3217,7 +3103,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3225,7 +3111,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -3242,25 +3127,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -3325,18 +3203,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3348,31 +3218,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3822,27 +3667,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3853,30 +3706,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3886,21 +3746,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3910,14 +3773,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3942,13 +3805,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4085,7 +3948,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4202,31 +4064,10 @@
                 "org.mock-server:mockserver-netty"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jettison:jettison": {
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -4786,14 +4627,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4801,7 +4634,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4809,7 +4642,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -4826,25 +4658,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -4909,18 +4734,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4932,31 +4749,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5406,27 +5198,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5437,30 +5237,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -5470,21 +5277,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5494,14 +5304,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5526,13 +5336,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5669,7 +5479,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5786,31 +5595,10 @@
                 "org.mock-server:mockserver-netty"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jettison:jettison": {
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6307,14 +6095,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6322,7 +6102,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6330,7 +6110,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -6347,25 +6126,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -6430,18 +6202,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6453,31 +6217,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6927,27 +6666,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6958,30 +6705,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -6991,21 +6745,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7015,14 +6772,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7047,13 +6804,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7190,7 +6947,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -7307,31 +7063,10 @@
                 "org.mock-server:mockserver-netty"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jettison:jettison": {
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -7936,14 +7671,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7951,7 +7678,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7959,7 +7686,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -7976,17 +7702,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -7994,9 +7716,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -8064,18 +7783,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8089,25 +7800,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8118,12 +7810,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -8672,27 +8358,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8703,30 +8397,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -8738,21 +8439,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -8762,14 +8466,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -8794,14 +8498,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -8811,7 +8515,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -8960,7 +8664,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9187,21 +8890,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9219,12 +8907,6 @@
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10023,14 +9705,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10038,7 +9712,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10046,7 +9720,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -10063,17 +9736,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -10081,9 +9750,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -10151,18 +9817,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10176,25 +9834,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10205,12 +9844,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -10759,27 +10392,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -10790,30 +10431,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -10825,21 +10473,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -10849,14 +10500,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -10881,14 +10532,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -10898,7 +10549,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11047,7 +10698,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11274,21 +10924,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11306,12 +10941,6 @@
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12110,14 +11739,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12125,7 +11746,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12133,7 +11754,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -12150,17 +11770,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12168,9 +11784,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -12238,18 +11851,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12263,25 +11868,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -12292,12 +11878,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -12846,27 +12426,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -12877,30 +12465,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -12912,21 +12507,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -12936,14 +12534,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -12968,14 +12566,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -12985,7 +12583,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13134,7 +12732,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13361,21 +12958,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -13393,12 +12975,6 @@
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -14198,14 +13774,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -14213,7 +13781,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.1",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -14221,7 +13789,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.twitter:util-cache_2.11",
@@ -14238,17 +13805,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -14256,9 +13819,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -14326,18 +13886,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -14351,25 +13903,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -14380,12 +13913,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -14934,27 +14461,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -14965,30 +14500,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -15000,21 +14542,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -15024,14 +14569,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -15056,14 +14601,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -15073,7 +14618,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -15222,7 +14767,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -15449,21 +14993,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -15481,12 +15010,6 @@
             "locked": "1.3.7",
             "transitive": [
                 "com.netflix.eureka:eureka-client"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-ext/jooq/dependencies.lock
+++ b/titus-ext/jooq/dependencies.lock
@@ -108,14 +108,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -123,7 +115,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -131,7 +123,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -145,25 +136,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -222,18 +206,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -243,31 +219,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -604,27 +555,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -635,30 +594,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -668,21 +634,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -692,14 +661,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -724,13 +693,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -858,7 +827,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -909,27 +877,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1359,14 +1306,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1374,7 +1313,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1382,7 +1321,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1396,25 +1334,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1473,18 +1404,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1494,31 +1417,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1855,27 +1753,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1886,30 +1792,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1919,21 +1832,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1943,14 +1859,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1975,13 +1891,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2109,7 +2025,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2160,27 +2075,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -2610,14 +2504,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2625,7 +2511,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2633,7 +2519,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2647,25 +2532,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2724,18 +2602,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2745,31 +2615,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3106,27 +2951,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3137,30 +2990,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3170,21 +3030,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3194,14 +3057,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3226,13 +3089,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3360,7 +3223,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3411,27 +3273,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -3953,14 +3794,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3968,7 +3801,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3976,7 +3809,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3990,25 +3822,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4067,18 +3892,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -4088,31 +3905,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4449,27 +4241,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4480,30 +4280,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4513,21 +4320,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4537,14 +4347,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4569,13 +4379,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4703,7 +4513,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4754,27 +4563,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -5205,14 +4993,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5220,7 +5000,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5228,7 +5008,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5242,25 +5021,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5319,18 +5091,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -5340,31 +5104,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5701,27 +5440,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5732,30 +5479,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -5765,21 +5519,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5789,14 +5546,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5821,13 +5578,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5955,7 +5712,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6006,27 +5762,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6601,14 +6336,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6616,7 +6343,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6624,7 +6351,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6638,17 +6364,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -6656,9 +6378,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6722,18 +6441,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6747,25 +6458,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6776,12 +6468,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7262,27 +6948,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7293,30 +6987,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7328,21 +7029,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7352,14 +7056,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7384,14 +7088,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7401,7 +7105,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7554,7 +7258,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7761,21 +7464,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7787,12 +7475,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8582,14 +8264,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -8597,7 +8271,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -8605,7 +8279,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -8619,17 +8292,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -8637,9 +8306,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8703,18 +8369,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8728,25 +8386,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8757,12 +8396,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9243,27 +8876,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -9274,30 +8915,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9309,21 +8957,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9333,14 +8984,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9365,14 +9016,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9382,7 +9033,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9535,7 +9186,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9742,21 +9392,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9768,12 +9403,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10563,14 +10192,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10578,7 +10199,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10586,7 +10207,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -10600,17 +10220,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -10618,9 +10234,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10684,18 +10297,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10709,25 +10314,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10738,12 +10324,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -11224,27 +10804,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -11255,30 +10843,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -11290,21 +10885,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -11314,14 +10912,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -11346,14 +10944,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -11363,7 +10961,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11516,7 +11114,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11723,21 +11320,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11749,12 +11331,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12545,14 +12121,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12560,7 +12128,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12568,7 +12136,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12582,17 +12149,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12600,9 +12163,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12666,18 +12226,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12691,25 +12243,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -12720,12 +12253,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -13206,27 +12733,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -13237,30 +12772,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -13272,21 +12814,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -13296,14 +12841,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -13328,14 +12873,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -13345,7 +12890,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13498,7 +13043,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13705,21 +13249,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -13731,12 +13260,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-ext/zookeeper/dependencies.lock
+++ b/titus-ext/zookeeper/dependencies.lock
@@ -137,14 +137,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -152,7 +144,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -160,7 +152,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -174,25 +165,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -253,18 +237,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -276,31 +252,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -678,27 +629,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -709,30 +668,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -742,21 +708,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -766,14 +735,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -798,13 +767,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -939,7 +908,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1023,27 +991,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1492,14 +1439,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1507,7 +1446,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1515,7 +1454,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1529,25 +1467,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1608,18 +1539,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -1631,31 +1554,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2033,27 +1931,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2064,30 +1970,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2097,21 +2010,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2121,14 +2037,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2153,13 +2069,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2294,7 +2210,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2378,27 +2293,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -2847,14 +2741,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2862,7 +2748,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2870,7 +2756,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2884,25 +2769,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2963,18 +2841,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -2986,31 +2856,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3388,27 +3233,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3419,30 +3272,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3452,21 +3312,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3476,14 +3339,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3508,13 +3371,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3649,7 +3512,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3733,27 +3595,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -4266,14 +4107,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4281,7 +4114,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4289,7 +4122,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -4303,25 +4135,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4382,18 +4207,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4405,31 +4222,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4807,27 +4599,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4838,30 +4638,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4871,21 +4678,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4895,14 +4705,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4927,13 +4737,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5068,7 +4878,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5152,27 +4961,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -5622,14 +5410,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5637,7 +5417,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5645,7 +5425,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5659,25 +5438,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5738,18 +5510,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5761,31 +5525,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6163,27 +5902,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6194,30 +5941,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -6227,21 +5981,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -6251,14 +6008,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -6283,13 +6040,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -6424,7 +6181,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6508,27 +6264,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -7097,14 +6832,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7112,7 +6839,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7120,7 +6847,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -7134,17 +6860,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -7152,9 +6874,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7218,18 +6937,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7243,25 +6954,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -7272,12 +6964,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7754,27 +7440,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7785,30 +7479,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7820,21 +7521,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7844,14 +7548,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7876,14 +7580,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7893,7 +7597,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -8040,7 +7744,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -8250,21 +7953,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -8276,12 +7964,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -9045,14 +8727,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -9060,7 +8734,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -9068,7 +8742,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -9082,17 +8755,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -9100,9 +8769,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9166,18 +8832,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9191,25 +8849,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -9220,12 +8859,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9702,27 +9335,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -9733,30 +9374,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9768,21 +9416,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9792,14 +9443,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9824,14 +9475,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9841,7 +9492,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9988,7 +9639,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -10198,21 +9848,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -10224,12 +9859,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10993,14 +10622,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -11008,7 +10629,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -11016,7 +10637,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -11030,17 +10650,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -11048,9 +10664,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11114,18 +10727,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11139,25 +10744,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -11168,12 +10754,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -11650,27 +11230,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -11681,30 +11269,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -11716,21 +11311,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -11740,14 +11338,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -11772,14 +11370,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -11789,7 +11387,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11936,7 +11534,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -12146,21 +11743,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -12172,12 +11754,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12942,14 +12518,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12957,7 +12525,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12965,7 +12533,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12979,17 +12546,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12997,9 +12560,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -13063,18 +12623,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -13088,25 +12640,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -13117,12 +12650,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -13599,27 +13126,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -13630,30 +13165,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -13665,21 +13207,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -13689,14 +13234,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -13721,14 +13266,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -13738,7 +13283,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13885,7 +13430,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -14095,21 +13639,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -14121,12 +13650,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-grpc-api/dependencies.lock
+++ b/titus-grpc-api/dependencies.lock
@@ -375,7 +375,7 @@
     },
     "protobuf": {
         "com.netflix.titus:titus-api-definitions": {
-            "locked": "0.0.1-rc55",
+            "locked": "0.0.1-rc56",
             "requested": "0.0.1-rc+"
         }
     },
@@ -711,13 +711,13 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "transitive": [
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "junit:junit-dep": {
@@ -879,13 +879,13 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "transitive": [
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "junit:junit-dep": {
@@ -1047,13 +1047,13 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "transitive": [
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "junit:junit-dep": {
@@ -1228,13 +1228,13 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "transitive": [
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "junit:junit-dep": {

--- a/titus-server-federation/dependencies.lock
+++ b/titus-server-federation/dependencies.lock
@@ -123,14 +123,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -138,7 +130,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -146,7 +138,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -160,25 +151,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -237,18 +221,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -258,31 +234,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -613,27 +564,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -644,30 +603,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -677,21 +643,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -701,14 +670,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -733,13 +702,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -861,7 +830,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -912,27 +880,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1344,14 +1291,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1359,7 +1298,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1367,7 +1306,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1381,25 +1319,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1458,18 +1389,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1479,31 +1402,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1834,27 +1732,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1865,30 +1771,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1898,21 +1811,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1922,14 +1838,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1954,13 +1870,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2082,7 +1998,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2133,27 +2048,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -2565,14 +2459,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2580,7 +2466,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2588,7 +2474,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2602,25 +2487,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2679,18 +2557,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2700,31 +2570,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3055,27 +2900,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3086,30 +2939,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3119,21 +2979,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3143,14 +3006,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3175,13 +3038,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3303,7 +3166,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3354,27 +3216,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -3850,14 +3691,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3865,7 +3698,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3873,7 +3706,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3887,25 +3719,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3964,18 +3789,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3985,31 +3802,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4340,27 +4132,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4371,30 +4171,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4404,21 +4211,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4428,14 +4238,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4460,13 +4270,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4588,7 +4398,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4639,27 +4448,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -5072,14 +4860,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5087,7 +4867,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5095,7 +4875,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5109,25 +4888,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5186,18 +4958,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -5207,31 +4971,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5562,27 +5301,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5593,30 +5340,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -5626,21 +5380,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5650,14 +5407,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5682,13 +5439,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5810,7 +5567,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5861,27 +5617,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6424,14 +6159,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6439,7 +6166,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6447,7 +6174,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6461,17 +6187,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -6479,9 +6201,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6545,18 +6264,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6570,25 +6281,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6599,12 +6291,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7109,27 +6795,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7140,30 +6834,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7175,21 +6876,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7199,14 +6903,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7231,14 +6935,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7248,7 +6952,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7395,7 +7099,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",
@@ -7605,21 +7308,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7631,12 +7319,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8400,14 +8082,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -8415,7 +8089,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -8423,7 +8097,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -8437,17 +8110,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -8455,9 +8124,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8521,18 +8187,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8546,25 +8204,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8575,12 +8214,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9085,27 +8718,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -9116,30 +8757,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9151,21 +8799,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9175,14 +8826,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9207,14 +8858,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9224,7 +8875,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9371,7 +9022,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",
@@ -9581,21 +9231,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9607,12 +9242,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10376,14 +10005,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10391,7 +10012,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10399,7 +10020,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -10413,17 +10033,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -10431,9 +10047,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10497,18 +10110,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10522,25 +10127,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10551,12 +10137,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -11061,27 +10641,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -11092,30 +10680,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -11127,21 +10722,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -11151,14 +10749,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -11183,14 +10781,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -11200,7 +10798,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11347,7 +10945,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",
@@ -11557,21 +11154,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11583,12 +11165,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12353,14 +11929,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12368,7 +11936,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12376,7 +11944,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12390,17 +11957,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12408,9 +11971,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12474,18 +12034,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12499,25 +12051,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -12528,12 +12061,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -13038,27 +12565,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -13069,30 +12604,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -13104,21 +12646,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -13128,14 +12673,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -13160,14 +12705,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -13177,7 +12722,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13324,7 +12869,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",
@@ -13534,21 +13078,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -13560,12 +13089,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-server-gateway/dependencies.lock
+++ b/titus-server-gateway/dependencies.lock
@@ -127,14 +127,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -142,7 +134,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -150,7 +142,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -164,25 +155,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -241,18 +225,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -262,31 +238,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -623,27 +574,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -654,30 +613,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -687,21 +653,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -711,14 +680,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -743,13 +712,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -873,7 +842,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -924,27 +892,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1362,14 +1309,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1377,7 +1316,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1385,7 +1324,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1399,25 +1337,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1476,18 +1407,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1497,31 +1420,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1858,27 +1756,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1889,30 +1795,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1922,21 +1835,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1946,14 +1862,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1978,13 +1894,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2108,7 +2024,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2159,27 +2074,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -2597,14 +2491,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2612,7 +2498,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2620,7 +2506,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2634,25 +2519,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2711,18 +2589,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2732,31 +2602,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3093,27 +2938,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3124,30 +2977,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3157,21 +3017,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3181,14 +3044,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3213,13 +3076,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3343,7 +3206,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3394,27 +3256,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -3896,14 +3737,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3911,7 +3744,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3919,7 +3752,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3933,25 +3765,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4010,18 +3835,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -4031,31 +3848,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4392,27 +4184,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4423,30 +4223,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4456,21 +4263,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4480,14 +4290,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4512,13 +4322,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4642,7 +4452,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4693,27 +4502,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -5132,14 +4920,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5147,7 +4927,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5155,7 +4935,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5169,25 +4948,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5246,18 +5018,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -5267,31 +5031,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5628,27 +5367,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5659,30 +5406,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -5692,21 +5446,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5716,14 +5473,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5748,13 +5505,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5878,7 +5635,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5929,27 +5685,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6495,14 +6230,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6510,7 +6237,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6518,7 +6245,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6532,17 +6258,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -6550,9 +6272,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6616,18 +6335,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6641,25 +6352,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6670,12 +6362,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7180,27 +6866,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7211,30 +6905,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7246,21 +6947,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7270,14 +6974,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7302,14 +7006,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7319,7 +7023,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7468,7 +7172,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",
@@ -7677,21 +7380,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7703,12 +7391,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8474,14 +8156,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -8489,7 +8163,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -8497,7 +8171,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -8511,17 +8184,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -8529,9 +8198,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8595,18 +8261,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8620,25 +8278,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8649,12 +8288,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9159,27 +8792,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -9190,30 +8831,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9225,21 +8873,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9249,14 +8900,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9281,14 +8932,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9298,7 +8949,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9447,7 +9098,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",
@@ -9656,21 +9306,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9682,12 +9317,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10453,14 +10082,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10468,7 +10089,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10476,7 +10097,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -10490,17 +10110,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -10508,9 +10124,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10574,18 +10187,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10599,25 +10204,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10628,12 +10214,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -11138,27 +10718,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -11169,30 +10757,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -11204,21 +10799,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -11228,14 +10826,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -11260,14 +10858,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -11277,7 +10875,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11426,7 +11024,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",
@@ -11635,21 +11232,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11661,12 +11243,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12433,14 +12009,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12448,7 +12016,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12456,7 +12024,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12470,17 +12037,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12488,9 +12051,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12554,18 +12114,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12579,25 +12131,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -12608,12 +12141,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -13118,27 +12645,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -13149,30 +12684,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -13184,21 +12726,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -13208,14 +12753,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -13240,14 +12785,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -13257,7 +12802,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13406,7 +12951,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",
@@ -13615,21 +13159,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -13641,12 +13170,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-server-master/dependencies.lock
+++ b/titus-server-master/dependencies.lock
@@ -135,14 +135,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -150,7 +142,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -158,7 +150,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -172,25 +163,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -251,19 +235,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -274,31 +250,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -664,27 +615,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -695,30 +654,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -728,21 +694,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -752,14 +721,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -784,13 +753,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -925,7 +894,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1007,27 +975,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1470,14 +1417,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1485,7 +1424,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1493,7 +1432,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1507,25 +1445,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1586,19 +1517,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -1609,31 +1532,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1999,27 +1897,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2030,30 +1936,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -2063,21 +1976,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2087,14 +2003,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2119,13 +2035,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2260,7 +2176,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2342,27 +2257,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -2805,14 +2699,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2820,7 +2706,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2828,7 +2714,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2842,25 +2727,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2921,19 +2799,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -2944,31 +2814,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3334,27 +3179,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3365,30 +3218,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3398,21 +3258,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3422,14 +3285,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3454,13 +3317,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3595,7 +3458,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3677,27 +3539,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -4204,14 +4045,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4219,7 +4052,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4227,7 +4060,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -4241,25 +4073,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4320,19 +4145,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -4343,31 +4160,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4733,27 +4525,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4764,30 +4564,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4797,21 +4604,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4821,14 +4631,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4853,13 +4663,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4994,7 +4804,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5076,27 +4885,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -5540,14 +5328,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5555,7 +5335,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5563,7 +5343,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5577,25 +5356,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5656,19 +5428,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -5679,31 +5443,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6069,27 +5808,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6100,30 +5847,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -6133,21 +5887,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -6157,14 +5914,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -6189,13 +5946,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -6330,7 +6087,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6412,27 +6168,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6994,14 +6729,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7009,7 +6736,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7017,7 +6744,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -7031,17 +6757,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -7049,9 +6771,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7116,19 +6835,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7142,25 +6853,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -7171,12 +6863,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7674,27 +7360,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7705,30 +7399,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7740,21 +7441,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7764,14 +7468,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7796,14 +7500,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7813,7 +7517,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7964,7 +7668,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -8188,21 +7891,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -8214,12 +7902,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -9022,14 +8704,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -9037,7 +8711,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -9045,7 +8719,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -9059,17 +8732,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -9077,9 +8746,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9144,19 +8810,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9170,25 +8828,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -9199,12 +8838,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9702,27 +9335,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -9733,30 +9374,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9768,21 +9416,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9792,14 +9443,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9824,14 +9475,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9841,7 +9492,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9992,7 +9643,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -10216,21 +9866,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -10242,12 +9877,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -11050,14 +10679,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -11065,7 +10686,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -11073,7 +10694,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -11087,17 +10707,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -11105,9 +10721,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11172,19 +10785,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11198,25 +10803,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -11227,12 +10813,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -11730,27 +11310,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -11761,30 +11349,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -11796,21 +11391,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -11820,14 +11418,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -11852,14 +11450,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -11869,7 +11467,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -12020,7 +11618,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -12244,21 +11841,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -12270,12 +11852,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -13079,14 +12655,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -13094,7 +12662,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -13102,7 +12670,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -13116,17 +12683,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -13134,9 +12697,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -13201,19 +12761,11 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -13227,25 +12779,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -13256,12 +12789,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -13759,27 +13286,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -13790,30 +13325,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -13825,21 +13367,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -13849,14 +13394,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -13881,14 +13426,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -13898,7 +13443,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -14049,7 +13594,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -14273,21 +13817,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -14299,12 +13828,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/MoveTaskTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/MoveTaskTest.java
@@ -105,7 +105,8 @@ public class MoveTaskTest {
             sourceJobBuilder.moveTask(0, 0, sourceJobId, targetJobId);
         } catch (JobManagerException e) {
             assertThat(e.getErrorCode()).isEqualTo(JobManagerException.ErrorCode.JobsNotCompatible);
-            assertThat(e.getMessage()).contains("container.image.name");
+            // TODO(fabio): re-enable assertion when proper diffing is added
+            // assertThat(e.getMessage()).contains("container.image.name");
         }
     }
 

--- a/titus-server-runtime/dependencies.lock
+++ b/titus-server-runtime/dependencies.lock
@@ -123,14 +123,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -138,7 +130,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -146,7 +138,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -160,25 +151,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -237,18 +221,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -258,31 +234,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -595,27 +546,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -626,30 +585,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -659,21 +625,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -683,14 +652,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -715,13 +684,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -841,7 +810,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -892,27 +860,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1316,14 +1263,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1331,7 +1270,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1339,7 +1278,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1353,25 +1291,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1430,18 +1361,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1451,31 +1374,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1788,27 +1686,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1819,30 +1725,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1852,21 +1765,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1876,14 +1792,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1908,13 +1824,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2034,7 +1950,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2085,27 +2000,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -2509,14 +2403,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2524,7 +2410,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2532,7 +2418,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2546,25 +2431,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2623,18 +2501,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2644,31 +2514,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2981,27 +2826,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3012,30 +2865,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3045,21 +2905,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3069,14 +2932,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3101,13 +2964,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3227,7 +3090,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3278,27 +3140,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -3766,14 +3607,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3781,7 +3614,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3789,7 +3622,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3803,25 +3635,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3880,18 +3705,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3901,31 +3718,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4238,27 +4030,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4269,30 +4069,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4302,21 +4109,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4326,14 +4136,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4358,13 +4168,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4484,7 +4294,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4535,27 +4344,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -4960,14 +4748,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4975,7 +4755,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4983,7 +4763,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -4997,25 +4776,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5074,18 +4846,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -5095,31 +4859,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5432,27 +5171,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5463,30 +5210,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -5496,21 +5250,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5520,14 +5277,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5552,13 +5309,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5678,7 +5435,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5729,27 +5485,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6283,14 +6018,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6298,7 +6025,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6306,7 +6033,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6320,17 +6046,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -6338,9 +6060,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6404,18 +6123,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6429,25 +6140,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6458,12 +6150,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -6946,27 +6632,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6977,30 +6671,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7012,21 +6713,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7036,14 +6740,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7068,14 +6772,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7085,7 +6789,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7234,7 +6938,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7441,21 +7144,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7467,12 +7155,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8236,14 +7918,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -8251,7 +7925,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -8259,7 +7933,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -8273,17 +7946,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -8291,9 +7960,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8357,18 +8023,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8382,25 +8040,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8411,12 +8050,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -8899,27 +8532,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8930,30 +8571,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -8965,21 +8613,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -8989,14 +8640,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9021,14 +8672,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9038,7 +8689,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9187,7 +8838,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9394,21 +9044,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9420,12 +9055,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10189,14 +9818,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10204,7 +9825,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10212,7 +9833,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -10226,17 +9846,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -10244,9 +9860,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10310,18 +9923,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10335,25 +9940,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10364,12 +9950,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -10852,27 +10432,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -10883,30 +10471,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -10918,21 +10513,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -10942,14 +10540,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -10974,14 +10572,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -10991,7 +10589,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11140,7 +10738,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11347,21 +10944,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11373,12 +10955,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12143,14 +11719,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12158,7 +11726,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12166,7 +11734,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12180,17 +11747,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12198,9 +11761,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12264,18 +11824,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12289,25 +11841,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -12318,12 +11851,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -12806,27 +12333,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -12837,30 +12372,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -12872,21 +12414,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -12896,14 +12441,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -12928,14 +12473,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -12945,7 +12490,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13094,7 +12639,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13301,21 +12845,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -13327,12 +12856,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-supplementary-component/task-relocation-springboot/dependencies.lock
+++ b/titus-supplementary-component/task-relocation-springboot/dependencies.lock
@@ -224,14 +224,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -239,7 +231,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -247,7 +239,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -261,17 +252,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -279,9 +266,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -345,18 +329,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -370,25 +346,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -399,12 +356,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -1174,7 +1125,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -1379,21 +1329,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -1405,12 +1340,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -2141,14 +2070,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2156,7 +2077,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2164,7 +2085,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2178,17 +2098,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -2196,9 +2112,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2262,18 +2175,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -2287,25 +2192,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -2316,12 +2202,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -3098,7 +2978,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -3322,21 +3201,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -3348,12 +3212,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -4136,14 +3994,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4151,7 +4001,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4159,7 +4009,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -4173,17 +4022,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -4191,9 +4036,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4257,18 +4099,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4282,25 +4116,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -4311,12 +4126,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -5093,7 +4902,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -5317,21 +5125,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -5343,12 +5136,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -6193,14 +5980,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6208,7 +5987,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6216,7 +5995,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6230,17 +6008,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -6248,9 +6022,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6314,18 +6085,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6339,25 +6102,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6368,12 +6112,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7143,7 +6881,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7348,21 +7085,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7374,12 +7096,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8111,14 +7827,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -8126,7 +7834,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -8134,7 +7842,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -8148,17 +7855,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -8166,9 +7869,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8232,18 +7932,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8257,25 +7949,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8286,12 +7959,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -9068,7 +8735,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9292,21 +8958,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9318,12 +8969,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10111,14 +9756,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10126,7 +9763,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10134,7 +9771,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -10148,17 +9784,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -10166,9 +9798,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10232,18 +9861,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10257,25 +9878,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10286,12 +9888,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -10923,7 +10519,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11070,7 +10666,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11277,21 +10872,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11303,12 +10883,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12050,14 +11624,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12065,7 +11631,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12073,7 +11639,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12087,17 +11652,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12105,9 +11666,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12171,18 +11729,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12196,25 +11746,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -12225,12 +11756,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -12868,7 +12393,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13016,7 +12541,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13242,21 +12766,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -13268,12 +12777,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -14065,14 +13568,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -14080,7 +13575,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -14088,7 +13583,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -14102,17 +13596,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -14120,9 +13610,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -14186,18 +13673,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -14211,25 +13690,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -14240,12 +13700,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -14877,7 +14331,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -15024,7 +14478,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -15231,21 +14684,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -15257,12 +14695,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -16005,14 +15437,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -16020,7 +15444,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -16028,7 +15452,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -16042,17 +15465,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -16060,9 +15479,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -16126,18 +15542,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -16151,25 +15559,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -16180,12 +15569,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -16823,7 +16206,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -16971,7 +16354,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -17197,21 +16579,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -17223,12 +16590,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-supplementary-component/task-relocation/dependencies.lock
+++ b/titus-supplementary-component/task-relocation/dependencies.lock
@@ -108,14 +108,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -123,7 +115,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -131,7 +123,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -145,25 +136,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -222,18 +206,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -243,31 +219,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -598,27 +549,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -629,30 +588,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -662,21 +628,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -686,14 +655,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -718,13 +687,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -846,7 +815,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -897,27 +865,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -1320,14 +1267,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -1335,7 +1274,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -1343,7 +1282,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -1357,25 +1295,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1434,18 +1365,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1455,31 +1378,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1810,27 +1708,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1841,30 +1747,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -1874,21 +1787,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -1898,14 +1814,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1930,13 +1846,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -2058,7 +1974,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2109,27 +2024,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -2532,14 +2426,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2547,7 +2433,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2555,7 +2441,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2569,25 +2454,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2646,18 +2524,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2667,31 +2537,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3022,27 +2867,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3053,30 +2906,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -3086,21 +2946,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -3110,14 +2973,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -3142,13 +3005,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3270,7 +3133,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3321,27 +3183,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -3808,14 +3649,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -3823,7 +3656,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -3831,7 +3664,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -3845,25 +3677,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3922,18 +3747,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3943,31 +3760,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4298,27 +4090,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4329,30 +4129,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -4362,21 +4169,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4386,14 +4196,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4418,13 +4228,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4546,7 +4356,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4597,27 +4406,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -5021,14 +4809,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -5036,7 +4816,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -5044,7 +4824,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -5058,25 +4837,18 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.github.fge:jackson-coreutils",
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5135,18 +4907,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -5156,31 +4920,6 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
-            ]
-        },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5511,27 +5250,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5542,30 +5289,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.projectreactor.netty:reactor-netty",
@@ -5575,21 +5329,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -5599,14 +5356,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -5631,13 +5388,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5759,7 +5516,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5810,27 +5566,6 @@
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jetty:jetty-http": {
@@ -6362,14 +6097,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6377,7 +6104,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6385,7 +6112,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6399,17 +6125,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -6417,9 +6139,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6483,18 +6202,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6508,25 +6219,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6537,12 +6229,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -7019,27 +6705,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7050,30 +6744,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -7085,21 +6786,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -7109,14 +6813,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -7141,14 +6845,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -7158,7 +6862,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -7305,7 +7009,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7512,21 +7215,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7538,12 +7226,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -8287,14 +7969,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -8302,7 +7976,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -8310,7 +7984,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -8324,17 +7997,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -8342,9 +8011,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8408,18 +8074,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8433,25 +8091,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8462,12 +8101,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -8944,27 +8577,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8975,30 +8616,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -9010,21 +8658,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -9034,14 +8685,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -9066,14 +8717,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -9083,7 +8734,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -9230,7 +8881,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9437,21 +9087,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9463,12 +9098,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -10212,14 +9841,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -10227,7 +9848,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -10235,7 +9856,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -10249,17 +9869,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -10267,9 +9883,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10333,18 +9946,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10358,25 +9963,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -10387,12 +9973,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -10869,27 +10449,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -10900,30 +10488,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -10935,21 +10530,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -10959,14 +10557,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -10991,14 +10589,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -11008,7 +10606,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -11155,7 +10753,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11362,21 +10959,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -11388,12 +10970,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -12138,14 +11714,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -12153,7 +11721,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -12161,7 +11729,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -12175,17 +11742,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -12193,9 +11756,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12259,18 +11819,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12284,25 +11836,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -12313,12 +11846,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -12795,27 +12322,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -12826,30 +12361,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -12861,21 +12403,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -12885,14 +12430,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -12917,14 +12462,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -12934,7 +12479,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -13081,7 +12626,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13288,21 +12832,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -13314,12 +12843,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {

--- a/titus-testkit/dependencies.lock
+++ b/titus-testkit/dependencies.lock
@@ -246,14 +246,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -261,7 +253,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -269,7 +261,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -283,17 +274,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -301,9 +288,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -367,18 +351,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -392,25 +368,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -421,12 +378,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -884,27 +835,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -915,30 +874,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -950,21 +916,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -974,14 +943,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -1006,14 +975,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1165,7 +1134,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -1366,21 +1334,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -1392,12 +1345,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -2139,14 +2086,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -2154,7 +2093,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -2162,7 +2101,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -2176,17 +2114,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -2194,9 +2128,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2260,18 +2191,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -2285,25 +2208,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -2314,12 +2218,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -2777,27 +2675,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2808,30 +2714,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -2843,21 +2756,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -2867,14 +2783,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -2899,14 +2815,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3058,7 +2974,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -3259,21 +3174,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -3285,12 +3185,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -4032,14 +3926,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -4047,7 +3933,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -4055,7 +3941,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -4069,17 +3954,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -4087,9 +3968,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4153,18 +4031,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4178,25 +4048,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -4207,12 +4058,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -4670,27 +4515,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4701,30 +4554,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -4736,21 +4596,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -4760,14 +4623,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -4792,14 +4655,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -4951,7 +4814,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -5152,21 +5014,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -5178,12 +5025,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -5989,14 +5830,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -6004,7 +5837,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -6012,7 +5845,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -6026,17 +5858,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -6044,9 +5872,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6110,18 +5935,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6135,25 +5952,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -6164,12 +5962,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -6627,27 +6419,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6658,30 +6458,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -6693,21 +6500,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -6717,14 +6527,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -6749,14 +6559,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -6908,7 +6718,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7109,21 +6918,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -7135,12 +6929,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -7883,14 +7671,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -7898,7 +7678,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -7906,7 +7686,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -7920,17 +7699,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -7938,9 +7713,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8004,18 +7776,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8029,25 +7793,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -8058,12 +7803,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -8521,27 +8260,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -8552,30 +8299,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -8587,21 +8341,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -8611,14 +8368,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -8643,14 +8400,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -8802,7 +8559,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9003,21 +8759,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -9029,12 +8770,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -9783,14 +9518,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -9798,7 +9525,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -9806,7 +9533,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -9820,17 +9546,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -9838,9 +9560,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9904,18 +9623,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9929,25 +9640,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -9958,12 +9650,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -10425,27 +10111,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -10456,30 +10150,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -10491,21 +10192,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -10515,14 +10219,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -10547,14 +10251,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -10564,7 +10268,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -10711,7 +10415,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -10912,21 +10615,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -10938,12 +10626,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -11695,14 +11377,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -11710,7 +11384,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -11718,7 +11392,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -11732,17 +11405,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -11750,9 +11419,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11816,18 +11482,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11841,25 +11499,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -11870,12 +11509,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -12337,27 +11970,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -12368,30 +12009,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -12403,21 +12051,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -12427,14 +12078,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -12459,14 +12110,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -12476,7 +12127,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -12623,7 +12274,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -12824,21 +12474,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -12850,12 +12485,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -13607,14 +13236,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -13622,7 +13243,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -13630,7 +13251,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -13644,17 +13264,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -13662,9 +13278,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -13728,18 +13341,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -13753,25 +13358,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -13782,12 +13368,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -14249,27 +13829,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -14280,30 +13868,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -14315,21 +13910,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -14339,14 +13937,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -14371,14 +13969,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -14388,7 +13986,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -14535,7 +14133,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -14736,21 +14333,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -14762,12 +14344,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {
@@ -15520,14 +15096,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.auto.value:auto-value-annotations": {
-            "locked": "1.6.2",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.1",
             "transitive": [
@@ -15535,7 +15103,7 @@
             ]
         },
         "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
+            "locked": "3.0.0",
             "transitive": [
                 "com.github.fge:btf",
                 "com.github.fge:jackson-coreutils",
@@ -15543,7 +15111,6 @@
                 "com.github.fge:json-schema-validator",
                 "com.github.fge:msg-simple",
                 "com.github.fge:uri-template",
-                "com.google.guava:guava",
                 "com.twitter:util-cache_2.11",
                 "com.twitter:util-collection_2.11",
                 "io.grpc:grpc-core"
@@ -15557,17 +15124,13 @@
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.3.1",
+            "locked": "2.1.2",
             "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
         "com.google.guava:guava": {
-            "locked": "25.1-android",
+            "locked": "20.0",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.datastax.cassandra:cassandra-driver-extras",
@@ -15575,9 +15138,6 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -15641,18 +15201,10 @@
                 "com.sun.jersey.contribs:jersey-guice"
             ]
         },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
-            "locked": "3.6.0",
+            "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -15666,25 +15218,6 @@
                 "io.grpc:grpc-protobuf"
             ]
         },
-        "com.google.truth.extensions:truth-liteproto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
-        "com.google.truth.extensions:truth-proto-extension": {
-            "locked": "0.42",
-            "transitive": [
-                "com.netflix.titus:titus-common"
-            ]
-        },
-        "com.google.truth:truth": {
-            "locked": "0.42",
-            "transitive": [
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension"
-            ]
-        },
         "com.googlecode.concurrent-trees:concurrent-trees": {
             "locked": "2.4.0",
             "transitive": [
@@ -15695,12 +15228,6 @@
             "locked": "1.4",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "com.googlecode.java-diff-utils:diffutils": {
-            "locked": "1.3.0",
-            "transitive": [
-                "com.google.truth:truth"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -16162,27 +15689,35 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -16193,30 +15728,37 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy",
                 "org.mock-server:mockserver-core"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
                 "io.netty:netty-resolver",
+                "io.netty:netty-transport",
                 "io.netty:netty-transport-native-epoll",
                 "io.netty:netty-transport-native-unix-common",
                 "org.mock-server:mockserver-netty"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core",
                 "io.netty:netty-codec-http2",
@@ -16228,21 +15770,24 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-codec",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
                 "io.netty:netty-transport-native-epoll",
@@ -16252,14 +15797,14 @@
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.reactivex:rxnetty"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.32.Final",
+            "locked": "4.1.33.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
@@ -16284,14 +15829,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "0.8.4.RELEASE",
+            "locked": "0.8.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.2.5.RELEASE",
+            "locked": "3.2.6.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -16301,7 +15846,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.1.14.RELEASE",
+            "locked": "3.1.15.RELEASE",
             "requested": "3.1.+"
         },
         "io.reactivex.rxjava2:rxjava": {
@@ -16448,7 +15993,6 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
-                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -16649,21 +16193,6 @@
                 "com.netflix.titus:titus-ext-cassandra-testkit"
             ]
         },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.guava:guava",
-                "com.google.truth.extensions:truth-liteproto-extension",
-                "com.google.truth.extensions:truth-proto-extension",
-                "com.google.truth:truth"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "2.5.3",
-            "transitive": [
-                "com.google.truth:truth"
-            ]
-        },
         "org.codehaus.jackson:jackson-core-asl": {
             "locked": "1.9.2",
             "transitive": [
@@ -16675,12 +16204,6 @@
             "locked": "1.9.2",
             "transitive": [
                 "org.apache.cassandra:cassandra-all"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         },
         "org.eclipse.jdt.core.compiler:ecj": {


### PR DESCRIPTION
... and temporarily disable full diffing of JobDescriptor protobufs on job compatibility violations. This will provide a less nice message on validation errors for the `MoveTask` operation.

`google-truth` requires a more recent version of guava that is incompatible with Curator. A future PR will re-introduce the diff without causing transitive dependency incompatibilities.