### PR TITLE
try google truth again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects {
         protobufVersion = '3.5.+'
         postgresqlVersion = '9.4.+'
         grpcVersion = '1.10.+'
-        googleTruthVersion = '0.42+'
+        googleTruthVersion = '0.34' // pinned to avoid a transitive dependency on guava > 20.x
         swaggerVersion = '1.5.12'
         jsonVersion = '20140107'
         zkVersion = '0.4'

--- a/titus-api/dependencies.lock
+++ b/titus-api/dependencies.lock
@@ -72,6 +72,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -80,6 +83,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -119,6 +125,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -127,6 +135,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -413,6 +440,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -429,6 +462,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -595,6 +634,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -603,6 +645,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -642,6 +687,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -650,6 +697,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -936,6 +1002,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -952,6 +1024,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1118,6 +1196,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1126,6 +1207,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1165,6 +1249,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1173,6 +1259,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1459,6 +1564,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1475,6 +1586,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1705,6 +1822,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1713,6 +1833,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1752,6 +1875,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1760,6 +1885,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2046,6 +2190,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2062,6 +2212,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2229,6 +2385,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2237,6 +2396,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2276,6 +2438,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2284,6 +2448,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2570,6 +2753,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2586,6 +2775,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2963,6 +3158,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2975,6 +3173,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3042,6 +3243,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3053,6 +3256,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -3845,6 +4067,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -4850,6 +5073,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4862,6 +5088,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4929,6 +5158,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4940,6 +5171,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -5732,6 +5982,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -6737,6 +6988,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6749,6 +7003,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6816,6 +7073,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6827,6 +7086,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7619,6 +7897,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -8625,6 +8904,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8637,6 +8919,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8704,6 +8989,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8715,6 +9002,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -9507,6 +9813,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-common/build.gradle
+++ b/titus-common/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
+    // Protobuf validation
+    compile "com.google.truth.extensions:truth-proto-extension:${googleTruthVersion}"
 
     compile "com.github.akarnokd:rxjava2-interop:${rxJavaInteropVersion}"
 

--- a/titus-common/dependencies.lock
+++ b/titus-common/dependencies.lock
@@ -66,6 +66,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -75,6 +78,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -114,6 +120,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -121,6 +129,23 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34"
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -376,6 +401,12 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
@@ -385,6 +416,12 @@
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
+            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -526,6 +563,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -535,6 +575,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -574,6 +617,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -581,6 +626,23 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34"
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -836,6 +898,12 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.3.2",
             "transitive": [
@@ -845,6 +913,12 @@
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
+            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -986,6 +1060,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -995,6 +1072,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -1034,6 +1114,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -1041,6 +1123,23 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34"
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1296,6 +1395,12 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1311,6 +1416,12 @@
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
+            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -1520,6 +1631,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1529,6 +1643,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -1568,6 +1685,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -1575,6 +1694,23 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34"
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1830,6 +1966,12 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1845,6 +1987,12 @@
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
+            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -1991,6 +2139,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2000,6 +2151,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
                 "io.grpc:grpc-protobuf-lite",
@@ -2039,6 +2193,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "io.grpc:grpc-protobuf"
             ]
         },
