### PR TITLE
Rollback to Curator version 2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
         jacksonVersion = '2.9.+'
         slf4jVersion = '1.7.0'
         cliParserVersion = '1.1.1'
-        curatorVersion = '4.+'
+        curatorVersion = '2.13.+'
         governatorVersion = '1.15.+'
         jettyVersion = '9.2.12.v20150709'
         jerseyVersion = '1.19.1'

--- a/titus-api/dependencies.lock
+++ b/titus-api/dependencies.lock
@@ -3172,7 +3172,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -3646,8 +3645,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -3741,10 +3739,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -4061,7 +4058,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -4160,25 +4156,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -4204,18 +4181,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -4586,10 +4551,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -5071,7 +5034,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -5545,8 +5507,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -5640,10 +5601,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -5960,7 +5920,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -6059,25 +6018,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -6103,18 +6043,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -6485,10 +6413,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6970,7 +6896,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7444,8 +7369,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -7539,10 +7463,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7859,7 +7782,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7958,25 +7880,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -8002,18 +7905,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -8384,10 +8275,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8870,7 +8759,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9344,8 +9232,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -9439,10 +9326,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9759,7 +9645,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9858,25 +9743,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9902,18 +9768,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -10284,10 +10138,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-common/dependencies.lock
+++ b/titus-common/dependencies.lock
@@ -2882,7 +2882,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -3368,8 +3367,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -3466,10 +3464,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -3795,7 +3792,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -3894,25 +3890,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -3938,18 +3915,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -4324,10 +4289,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4817,7 +4780,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -5303,8 +5265,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -5401,10 +5362,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -5730,7 +5690,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -5829,25 +5788,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -5873,18 +5813,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -6259,10 +6187,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6752,7 +6678,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7238,8 +7163,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -7336,10 +7260,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7665,7 +7588,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7764,25 +7686,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7808,18 +7711,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -8194,10 +8085,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8688,7 +8577,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9174,8 +9062,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -9272,10 +9159,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9601,7 +9487,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9700,25 +9585,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9744,18 +9610,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -10130,10 +9984,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-ext/aws/dependencies.lock
+++ b/titus-ext/aws/dependencies.lock
@@ -7,19 +7,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -30,19 +30,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -679,19 +679,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -702,19 +702,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1351,19 +1351,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1374,19 +1374,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2087,19 +2087,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2110,19 +2110,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2760,19 +2760,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2783,19 +2783,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3457,19 +3457,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3480,19 +3480,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3777,7 +3777,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4251,8 +4250,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -4364,10 +4362,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -4685,7 +4682,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -4784,25 +4780,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.5",
             "transitive": [
@@ -4840,18 +4817,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -5222,10 +5187,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -5448,19 +5411,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -5471,19 +5434,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -5768,7 +5731,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6242,8 +6204,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6355,10 +6316,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -6676,7 +6636,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -6775,25 +6734,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.5",
             "transitive": [
@@ -6831,18 +6771,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7213,10 +7141,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7439,19 +7365,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7462,19 +7388,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7759,7 +7685,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8233,8 +8158,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8346,10 +8270,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -8667,7 +8590,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -8766,25 +8688,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.5",
             "transitive": [
@@ -8822,18 +8725,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9204,10 +9095,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9431,19 +9320,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9454,19 +9343,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.506",
+            "locked": "1.11.508",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9751,7 +9640,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10225,8 +10113,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10338,10 +10225,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10659,7 +10545,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -10758,25 +10643,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.5",
             "transitive": [
@@ -10814,18 +10680,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11196,10 +11050,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-ext/cassandra/dependencies.lock
+++ b/titus-ext/cassandra/dependencies.lock
@@ -3664,7 +3664,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4139,8 +4138,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -4234,10 +4232,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -4553,7 +4550,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -4652,25 +4648,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -4696,18 +4673,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -5079,10 +5044,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -5566,7 +5529,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6041,8 +6003,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6136,10 +6097,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -6455,7 +6415,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -6554,25 +6513,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -6598,18 +6538,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -6981,10 +6909,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7468,7 +7394,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7943,8 +7868,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8038,10 +7962,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -8357,7 +8280,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -8456,25 +8378,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -8500,18 +8403,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -8883,10 +8774,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9371,7 +9260,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9846,8 +9734,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -9941,10 +9828,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10260,7 +10146,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -10359,25 +10244,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -10403,18 +10269,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -10786,10 +10640,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-ext/elasticsearch/dependencies.lock
+++ b/titus-ext/elasticsearch/dependencies.lock
@@ -201,7 +201,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -611,7 +610,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -686,7 +684,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -972,7 +969,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -995,25 +991,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -1123,18 +1100,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -1369,8 +1334,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -1680,7 +1643,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -2090,7 +2052,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -2165,7 +2126,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -2451,7 +2411,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -2474,25 +2433,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -2602,18 +2542,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -2848,8 +2776,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -3159,7 +3085,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -3569,7 +3494,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -3644,7 +3568,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -3930,7 +3853,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -3953,25 +3875,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -4081,18 +3984,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -4327,8 +4218,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -4702,7 +4591,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -5112,7 +5000,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -5187,7 +5074,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -5473,7 +5359,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -5496,25 +5381,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -5624,18 +5490,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -5870,8 +5724,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -6182,7 +6034,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -6592,7 +6443,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -6667,7 +6517,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -6953,7 +6802,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -6976,25 +6824,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -7104,18 +6933,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -7350,8 +7167,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -7668,7 +7483,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -8082,7 +7896,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -8157,7 +7970,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -8452,7 +8264,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -8487,25 +8298,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -8615,18 +8407,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -8886,8 +8666,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -9203,7 +8981,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -9617,7 +9394,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -9692,7 +9468,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -9987,7 +9762,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -10022,25 +9796,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -10150,18 +9905,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -10421,8 +10164,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -10738,7 +10479,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -11152,7 +10892,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -11227,7 +10966,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -11522,7 +11260,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11557,25 +11294,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -11685,18 +11403,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11956,8 +11662,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -12274,7 +11978,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.elasticsearch:elasticsearch",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
@@ -12688,7 +12391,6 @@
         "commons-cli:commons-cli": {
             "locked": "1.3.1",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -12763,7 +12465,6 @@
             "locked": "3.10.6.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper",
                 "org.elasticsearch:elasticsearch"
             ]
         },
@@ -13058,7 +12759,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -13093,25 +12793,6 @@
                 "io.swagger:swagger-core",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core"
-            ]
-        },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
             ]
         },
         "org.apache.lucene:lucene-analyzers-common": {
@@ -13221,18 +12902,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13492,8 +13161,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",

--- a/titus-ext/eureka/dependencies.lock
+++ b/titus-ext/eureka/dependencies.lock
@@ -210,7 +210,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -649,12 +648,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -744,10 +737,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -1033,7 +1025,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -1076,25 +1067,6 @@
                 "com.netflix.netflix-commons:netflix-eventbus"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -1113,18 +1085,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -1358,8 +1318,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -1695,7 +1653,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -2134,12 +2091,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -2229,10 +2180,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -2518,7 +2468,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -2561,25 +2510,6 @@
                 "com.netflix.netflix-commons:netflix-eventbus"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -2598,18 +2528,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -2843,8 +2761,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -3180,7 +3096,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -3619,12 +3534,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -3714,10 +3623,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -4003,7 +3911,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -4046,25 +3953,6 @@
                 "com.netflix.netflix-commons:netflix-eventbus"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -4083,18 +3971,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -4328,8 +4204,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -4729,7 +4603,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -5168,12 +5041,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -5263,10 +5130,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -5552,7 +5418,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -5595,25 +5460,6 @@
                 "com.netflix.netflix-commons:netflix-eventbus"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -5632,18 +5478,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -5877,8 +5711,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -6215,7 +6047,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -6654,12 +6485,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -6749,10 +6574,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7038,7 +6862,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7081,25 +6904,6 @@
                 "com.netflix.netflix-commons:netflix-eventbus"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -7118,18 +6922,6 @@
             "transitive": [
                 "com.netflix.fenzo:fenzo-core",
                 "com.netflix.titus:titus-server-master"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -7363,8 +7155,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -7811,7 +7601,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8337,8 +8126,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8453,10 +8241,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -8775,7 +8562,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -8881,25 +8667,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -8938,18 +8705,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9330,10 +9085,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9857,7 +9610,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10383,8 +10135,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10499,10 +10250,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10821,7 +10571,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -10927,25 +10676,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -10984,18 +10714,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11376,10 +11094,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -11903,7 +11619,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12429,8 +12144,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12545,10 +12259,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12867,7 +12580,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -12973,25 +12685,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -13030,18 +12723,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13422,10 +13103,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -13950,7 +13629,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -14476,8 +14154,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -14592,10 +14269,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -14914,7 +14590,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -15020,25 +14695,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.3",
             "transitive": [
@@ -15077,18 +14733,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -15469,10 +15113,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-ext/jooq/dependencies.lock
+++ b/titus-ext/jooq/dependencies.lock
@@ -6570,7 +6570,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7054,8 +7053,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -7149,10 +7147,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7475,7 +7472,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7574,25 +7570,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7618,18 +7595,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -8029,10 +7994,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8520,7 +8483,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9004,8 +8966,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -9099,10 +9060,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9425,7 +9385,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9524,25 +9483,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9568,18 +9508,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9979,10 +9907,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10470,7 +10396,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10954,8 +10879,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -11049,10 +10973,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -11375,7 +11298,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11474,25 +11396,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -11518,18 +11421,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11929,10 +11820,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12421,7 +12310,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12905,8 +12793,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -13000,10 +12887,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -13326,7 +13212,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -13425,25 +13310,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -13469,18 +13335,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13880,10 +13734,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-ext/zookeeper/build.gradle
+++ b/titus-ext/zookeeper/build.gradle
@@ -15,6 +15,8 @@
  */
 
 dependencies {
+    compile "org.apache.curator:curator-recipes:${curatorVersion}"
+
     compile project(':titus-server-master')
 
     // 'curator-test' must be pinned to this version (see https://curator.apache.org/zk-compatibility.html)

--- a/titus-ext/zookeeper/dependencies.lock
+++ b/titus-ext/zookeeper/dependencies.lock
@@ -566,12 +566,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -640,7 +634,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -910,6 +904,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -953,23 +953,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
@@ -978,14 +975,8 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -1886,12 +1877,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -1960,7 +1945,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -2230,6 +2215,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -2273,23 +2264,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
@@ -2298,14 +2286,8 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -3206,12 +3188,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -3280,7 +3256,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -3550,6 +3526,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -3593,23 +3575,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
@@ -3618,14 +3597,8 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -4590,12 +4563,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -4664,7 +4631,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -4934,6 +4901,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -4977,23 +4950,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
@@ -5002,14 +4972,8 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -5911,12 +5875,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -5985,7 +5943,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -6255,6 +6213,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -6298,23 +6262,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
@@ -6323,14 +6284,8 @@
                 "com.netflix.titus:titus-server-master"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -7437,8 +7392,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -7532,7 +7486,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -7826,6 +7780,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -7952,23 +7912,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.curator:curator-test": {
             "locked": "2.12.0",
@@ -8001,14 +7958,8 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -9342,8 +9293,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -9437,7 +9387,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -9731,6 +9681,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -9857,23 +9813,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.curator:curator-test": {
             "locked": "2.12.0",
@@ -9906,14 +9859,8 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -11247,8 +11194,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -11342,7 +11288,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -11636,6 +11582,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -11762,23 +11714,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.curator:curator-test": {
             "locked": "2.12.0",
@@ -11811,14 +11760,8 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]
@@ -13153,8 +13096,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -13248,7 +13190,7 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
                 "com.twitter:finagle-core_2.11",
                 "org.apache.zookeeper:zookeeper"
@@ -13542,6 +13484,12 @@
                 "io.swagger:swagger-jaxrs"
             ]
         },
+        "jline:jline": {
+            "locked": "0.9.94",
+            "transitive": [
+                "org.apache.zookeeper:zookeeper"
+            ]
+        },
         "joda-time:joda-time": {
             "locked": "2.9.9",
             "transitive": [
@@ -13668,23 +13616,20 @@
             ]
         },
         "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
                 "org.apache.curator:curator-framework"
             ]
         },
         "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
