### PR TITLE
retry builder fix for reactor based unlimited retries

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/rx/RetryHandlerBuilder.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/rx/RetryHandlerBuilder.java
@@ -84,6 +84,7 @@ public final class RetryHandlerBuilder {
 
     public RetryHandlerBuilder withRetryDelay(long retryDelay, TimeUnit timeUnit) {
         Preconditions.checkArgument(retryDelay > 0, "Retry delay must be >0");
+        Preconditions.checkArgument(retryDelay < Integer.MAX_VALUE, "Retry delay should be < Integer.MAX_VALUE");
         this.retryDelayMs = timeUnit.toMillis(retryDelay);
         return this;
     }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/rx/RetryHandlerBuilder.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/rx/RetryHandlerBuilder.java
@@ -150,7 +150,7 @@ public final class RetryHandlerBuilder {
                         );
                         return Observable.error(new IOException(errorMessage, retryItem.cause));
                     }
-                    long expDelay = Math.min(maxDelay, (1 << retryItem.retry) * retryDelayMs);
+                    long expDelay = buildDelay(retryItem.retry);
                     if (retryItem.cause instanceof TimeoutException) {
                         logger.info("Delaying timed-out {} retry by {}[ms]", title, expDelay);
                     } else {
@@ -184,7 +184,7 @@ public final class RetryHandlerBuilder {
                         );
                         return Flux.error(new IOException(errorMessage, retryItem.cause));
                     }
-                    long expDelay = Math.min(maxDelay, (1 << retryItem.retry) * retryDelayMs);
+                    long expDelay = buildDelay(retryItem.retry);
                     if (retryItem.cause instanceof TimeoutException) {
                         logger.info("Delaying timed-out {} retry by {}[ms]", title, expDelay);
                     } else {
@@ -193,6 +193,14 @@ public final class RetryHandlerBuilder {
                     }
                     return Flux.interval(Duration.ofMillis(expDelay), reactorScheduler).take(1);
                 });
+    }
+
+    private long buildDelay(int retry) {
+        final long backOffTime = (1 << retry) * retryDelayMs;
+        if (backOffTime < 0) {
+            return maxDelay;
+        }
+        return Math.min(maxDelay, backOffTime);
     }
 
     public static RetryHandlerBuilder retryHandler() {


### PR DESCRIPTION
### Retry builder logic fix for unlimited retries for reactor stream

Reactor based retry builder code uses FluxInterval to generate timer events. It throws IllegalArgumentException when period < 0. The fix is meant to address this issue