@@ -2046,6 +2202,23 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34"
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2301,6 +2474,12 @@
             "locked": "1.1.1",
             "requested": "1.1.1"
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2316,6 +2495,12 @@
         "org.glassfish:javax.el": {
             "locked": "3.0.1-b11",
             "requested": "3.+"
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
+            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.11",
@@ -2682,6 +2867,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2695,6 +2883,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2763,6 +2954,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -2774,6 +2967,26 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -3587,6 +3800,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -4604,6 +4818,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4617,6 +4834,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4685,6 +4905,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4696,6 +4918,26 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -5509,6 +5751,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -6526,6 +6769,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6539,6 +6785,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6607,6 +6856,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6618,6 +6869,26 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7431,6 +7702,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -8449,6 +8721,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8462,6 +8737,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8530,6 +8808,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8541,6 +8821,26 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "requested": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -9354,6 +9654,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.squareup.okhttp3:mockwebserver",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"

--- a/titus-common/src/test/java/com/netflix/titus/common/util/ProtobufDiffTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/ProtobufDiffTest.java
@@ -19,7 +19,6 @@ package com.netflix.titus.common.util;
 import java.util.Optional;
 
 import com.google.protobuf.Message;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,8 +35,6 @@ public class ProtobufDiffTest {
         assertThat(ProtobufExt.diffReport(composed1, composed2)).isNotPresent();
     }
 
-    // TODO(fabio): re-enable with a proper diff-ing implementation
-    @Ignore
     @Test
     public void testTopLevelDifferences() {
         Message one = ProtoMessageBuilder.newInner("value1", "value2");
@@ -57,8 +54,6 @@ public class ProtobufDiffTest {
         );
     }
 
-    // TODO(fabio): re-enable with a proper diff-ing implementation
-    @Ignore
     @Test
     public void testNestedDifferences() {
         Message one = ProtoMessageBuilder.newInner("value1", "value2");

--- a/titus-ext/aws/dependencies.lock
+++ b/titus-ext/aws/dependencies.lock
@@ -121,6 +121,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -129,6 +132,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -168,6 +174,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -176,6 +184,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -497,6 +524,12 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -525,6 +558,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -748,6 +787,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -756,6 +798,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -795,6 +840,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -803,6 +850,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1124,6 +1190,12 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1152,6 +1224,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1375,6 +1453,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1383,6 +1464,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1422,6 +1506,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1430,6 +1516,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1751,6 +1856,12 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1779,6 +1890,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2066,6 +2183,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2074,6 +2194,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2113,6 +2236,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2121,6 +2246,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2442,6 +2586,12 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2470,6 +2620,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2694,6 +2850,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2702,6 +2861,9 @@
             "transitive": [
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2741,6 +2903,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2749,6 +2913,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -3070,6 +3253,12 @@
                 "com.amazonaws:aws-java-sdk-core"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -3098,6 +3287,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -3532,6 +3727,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3544,6 +3742,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3611,6 +3812,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3622,6 +3825,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -4433,6 +4655,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -5505,6 +5728,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5517,6 +5743,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5584,6 +5813,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5595,6 +5826,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -6406,6 +6656,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7478,6 +7729,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7490,6 +7744,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7557,6 +7814,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7568,6 +7827,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8379,6 +8657,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9452,6 +9731,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9464,6 +9746,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9531,6 +9816,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9542,6 +9829,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10353,6 +10659,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-ext/cassandra-testkit/dependencies.lock
+++ b/titus-ext/cassandra-testkit/dependencies.lock
@@ -159,6 +159,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -169,6 +172,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -211,6 +217,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -219,6 +227,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -605,6 +632,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -1068,6 +1096,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1078,6 +1109,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1120,6 +1154,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1128,6 +1164,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -1514,6 +1569,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -1977,6 +2033,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1987,6 +2046,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2029,6 +2091,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2037,6 +2101,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -2423,6 +2506,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -2950,6 +3034,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2960,6 +3047,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -3002,6 +3092,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -3010,6 +3102,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -3396,6 +3507,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -3860,6 +3972,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3870,6 +3985,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -3912,6 +4030,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -3920,6 +4040,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -4306,6 +4445,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -4776,6 +4916,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4786,6 +4929,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -4828,6 +4974,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -4836,6 +4984,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -5231,6 +5398,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -5735,6 +5903,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5745,6 +5916,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -5787,6 +5961,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -5795,6 +5971,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -6190,6 +6385,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -6694,6 +6890,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6704,6 +6903,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -6746,6 +6948,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -6754,6 +6958,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7149,6 +7372,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },
@@ -7654,6 +7878,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7664,6 +7891,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -7706,6 +7936,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -7714,6 +7946,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8109,6 +8360,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit"
             ]
         },

--- a/titus-ext/cassandra/dependencies.lock
+++ b/titus-ext/cassandra/dependencies.lock
@@ -114,6 +114,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -124,6 +127,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -163,6 +169,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -171,6 +179,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -473,6 +500,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -489,6 +522,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -735,6 +774,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -745,6 +787,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -784,6 +829,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -792,6 +839,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1094,6 +1160,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1110,6 +1182,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1356,6 +1434,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1366,6 +1447,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -1405,6 +1489,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -1413,6 +1499,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -1715,6 +1820,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -1731,6 +1842,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2041,6 +2158,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2051,6 +2171,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2090,6 +2213,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2098,6 +2223,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -2400,6 +2544,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -2416,6 +2566,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2663,6 +2819,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2673,6 +2832,9 @@
                 "com.datastax.cassandra:cassandra-driver-extras",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-core",
                 "io.grpc:grpc-protobuf",
@@ -2712,6 +2874,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "io.grpc:grpc-protobuf"
             ]