+            "locked": "2.13.0",
             "transitive": [
-                "com.netflix.titus:titus-server-master",
                 "org.apache.curator:curator-recipes"
             ]
         },
         "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
+            "locked": "2.13.0",
+            "requested": "2.13.+"
         },
         "org.apache.curator:curator-test": {
             "locked": "2.12.0",
@@ -13717,14 +13662,8 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
+            "locked": "3.4.8",
             "transitive": [
                 "org.apache.curator:curator-client"
             ]

--- a/titus-ext/zookeeper/src/test/java/com/netflix/titus/ext/zookeeper/supervisor/ZookeeperLeaderElectorTest.java
+++ b/titus-ext/zookeeper/src/test/java/com/netflix/titus/ext/zookeeper/supervisor/ZookeeperLeaderElectorTest.java
@@ -33,8 +33,8 @@ import com.netflix.titus.master.supervisor.service.LeaderActivator;
 import com.netflix.titus.master.supervisor.service.MasterDescription;
 import com.netflix.titus.testkit.junit.category.IntegrationNotParallelizableTest;
 import com.netflix.titus.testkit.junit.resource.CloseableExternalResource;
+import org.apache.curator.CuratorConnectionLossException;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.zookeeper.KeeperException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -84,7 +84,7 @@ public class ZookeeperLeaderElectorTest {
             elector.join();
             fail("The elector should fail fast");
         } catch (IllegalStateException e) {
-            assertEquals("The cause should be from ZK connection failure", KeeperException.ConnectionLossException.class, e.getCause().getClass());
+            assertEquals("The cause should be from ZK connection failure", CuratorConnectionLossException.class, e.getCause().getClass());
             assertTrue("The error message is unexpected: " + e.getMessage(), e.getCause().getMessage().contains("ConnectionLoss"));
         }
     }

