### PR TITLE
Run all integration tests on CI

### DIFF
--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -2,8 +2,8 @@
 # This script will build the project.
 
 if [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
-  echo -e "Running integration tests (PR $TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
-  ./gradlew integrationTest --stacktrace
+  echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
+  ./gradlew testAll --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build --stacktrace


### PR DESCRIPTION
Not all tests were being executed on Travis CI.

@tbak this is why CI didn't catch the transitive dependencies issue a few commits ago.