@@ -2720,6 +2884,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.netflix.archaius:archaius2-api": {
@@ -3022,6 +3205,12 @@
                 "com.netflix.titus:titus-common"
             ]
         },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.google.truth:truth"
+            ]
+        },
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
@@ -3038,6 +3227,12 @@
             "locked": "3.0.1-b11",
             "transitive": [
                 "com.netflix.titus:titus-common"
+            ]
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3",
+            "transitive": [
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -3455,6 +3650,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3467,6 +3665,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3534,6 +3735,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3545,6 +3748,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -4337,6 +4559,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -5345,6 +5568,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5357,6 +5583,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5424,6 +5653,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5435,6 +5666,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -6227,6 +6477,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7235,6 +7486,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7247,6 +7501,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7314,6 +7571,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7325,6 +7584,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8117,6 +8395,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9126,6 +9405,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9138,6 +9420,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9205,6 +9490,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9216,6 +9503,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10008,6 +10314,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-ext/elasticsearch/dependencies.lock
+++ b/titus-ext/elasticsearch/dependencies.lock
@@ -189,6 +189,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -199,6 +202,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -264,6 +270,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -275,6 +283,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -958,6 +985,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1655,6 +1683,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1665,6 +1696,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1730,6 +1764,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -1741,6 +1777,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2424,6 +2479,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3121,6 +3177,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3131,6 +3190,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3196,6 +3258,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3207,6 +3271,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3890,6 +3973,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4651,6 +4735,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4661,6 +4748,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4726,6 +4816,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4737,6 +4829,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5420,6 +5531,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6118,6 +6230,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6128,6 +6243,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6193,6 +6311,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6204,6 +6324,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6887,6 +7026,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -7591,6 +7731,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7601,6 +7744,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7666,6 +7812,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7677,6 +7825,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -8369,6 +8536,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -9113,6 +9281,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9123,6 +9294,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9188,6 +9362,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9199,6 +9375,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -9891,6 +10086,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -10635,6 +10831,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -10645,6 +10844,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10710,6 +10912,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10721,6 +10925,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -11413,6 +11636,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -12158,6 +12382,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -12168,6 +12395,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12233,6 +12463,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12244,6 +12476,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -12936,6 +13187,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },

--- a/titus-ext/eureka/dependencies.lock
+++ b/titus-ext/eureka/dependencies.lock
@@ -195,6 +195,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -205,6 +208,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -273,6 +279,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -284,6 +292,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1014,6 +1041,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1662,6 +1690,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1672,6 +1703,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -1740,6 +1774,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -1751,6 +1787,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2481,6 +2536,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3129,6 +3185,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3139,6 +3198,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -3207,6 +3269,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -3218,6 +3282,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3948,6 +4031,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4660,6 +4744,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4670,6 +4757,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -4738,6 +4828,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4749,6 +4841,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5479,6 +5590,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6128,6 +6240,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6138,6 +6253,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -6206,6 +6324,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6217,6 +6337,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6947,6 +7086,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -7704,6 +7844,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7716,6 +7859,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -7787,6 +7933,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7798,6 +7946,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8664,6 +8831,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9738,6 +9906,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9750,6 +9921,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -9821,6 +9995,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9832,6 +10008,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10698,6 +10893,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11772,6 +11968,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -11784,6 +11983,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -11855,6 +12057,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11866,6 +12070,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -12732,6 +12955,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13807,6 +14031,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -13819,6 +14046,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius-core",
                 "com.netflix.netflix-commons:netflix-infix",
                 "com.netflix.servo:servo-core",