--- a/titus-server-federation/dependencies.lock
+++ b/titus-server-federation/dependencies.lock
@@ -6263,7 +6263,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6759,8 +6758,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6860,10 +6858,9 @@
             "requested": "1.10.+"
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7183,7 +7180,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7282,25 +7278,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7326,18 +7303,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7712,10 +7677,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8198,7 +8161,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8694,8 +8656,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8795,10 +8756,9 @@
             "requested": "1.10.+"
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9118,7 +9078,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9217,25 +9176,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9261,18 +9201,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9647,10 +9575,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10133,7 +10059,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10629,8 +10554,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10730,10 +10654,9 @@
             "requested": "1.10.+"
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -11053,7 +10976,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11152,25 +11074,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -11196,18 +11099,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11582,10 +11473,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12069,7 +11958,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12565,8 +12453,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12666,10 +12553,9 @@
             "requested": "1.10.+"
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12989,7 +12875,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -13088,25 +12973,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -13132,18 +12998,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13518,10 +13372,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-server-gateway/dependencies.lock
+++ b/titus-server-gateway/dependencies.lock
@@ -6334,7 +6334,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6835,8 +6834,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6931,10 +6929,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7255,7 +7252,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7354,25 +7350,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7398,18 +7375,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7785,10 +7750,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8272,7 +8235,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8773,8 +8735,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8869,10 +8830,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9193,7 +9153,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9292,25 +9251,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9336,18 +9276,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9723,10 +9651,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10210,7 +10136,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10711,8 +10636,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10807,10 +10731,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -11131,7 +11054,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11230,25 +11152,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -11274,18 +11177,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11661,10 +11552,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12149,7 +12038,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12650,8 +12538,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12746,10 +12633,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -13070,7 +12956,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -13169,25 +13054,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -13213,18 +13079,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13600,10 +13454,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-server-master/build.gradle
+++ b/titus-server-master/build.gradle
@@ -28,8 +28,6 @@ dependencies {
     // Misc dependencies
     compile "org.apache.mesos:mesos:${mesosVersion}"
     compile "com.github.spullara.cli-parser:cli-parser:${cliParserVersion}"
-    compile "org.apache.curator:curator-framework:${curatorVersion}"
-    compile "org.apache.curator:curator-recipes:${curatorVersion}"
     compile("io.reactivex:rxnetty:${rxnettyVersion}") {
         exclude module: 'rxjava-core' // netty was pinned to rxjava-core 0.19.1
     }

--- a/titus-server-master/dependencies.lock
+++ b/titus-server-master/dependencies.lock
@@ -177,7 +177,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -552,12 +551,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -626,10 +619,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -913,7 +905,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -938,40 +929,11 @@
                 "org.mock-server:mockserver-core"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+"
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
             "requested": "1.4.2",
             "transitive": [
                 "com.netflix.fenzo:fenzo-core"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -1194,8 +1156,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -1477,7 +1437,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -1852,12 +1811,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -1926,10 +1879,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -2213,7 +2165,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -2238,40 +2189,11 @@
                 "org.mock-server:mockserver-core"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+"
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
             "requested": "1.4.2",
             "transitive": [
                 "com.netflix.fenzo:fenzo-core"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -2494,8 +2416,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -2777,7 +2697,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -3152,12 +3071,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -3226,10 +3139,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -3513,7 +3425,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -3538,40 +3449,11 @@
                 "org.mock-server:mockserver-core"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+"
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
             "requested": "1.4.2",
             "transitive": [
                 "com.netflix.fenzo:fenzo-core"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -3794,8 +3676,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -4141,7 +4021,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -4516,12 +4395,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -4590,10 +4463,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -4877,7 +4749,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -4902,40 +4773,11 @@
                 "org.mock-server:mockserver-core"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+"
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
             "requested": "1.4.2",
             "transitive": [
                 "com.netflix.fenzo:fenzo-core"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -5158,8 +5000,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -5442,7 +5282,6 @@
                 "io.opencensus:opencensus-api",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
-                "org.apache.curator:curator-client",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-netty",
@@ -5817,12 +5656,6 @@
                 "com.twitter:util-logging_2.11"
             ]
         },
-        "commons-cli:commons-cli": {
-            "locked": "1.2",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
         "commons-codec:commons-codec": {
             "locked": "1.9",
             "transitive": [
@@ -5891,10 +5724,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -6178,7 +6010,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -6203,40 +6034,11 @@
                 "org.mock-server:mockserver-core"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+"
-        },
         "org.apache.mesos:mesos": {
             "locked": "1.4.2",
             "requested": "1.4.2",
             "transitive": [
                 "com.netflix.fenzo:fenzo-core"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.bouncycastle:bcmail-jdk15on": {
@@ -6459,8 +6261,6 @@
                 "io.reactivex:rxnetty",
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-models",
-                "org.apache.curator:curator-client",
-                "org.apache.zookeeper:zookeeper",
                 "org.mock-server:mockserver-client-java",
                 "org.mock-server:mockserver-core",
                 "org.mock-server:mockserver-logging",
@@ -6863,7 +6663,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7360,8 +7159,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -7455,10 +7253,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7780,7 +7577,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7891,27 +7687,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7938,18 +7713,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -8329,10 +8092,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8850,7 +8611,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9347,8 +9107,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -9442,10 +9201,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9767,7 +9525,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9878,27 +9635,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9925,18 +9661,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -10316,10 +10040,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10837,7 +10559,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -11334,8 +11055,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -11429,10 +11149,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -11754,7 +11473,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11865,27 +11583,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -11912,18 +11609,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -12303,10 +11988,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12825,7 +12508,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -13322,8 +13004,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -13417,10 +13098,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -13742,7 +13422,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -13853,27 +13532,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "requested": "4.+",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -13900,18 +13558,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -14291,10 +13937,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-server-runtime-spring/dependencies.lock
+++ b/titus-server-runtime-spring/dependencies.lock
@@ -6297,7 +6297,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6771,8 +6770,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6866,10 +6864,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7186,7 +7183,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7285,25 +7281,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7329,18 +7306,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7711,10 +7676,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8198,7 +8161,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8672,8 +8634,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8767,10 +8728,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9087,7 +9047,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9186,25 +9145,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9230,18 +9170,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9612,10 +9540,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10099,7 +10025,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10573,8 +10498,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10668,10 +10592,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10988,7 +10911,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11087,25 +11009,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -11131,18 +11034,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11513,10 +11404,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12001,7 +11890,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12475,8 +12363,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12570,10 +12457,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12890,7 +12776,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -12989,25 +12874,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -13033,18 +12899,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13415,10 +13269,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-server-runtime/dependencies.lock
+++ b/titus-server-runtime/dependencies.lock
@@ -6122,7 +6122,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6601,8 +6600,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6697,10 +6695,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7019,7 +7016,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7118,25 +7114,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7162,18 +7139,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7548,10 +7513,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8034,7 +7997,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8513,8 +8475,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8609,10 +8570,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -8931,7 +8891,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9030,25 +8989,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9074,18 +9014,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9460,10 +9388,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9946,7 +9872,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10425,8 +10350,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10521,10 +10445,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10843,7 +10766,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -10942,25 +10864,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -10986,18 +10889,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11372,10 +11263,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -11859,7 +11748,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12338,8 +12226,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12434,10 +12321,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12756,7 +12642,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -12855,25 +12740,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -12899,18 +12765,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13285,10 +13139,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-supplementary-component/job-activity-history-springboot/dependencies.lock
+++ b/titus-supplementary-component/job-activity-history-springboot/dependencies.lock
@@ -284,7 +284,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -776,8 +775,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -871,10 +869,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -1167,7 +1164,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -1266,25 +1262,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -1310,18 +1287,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -1688,10 +1653,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -2169,7 +2132,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -2661,8 +2623,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -2762,10 +2723,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -3059,7 +3019,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -3158,25 +3117,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -3221,18 +3161,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -3607,10 +3535,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4132,7 +4058,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4624,8 +4549,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -4725,10 +4649,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -5022,7 +4945,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -5121,25 +5043,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -5184,18 +5087,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -5570,10 +5461,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6157,7 +6046,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6649,8 +6537,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6744,10 +6631,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7040,7 +6926,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7139,25 +7024,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -7183,18 +7049,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7561,10 +7415,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8043,7 +7895,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8535,8 +8386,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8636,10 +8486,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -8933,7 +8782,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9032,25 +8880,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -9095,18 +8924,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9481,10 +9298,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10011,7 +9826,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10507,8 +10321,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10602,10 +10415,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10904,7 +10716,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11003,25 +10814,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -11047,18 +10839,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11431,10 +11211,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -11918,7 +11696,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12414,8 +12191,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12515,10 +12291,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12818,7 +12593,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -12917,25 +12691,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -12980,18 +12735,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13372,10 +13115,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -13901,7 +13642,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -14397,8 +14137,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -14492,10 +14231,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -14794,7 +14532,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -14893,25 +14630,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -14937,18 +14655,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -15321,10 +15027,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -15809,7 +15513,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -16305,8 +16008,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -16406,10 +16108,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -16709,7 +16410,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -16808,25 +16508,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -16871,18 +16552,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -17263,10 +16932,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-supplementary-component/job-activity-history/dependencies.lock
+++ b/titus-supplementary-component/job-activity-history/dependencies.lock
@@ -6357,7 +6357,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6835,8 +6834,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6930,10 +6928,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7250,7 +7247,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7349,25 +7345,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7393,18 +7370,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7776,10 +7741,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8266,7 +8229,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8744,8 +8706,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8839,10 +8800,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9159,7 +9119,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9258,25 +9217,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9302,18 +9242,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9685,10 +9613,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10175,7 +10101,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10653,8 +10578,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10748,10 +10672,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -11068,7 +10991,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11167,25 +11089,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -11211,18 +11114,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11594,10 +11485,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12085,7 +11974,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12563,8 +12451,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12658,10 +12545,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12978,7 +12864,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -13077,25 +12962,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -13121,18 +12987,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13504,10 +13358,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-supplementary-component/task-relocation-springboot/dependencies.lock
+++ b/titus-supplementary-component/task-relocation-springboot/dependencies.lock
@@ -284,7 +284,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -776,8 +775,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -871,10 +869,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -1167,7 +1164,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -1266,25 +1262,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -1310,18 +1287,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -1688,10 +1653,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -2169,7 +2132,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -2661,8 +2623,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -2762,10 +2723,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -3059,7 +3019,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -3158,25 +3117,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -3221,18 +3161,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -3607,10 +3535,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4132,7 +4058,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4624,8 +4549,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -4725,10 +4649,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -5022,7 +4945,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -5121,25 +5043,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -5184,18 +5087,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -5570,10 +5461,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6157,7 +6046,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6649,8 +6537,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6744,10 +6631,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7040,7 +6926,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7139,25 +7024,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -7183,18 +7049,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7561,10 +7415,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8043,7 +7895,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8535,8 +8386,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8636,10 +8486,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -8933,7 +8782,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9032,25 +8880,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -9095,18 +8924,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9481,10 +9298,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10011,7 +9826,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10507,8 +10321,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10602,10 +10415,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10904,7 +10716,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11003,25 +10814,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -11047,18 +10839,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11431,10 +11211,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -11918,7 +11696,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12414,8 +12191,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12515,10 +12291,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12818,7 +12593,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -12917,25 +12691,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -12980,18 +12735,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13372,10 +13115,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -13901,7 +13642,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -14397,8 +14137,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -14492,10 +14231,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -14794,7 +14532,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -14893,25 +14630,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -14937,18 +14655,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -15321,10 +15027,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -15809,7 +15513,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -16305,8 +16008,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -16406,10 +16108,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -16709,7 +16410,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -16808,25 +16508,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.1",
             "transitive": [
@@ -16871,18 +16552,6 @@
             "locked": "9.0.14",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -17263,10 +16932,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-supplementary-component/task-relocation/dependencies.lock
+++ b/titus-supplementary-component/task-relocation/dependencies.lock
@@ -6357,7 +6357,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6835,8 +6834,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6930,10 +6928,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -7250,7 +7247,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -7349,25 +7345,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -7393,18 +7370,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7776,10 +7741,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8266,7 +8229,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8744,8 +8706,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8839,10 +8800,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -9159,7 +9119,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -9258,25 +9217,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -9302,18 +9242,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9685,10 +9613,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10175,7 +10101,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10653,8 +10578,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10748,10 +10672,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -11068,7 +10991,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -11167,25 +11089,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -11211,18 +11114,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11594,10 +11485,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12085,7 +11974,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -12563,8 +12451,7 @@
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
                 "com.netflix.titus:titus-testkit",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12658,10 +12545,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12978,7 +12864,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -13077,25 +12962,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -13121,18 +12987,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -13504,10 +13358,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",

--- a/titus-testkit/dependencies.lock
+++ b/titus-testkit/dependencies.lock
@@ -290,7 +290,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -745,8 +744,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -840,10 +838,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -1152,7 +1149,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -1251,25 +1247,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -1295,18 +1272,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -1666,10 +1631,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -2142,7 +2105,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -2597,8 +2559,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -2692,10 +2653,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -3004,7 +2964,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -3103,25 +3062,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -3147,18 +3087,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -3518,10 +3446,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -3994,7 +3920,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -4449,8 +4374,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -4544,10 +4468,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -4856,7 +4779,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -4955,25 +4877,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -4999,18 +4902,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -5370,10 +5261,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -5910,7 +5799,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -6365,8 +6253,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -6460,10 +6347,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -6772,7 +6658,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -6871,25 +6756,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -6915,18 +6781,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -7286,10 +7140,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -7763,7 +7615,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -8218,8 +8069,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -8313,10 +8163,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -8625,7 +8474,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -8724,25 +8572,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -8768,18 +8597,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -9139,10 +8956,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -9622,7 +9437,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -10081,8 +9895,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -10176,10 +9989,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -10493,7 +10305,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -10592,25 +10403,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -10636,18 +10428,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -11011,10 +10791,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -11493,7 +11271,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -11952,8 +11729,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -12047,10 +11823,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -12364,7 +12139,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -12463,25 +12237,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -12507,18 +12262,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -12882,10 +12625,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -13364,7 +13105,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -13823,8 +13563,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -13918,10 +13657,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -14235,7 +13973,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -14334,25 +14071,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -14378,18 +14096,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -14753,10 +14459,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -15236,7 +14940,6 @@
                 "io.swagger:swagger-core",
                 "io.swagger:swagger-jaxrs",
                 "org.apache.cassandra:cassandra-all",
-                "org.apache.curator:curator-client",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",
@@ -15695,8 +15398,7 @@
             "requested": "1.3.+",
             "transitive": [
                 "com.netflix.titus:titus-ext-cassandra",
-                "org.apache.cassandra:cassandra-all",
-                "org.apache.zookeeper:zookeeper"
+                "org.apache.cassandra:cassandra-all"
             ]
         },
         "commons-codec:commons-codec": {
@@ -15790,10 +15492,9 @@
             ]
         },
         "io.netty:netty": {
-            "locked": "3.10.6.Final",
+            "locked": "3.10.1.Final",
             "transitive": [
-                "com.twitter:finagle-core_2.11",
-                "org.apache.zookeeper:zookeeper"
+                "com.twitter:finagle-core_2.11"
             ]
         },
         "io.netty:netty-buffer": {
@@ -16107,7 +15808,6 @@
         "log4j:log4j": {
             "locked": "1.2.17",
             "transitive": [
-                "org.apache.zookeeper:zookeeper",
                 "org.slf4j:slf4j-log4j12"
             ]
         },
@@ -16206,25 +15906,6 @@
                 "org.apache.cassandra:cassandra-all"
             ]
         },
-        "org.apache.curator:curator-client": {
-            "locked": "4.1.0",
-            "transitive": [
-                "org.apache.curator:curator-framework"
-            ]
-        },
-        "org.apache.curator:curator-framework": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master",
-                "org.apache.curator:curator-recipes"
-            ]
-        },
-        "org.apache.curator:curator-recipes": {
-            "locked": "4.1.0",
-            "transitive": [
-                "com.netflix.titus:titus-server-master"
-            ]
-        },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.11.2",
             "transitive": [
@@ -16250,18 +15931,6 @@
                 "com.thinkaurelius.thrift:thrift-server",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.yetus:audience-annotations": {
-            "locked": "0.5.0",
-            "transitive": [
-                "org.apache.zookeeper:zookeeper"
-            ]
-        },
-        "org.apache.zookeeper:zookeeper": {
-            "locked": "3.5.4-beta",
-            "transitive": [
-                "org.apache.curator:curator-client"
             ]
         },
         "org.assertj:assertj-core": {
@@ -16625,10 +16294,8 @@
                 "io.swagger:swagger-models",
                 "org.apache.cassandra:cassandra-all",
                 "org.apache.cassandra:cassandra-thrift",
-                "org.apache.curator:curator-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.apache.thrift:libthrift",
-                "org.apache.zookeeper:zookeeper",
                 "org.caffinitas.ohc:ohc-core",
                 "org.cassandraunit:cassandra-unit",
                 "org.mock-server:mockserver-client-java",


### PR DESCRIPTION
As described here: https://curator.apache.org/zk-compatibility.html
```
Curator 4.0 has a hard dependency on ZooKeeper 3.5.x
If you are using ZooKeeper 3.5.x there's nothing additional to do - just use Curator 4.0
```

Although it is possible to run Curator 4.x with Zookeper 3.4.x in a compatibility mode,
not all operations are available. In our case we hit this issue, as for at least one
operation we get UNIMPLEMENTED error.