@@ -13890,6 +14120,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -13901,6 +14133,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -14767,6 +15018,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-ext/jooq/dependencies.lock
+++ b/titus-ext/jooq/dependencies.lock
@@ -138,6 +138,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -148,6 +151,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -210,6 +216,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -219,6 +227,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -827,6 +854,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1336,6 +1364,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1346,6 +1377,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1408,6 +1442,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1417,6 +1453,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2025,6 +2080,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2534,6 +2590,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2544,6 +2603,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2606,6 +2668,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2615,6 +2679,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3223,6 +3306,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3824,6 +3908,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3834,6 +3921,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3896,6 +3986,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3905,6 +3997,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4513,6 +4624,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5023,6 +5135,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5033,6 +5148,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5095,6 +5213,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -5104,6 +5224,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5712,6 +5851,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6366,6 +6506,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6378,6 +6521,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6445,6 +6591,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6456,6 +6604,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7258,6 +7425,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -8294,6 +8462,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8306,6 +8477,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8373,6 +8547,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8384,6 +8560,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -9186,6 +9381,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -10222,6 +10418,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -10234,6 +10433,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10301,6 +10503,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10312,6 +10516,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -11114,6 +11337,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -12151,6 +12375,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -12163,6 +12390,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12230,6 +12460,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12241,6 +12473,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -13043,6 +13294,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-ext/zookeeper/dependencies.lock
+++ b/titus-ext/zookeeper/dependencies.lock
@@ -167,6 +167,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -177,6 +180,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -241,6 +247,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -252,6 +260,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -908,6 +935,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1469,6 +1497,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1479,6 +1510,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1543,6 +1577,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -1554,6 +1590,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2210,6 +2265,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2771,6 +2827,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2781,6 +2840,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2845,6 +2907,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -2856,6 +2920,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3512,6 +3595,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4137,6 +4221,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4147,6 +4234,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4211,6 +4301,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4222,6 +4314,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4878,6 +4989,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5440,6 +5552,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5450,6 +5565,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5514,6 +5632,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5525,6 +5645,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6181,6 +6320,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6862,6 +7002,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6874,6 +7017,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6941,6 +7087,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6952,6 +7100,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7744,6 +7911,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -8757,6 +8925,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8769,6 +8940,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8836,6 +9010,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8847,6 +9023,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -9639,6 +9834,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -10652,6 +10848,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -10664,6 +10863,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10731,6 +10933,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10742,6 +10946,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -11534,6 +11757,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
@@ -12548,6 +12772,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -12560,6 +12787,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12627,6 +12857,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12638,6 +12870,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -13430,6 +13681,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "jline:jline",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"

--- a/titus-server-federation/dependencies.lock
+++ b/titus-server-federation/dependencies.lock
@@ -153,6 +153,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -163,6 +166,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -225,6 +231,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -234,6 +242,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -830,6 +857,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1321,6 +1349,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1331,6 +1362,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1393,6 +1427,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1402,6 +1438,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1998,6 +2053,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2489,6 +2545,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2499,6 +2558,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2561,6 +2623,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2570,6 +2634,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3166,6 +3249,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3721,6 +3805,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3731,6 +3818,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3793,6 +3883,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3802,6 +3894,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4398,6 +4509,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4890,6 +5002,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4900,6 +5015,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4962,6 +5080,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -4971,6 +5091,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5567,6 +5706,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6189,6 +6329,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6201,6 +6344,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6268,6 +6414,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6279,6 +6427,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7099,6 +7266,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",
@@ -8112,6 +8280,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8124,6 +8295,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8191,6 +8365,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8202,6 +8378,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -9022,6 +9217,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",
@@ -10035,6 +10231,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -10047,6 +10246,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10114,6 +10316,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10125,6 +10329,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10945,6 +11168,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",
@@ -11959,6 +12183,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -11971,6 +12198,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12038,6 +12268,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12049,6 +12281,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -12869,6 +13120,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "io.grpc:grpc-testing",

--- a/titus-server-gateway/dependencies.lock
+++ b/titus-server-gateway/dependencies.lock
@@ -157,6 +157,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -167,6 +170,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -229,6 +235,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -238,6 +246,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -842,6 +869,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1339,6 +1367,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1349,6 +1380,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1411,6 +1445,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1420,6 +1456,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2024,6 +2079,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2521,6 +2577,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2531,6 +2590,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2593,6 +2655,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2602,6 +2666,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3206,6 +3289,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3767,6 +3851,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3777,6 +3864,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3839,6 +3929,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3848,6 +3940,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4452,6 +4563,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4950,6 +5062,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4960,6 +5075,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5022,6 +5140,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -5031,6 +5151,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5635,6 +5774,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6260,6 +6400,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6272,6 +6415,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6339,6 +6485,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6350,6 +6498,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7172,6 +7339,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",
@@ -8186,6 +8354,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8198,6 +8369,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8265,6 +8439,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8276,6 +8452,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -9098,6 +9293,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",
@@ -10112,6 +10308,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -10124,6 +10323,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10191,6 +10393,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10202,6 +10406,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -11024,6 +11247,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",
@@ -12039,6 +12263,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -12051,6 +12278,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12118,6 +12348,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12129,6 +12361,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -12951,6 +13202,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "com.netflix.archaius:archaius2-test",
                 "com.netflix.governator:governator-test-junit",
                 "org.cassandraunit:cassandra-unit",

--- a/titus-server-master/dependencies.lock
+++ b/titus-server-master/dependencies.lock
@@ -165,6 +165,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -175,6 +178,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -240,6 +246,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -250,6 +258,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -894,6 +921,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1447,6 +1475,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1457,6 +1488,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1522,6 +1556,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -1532,6 +1568,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -2176,6 +2231,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2729,6 +2785,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2739,6 +2798,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2804,6 +2866,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -2814,6 +2878,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3458,6 +3541,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4075,6 +4159,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4085,6 +4172,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4150,6 +4240,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -4160,6 +4252,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4804,6 +4915,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -5358,6 +5470,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5368,6 +5483,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5433,6 +5551,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf",
@@ -5443,6 +5563,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -6087,6 +6226,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6759,6 +6899,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6771,6 +6914,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6840,6 +6986,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6851,6 +6999,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7668,6 +7835,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -8734,6 +8902,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8746,6 +8917,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8815,6 +8989,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8826,6 +9002,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -9643,6 +9838,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -10709,6 +10905,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -10721,6 +10920,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -10790,6 +10992,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -10801,6 +11005,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -11618,6 +11841,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -12685,6 +12909,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -12697,6 +12924,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -12766,6 +12996,8 @@
             "requested": "3.5.+",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -12777,6 +13009,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -13594,6 +13845,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty",
                 "org.springframework.boot:spring-boot-starter-test"

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/MoveTaskTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/MoveTaskTest.java
@@ -105,8 +105,7 @@ public class MoveTaskTest {
             sourceJobBuilder.moveTask(0, 0, sourceJobId, targetJobId);
         } catch (JobManagerException e) {
             assertThat(e.getErrorCode()).isEqualTo(JobManagerException.ErrorCode.JobsNotCompatible);
-            // TODO(fabio): re-enable assertion when proper diffing is added
-            // assertThat(e.getMessage()).contains("container.image.name");
+            assertThat(e.getMessage()).contains("container.image.name");
         }
     }
 

--- a/titus-server-runtime/dependencies.lock
+++ b/titus-server-runtime/dependencies.lock
@@ -153,6 +153,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -163,6 +166,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -225,6 +231,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -234,6 +242,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -810,6 +837,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1293,6 +1321,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1303,6 +1334,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1365,6 +1399,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1374,6 +1410,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1950,6 +2005,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2433,6 +2489,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2443,6 +2502,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2505,6 +2567,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2514,6 +2578,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3090,6 +3173,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3637,6 +3721,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3647,6 +3734,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3709,6 +3799,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3718,6 +3810,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4294,6 +4405,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4778,6 +4890,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4788,6 +4903,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4850,6 +4968,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -4859,6 +4979,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5435,6 +5574,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6048,6 +6188,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6060,6 +6203,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6127,6 +6273,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6138,6 +6286,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -6938,6 +7105,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7948,6 +8116,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7960,6 +8131,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8027,6 +8201,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8038,6 +8214,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8838,6 +9033,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9848,6 +10044,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9860,6 +10059,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9927,6 +10129,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9938,6 +10142,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10738,6 +10961,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11749,6 +11973,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -11761,6 +11988,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11828,6 +12058,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11839,6 +12071,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -12639,6 +12890,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-supplementary-component/task-relocation-springboot/dependencies.lock
+++ b/titus-supplementary-component/task-relocation-springboot/dependencies.lock
@@ -254,6 +254,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -266,6 +269,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -333,6 +339,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -344,6 +352,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -1125,6 +1152,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -2100,6 +2128,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2112,6 +2143,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2179,6 +2213,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -2190,6 +2226,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -2978,6 +3033,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -4024,6 +4080,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4036,6 +4095,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4103,6 +4165,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4114,6 +4178,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -4902,6 +4985,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -6010,6 +6094,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6022,6 +6109,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6089,6 +6179,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6100,6 +6192,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -6881,6 +6992,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7857,6 +7969,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7869,6 +7984,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7936,6 +8054,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7947,6 +8067,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8735,6 +8874,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9786,6 +9926,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9798,6 +9941,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9865,6 +10011,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9876,6 +10024,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10666,6 +10833,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11654,6 +11822,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -11666,6 +11837,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11733,6 +11907,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11744,6 +11920,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -12541,6 +12736,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13598,6 +13794,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -13610,6 +13809,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -13677,6 +13879,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -13688,6 +13892,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -14478,6 +14701,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -15467,6 +15691,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -15479,6 +15706,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -15546,6 +15776,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -15557,6 +15789,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -16354,6 +16605,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-supplementary-component/task-relocation/dependencies.lock
+++ b/titus-supplementary-component/task-relocation/dependencies.lock
@@ -138,6 +138,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -148,6 +151,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -210,6 +216,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -219,6 +227,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -815,6 +842,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -1297,6 +1325,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -1307,6 +1338,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -1369,6 +1403,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -1378,6 +1414,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -1974,6 +2029,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -2456,6 +2512,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2466,6 +2525,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2528,6 +2590,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -2537,6 +2601,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -3133,6 +3216,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -3679,6 +3763,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3689,6 +3776,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -3751,6 +3841,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -3760,6 +3852,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -4356,6 +4467,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -4839,6 +4951,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -4849,6 +4964,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4911,6 +5029,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "io.grpc:grpc-protobuf"
@@ -4920,6 +5040,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
@@ -5516,6 +5655,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.mock-server:mockserver-netty"
             ]
         },
@@ -6127,6 +6267,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -6139,6 +6282,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -6206,6 +6352,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -6217,6 +6365,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -7009,6 +7176,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7999,6 +8167,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -8011,6 +8182,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -8078,6 +8252,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -8089,6 +8265,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8881,6 +9076,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9871,6 +10067,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9883,6 +10082,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9950,6 +10152,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9961,6 +10165,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10753,6 +10976,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11744,6 +11968,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -11756,6 +11983,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11823,6 +12053,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11834,6 +12066,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -12626,6 +12877,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]

--- a/titus-testkit/dependencies.lock
+++ b/titus-testkit/dependencies.lock
@@ -276,6 +276,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -288,6 +291,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -355,6 +361,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -366,6 +374,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -1134,6 +1161,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -2116,6 +2144,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -2128,6 +2159,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -2195,6 +2229,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -2206,6 +2242,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -2974,6 +3029,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -3956,6 +4012,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -3968,6 +4027,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -4035,6 +4097,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -4046,6 +4110,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -4814,6 +4897,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -5860,6 +5944,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -5872,6 +5959,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -5939,6 +6029,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -5950,6 +6042,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -6718,6 +6829,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -7701,6 +7813,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -7713,6 +7828,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -7780,6 +7898,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -7791,6 +7911,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -8559,6 +8698,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -9548,6 +9688,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -9560,6 +9703,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -9627,6 +9773,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -9638,6 +9786,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -10415,6 +10582,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -11407,6 +11575,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -11419,6 +11590,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -11486,6 +11660,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -11497,6 +11673,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -12274,6 +12469,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -13266,6 +13462,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -13278,6 +13477,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -13345,6 +13547,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -13356,6 +13560,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -14133,6 +14356,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]
@@ -15126,6 +15350,9 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.2",
             "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "io.grpc:grpc-core"
             ]
         },
@@ -15138,6 +15365,9 @@
                 "com.github.fge:uri-template",
                 "com.google.inject:guice",
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
+                "com.google.truth:truth",
                 "com.netflix.titus:titus-common",
                 "com.twitter:finagle-core_2.11",
                 "com.twitter:finagle-http_2.11",
@@ -15205,6 +15435,8 @@
             "locked": "3.5.1",
             "transitive": [
                 "com.google.protobuf:protobuf-java-util",
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension",
                 "com.netflix.titus:titus-common",
                 "com.netflix.titus:titus-grpc-api",
                 "com.netflix.titus:titus-server-master",
@@ -15216,6 +15448,25 @@
             "locked": "3.5.1",
             "transitive": [
                 "io.grpc:grpc-protobuf"
+            ]
+        },
+        "com.google.truth.extensions:truth-liteproto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-proto-extension"
+            ]
+        },
+        "com.google.truth.extensions:truth-proto-extension": {
+            "locked": "0.34",
+            "transitive": [
+                "com.netflix.titus:titus-common"
+            ]
+        },
+        "com.google.truth:truth": {
+            "locked": "0.34",
+            "transitive": [
+                "com.google.truth.extensions:truth-liteproto-extension",
+                "com.google.truth.extensions:truth-proto-extension"
             ]
         },
         "com.googlecode.concurrent-trees:concurrent-trees": {
@@ -15993,6 +16244,7 @@
         "junit:junit": {
             "locked": "4.12",
             "transitive": [
+                "com.google.truth:truth",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-netty"
             ]


### PR DESCRIPTION
Pull in an older version that doesn't depend on recent versions of Guava. The older version does what we need it to do, and we don't use any of the functionality in google-truth itself, we only rely on the `ProtobufMessageDifferencer` functionality.