### PR TITLE
Improve how the agent cache integrates with the instance cache

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/agent/model/AgentInstance.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/agent/model/AgentInstance.java
@@ -18,6 +18,7 @@ package com.netflix.titus.api.agent.model;
 
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 
 import com.netflix.titus.common.model.sanitizer.ClassFieldsNotNull;
 import com.netflix.titus.common.model.sanitizer.CollectionInvariants;
@@ -86,36 +87,18 @@ public class AgentInstance {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         AgentInstance that = (AgentInstance) o;
-
-        if (id != null ? !id.equals(that.id) : that.id != null) {
-            return false;
-        }
-        if (instanceGroupId != null ? !instanceGroupId.equals(that.instanceGroupId) : that.instanceGroupId != null) {
-            return false;
-        }
-        if (ipAddress != null ? !ipAddress.equals(that.ipAddress) : that.ipAddress != null) {
-            return false;
-        }
-        if (hostname != null ? !hostname.equals(that.hostname) : that.hostname != null) {
-            return false;
-        }
-        if (lifecycleStatus != null ? !lifecycleStatus.equals(that.lifecycleStatus) : that.lifecycleStatus != null) {
-            return false;
-        }
-        return attributes != null ? attributes.equals(that.attributes) : that.attributes == null;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(instanceGroupId, that.instanceGroupId) &&
+                Objects.equals(ipAddress, that.ipAddress) &&
+                Objects.equals(hostname, that.hostname) &&
+                Objects.equals(lifecycleStatus, that.lifecycleStatus) &&
+                Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (instanceGroupId != null ? instanceGroupId.hashCode() : 0);
-        result = 31 * result + (ipAddress != null ? ipAddress.hashCode() : 0);
-        result = 31 * result + (hostname != null ? hostname.hashCode() : 0);
-        result = 31 * result + (lifecycleStatus != null ? lifecycleStatus.hashCode() : 0);
-        result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
-        return result;
+        return Objects.hash(id, instanceGroupId, ipAddress, hostname, lifecycleStatus, attributes);
     }
 
     @Override
@@ -190,18 +173,12 @@ public class AgentInstance {
             return this;
         }
 
-        public Builder withTimestamp(long timestamp) {
-            this.timestamp = timestamp;
-            return this;
-        }
-
         public Builder but() {
-            return newBuilder().withId(id).withInstanceGroupId(instanceGroupId).withIpAddress(ipAddress).withHostname(hostname).withDeploymentStatus(instanceLifecycleStatus).withAttributes(attributes).withTimestamp(timestamp);
+            return newBuilder().withId(id).withInstanceGroupId(instanceGroupId).withIpAddress(ipAddress).withHostname(hostname).withDeploymentStatus(instanceLifecycleStatus).withAttributes(attributes);
         }
 
         public AgentInstance build() {
-            AgentInstance agentInstance = new AgentInstance(id, instanceGroupId, ipAddress, hostname, instanceLifecycleStatus, attributes);
-            return agentInstance;
+            return new AgentInstance(id, instanceGroupId, ipAddress, hostname, instanceLifecycleStatus, attributes);
         }
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/agent/model/AgentInstanceGroup.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/agent/model/AgentInstanceGroup.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.api.agent.model;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -155,64 +156,25 @@ public class AgentInstanceGroup {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         AgentInstanceGroup that = (AgentInstanceGroup) o;
-
-        if (min != that.min) {
-            return false;
-        }
-        if (desired != that.desired) {
-            return false;
-        }
-        if (current != that.current) {
-            return false;
-        }
-        if (max != that.max) {
-            return false;
-        }
-        if (isLaunchEnabled != that.isLaunchEnabled) {
-            return false;
-        }
-        if (isTerminateEnabled != that.isTerminateEnabled) {
-            return false;
-        }
-        if (launchTimestamp != that.launchTimestamp) {
-            return false;
-        }
-        if (id != null ? !id.equals(that.id) : that.id != null) {
-            return false;
-        }
-        if (instanceType != null ? !instanceType.equals(that.instanceType) : that.instanceType != null) {
-            return false;
-        }
-        if (tier != that.tier) {
-            return false;
-        }
-        if (resourceDimension != null ? !resourceDimension.equals(that.resourceDimension) : that.resourceDimension != null) {
-            return false;
-        }
-        if (lifecycleStatus != null ? !lifecycleStatus.equals(that.lifecycleStatus) : that.lifecycleStatus != null) {
-            return false;
-        }
-        return attributes != null ? attributes.equals(that.attributes) : that.attributes == null;
+        return min == that.min &&
+                desired == that.desired &&
+                current == that.current &&
+                max == that.max &&
+                isLaunchEnabled == that.isLaunchEnabled &&
+                isTerminateEnabled == that.isTerminateEnabled &&
+                launchTimestamp == that.launchTimestamp &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(instanceType, that.instanceType) &&
+                tier == that.tier &&
+                Objects.equals(resourceDimension, that.resourceDimension) &&
+                Objects.equals(lifecycleStatus, that.lifecycleStatus) &&
+                Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (instanceType != null ? instanceType.hashCode() : 0);
-        result = 31 * result + (tier != null ? tier.hashCode() : 0);
-        result = 31 * result + (resourceDimension != null ? resourceDimension.hashCode() : 0);
-        result = 31 * result + min;
-        result = 31 * result + desired;
-        result = 31 * result + current;
-        result = 31 * result + max;
-        result = 31 * result + (isLaunchEnabled ? 1 : 0);
-        result = 31 * result + (isTerminateEnabled ? 1 : 0);
-        result = 31 * result + (lifecycleStatus != null ? lifecycleStatus.hashCode() : 0);
-        result = 31 * result + (int) (launchTimestamp ^ (launchTimestamp >>> 32));
-        result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
-        return result;
+        return Objects.hash(id, instanceType, tier, resourceDimension, min, desired, current, max, isLaunchEnabled, isTerminateEnabled, lifecycleStatus, launchTimestamp, attributes);
     }
 
     @Override

--- a/titus-api/src/main/java/com/netflix/titus/api/agent/service/AgentManagementService.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/agent/service/AgentManagementService.java
@@ -117,11 +117,6 @@ public interface AgentManagementService extends ReadOnlyAgentOperations {
     Observable<List<Either<Boolean, Throwable>>> terminateAgents(String instanceGroupId, List<String> instanceIds, boolean shrink);
 
     /**
-     * Refresh any cached state now.
-     */
-    void forceRefresh();
-
-    /**
      * On subscription emit all known agent instance groups and instances, followed by a marker event. Next emit an
      * event for each instance group or agent instance change (add/update/remove).
      */

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/AgentManagementConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/AgentManagementConfiguration.java
@@ -28,6 +28,9 @@ public interface AgentManagementConfiguration {
     @DefaultValue("120000")
     long getFullCacheRefreshIntervalMs();
 
+    @DefaultValue("60000")
+    long getSynchronizeWithInstanceCacheIntervalMs();
+
     @DefaultValue(".*")
     String getAgentInstanceGroupPattern();
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
@@ -272,11 +272,6 @@ public class DefaultAgentManagementService implements AgentManagementService {
     }
 
     @Override
-    public void forceRefresh() {
-        agentCache.forceRefresh();
-    }
-
-    @Override
     public Observable<AgentEvent> events(boolean includeSnapshot) {
         return Observable.fromCallable(() -> new AgentEventEmitter(agentCache)).flatMap(initial -> {
             Observable<AgentEvent> eventObservable = agentCache.events()

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/AgentCache.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/AgentCache.java
@@ -48,7 +48,5 @@ public interface AgentCache {
 
     Completable removeInstances(String instanceGroupId, Set<String> agentInstanceIds);
 
-    void forceRefresh();
-
     Observable<CacheUpdateEvent> events();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DataConverters.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DataConverters.java
@@ -31,6 +31,7 @@ import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.Evaluators;
+import com.netflix.titus.master.agent.store.AgentStoreReaper;
 
 class DataConverters {
 
@@ -63,6 +64,7 @@ class DataConverters {
     static AgentInstanceGroup updateAgentInstanceGroup(AgentInstanceGroup original, InstanceGroup instanceGroup) {
         long now = System.currentTimeMillis();
         Map<String, String> updatedAttributes = CollectionsExt.merge(original.getAttributes(), instanceGroup.getAttributes());
+        updatedAttributes.remove(AgentStoreReaper.INSTANCE_GROUP_REMOVED_ATTRIBUTE);
         return original.toBuilder()
                 .withMin(instanceGroup.getMin())
                 .withDesired(instanceGroup.getDesired())
@@ -83,7 +85,6 @@ class DataConverters {
                 .withHostname(instance.getHostname())
                 .withDeploymentStatus(toDeploymentStatus(instance))
                 .withAttributes(instance.getAttributes())
-                .withTimestamp(System.currentTimeMillis())
                 .build();
     }
 
@@ -97,8 +98,7 @@ class DataConverters {
         return builder.withIpAddress(Evaluators.getOrDefault(instance.getIpAddress(), "0.0.0.0"))
                 .withInstanceGroupId(Evaluators.getOrDefault(instance.getInstanceGroupId(), "detached"))
                 .withHostname(Evaluators.getOrDefault(instance.getHostname(), "0_0_0_0"))
-                .withAttributes(updatedAttributes)
-                .withTimestamp(System.currentTimeMillis());
+                .withAttributes(updatedAttributes);
     }
 
     static InstanceLifecycleStatus toDeploymentStatus(Instance instance) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DataConverters.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DataConverters.java
@@ -31,7 +31,6 @@ import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.Evaluators;
-import com.netflix.titus.master.agent.store.AgentStoreReaper;
 
 class DataConverters {
 
@@ -64,7 +63,6 @@ class DataConverters {
     static AgentInstanceGroup updateAgentInstanceGroup(AgentInstanceGroup original, InstanceGroup instanceGroup) {
         long now = System.currentTimeMillis();
         Map<String, String> updatedAttributes = CollectionsExt.merge(original.getAttributes(), instanceGroup.getAttributes());
-        updatedAttributes.remove(AgentStoreReaper.INSTANCE_GROUP_REMOVED_ATTRIBUTE);
         return original.toBuilder()
                 .withMin(instanceGroup.getMin())
                 .withDesired(instanceGroup.getDesired())

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DefaultAgentCache.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DefaultAgentCache.java
@@ -330,11 +330,6 @@ public class DefaultAgentCache implements AgentCache {
                     .filter(Objects::nonNull)
                     .collect(Collectors.toCollection(() -> new TreeSet<>(AgentInstance.idComparator())));
 
-            // Update store with removed attribute in case an instance group only temporarily was removed
-            if (isTaggedToRemove(existingInstanceGroup) && !isTaggedToRemove(agentInstanceGroup)) {
-                storeEagerly(agentInstanceGroup);
-            }
-
             if (isAgentInstanceGroupUpdated(existingInstanceGroup, agentInstanceGroup)
                     || isAgentInstancesUpdated(existingAgentInstances, agentInstances)) {
                 setDataSnapshot(dataSnapshot.updateInstanceGroup(agentInstanceGroup, agentInstances));

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DefaultAgentCache.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DefaultAgentCache.java
@@ -18,17 +18,20 @@ package com.netflix.titus.master.agent.service.cache;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.google.common.collect.Sets;
 import com.netflix.spectator.api.Registry;
 import com.netflix.titus.api.agent.model.AgentInstance;
 import com.netflix.titus.api.agent.model.AgentInstanceGroup;
@@ -40,6 +43,7 @@ import com.netflix.titus.api.connector.cloud.InstanceGroup;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.rx.ObservableExt;
+import com.netflix.titus.common.util.rx.SchedulerExt;
 import com.netflix.titus.master.agent.service.AgentManagementConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,9 +53,9 @@ import rx.Scheduler;
 import rx.Single;
 import rx.Subscription;
 import rx.functions.Action0;
-import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 
+import static com.netflix.titus.master.MetricConstants.METRIC_AGENT_CACHE;
 import static com.netflix.titus.master.agent.store.AgentStoreReaper.isTaggedToRemove;
 import static com.netflix.titus.master.agent.store.AgentStoreReaper.tagToRemove;
 
@@ -82,6 +86,7 @@ public class DefaultAgentCache implements AgentCache {
 
     private InstanceCache instanceCache;
     private Subscription instanceCacheSubscription;
+    private Subscription synchronizeWithInstanceCacheSubscription;
 
     private volatile AgentDataSnapshot dataSnapshot = new AgentDataSnapshot();
 
@@ -92,7 +97,7 @@ public class DefaultAgentCache implements AgentCache {
                              AgentStore agentStore,
                              InstanceCloudConnector connector,
                              Registry registry) {
-        this(configuration, agentStore, connector, registry, Schedulers.computation());
+        this(configuration, agentStore, connector, registry, SchedulerExt.createSingleThreadScheduler("agent-cache"));
     }
 
     DefaultAgentCache(AgentManagementConfiguration configuration,
@@ -132,36 +137,43 @@ public class DefaultAgentCache implements AgentCache {
         this.instanceCache = InstanceCache.newInstance(configuration, connector, knownInstanceGroupIds, registry, scheduler);
         setDataSnapshot(AgentDataSnapshot.initWithStaleDataSnapshot(persistedInstanceGroups, persistedInstances));
 
-        logger.info("Started AgentCache with: {}", dataSnapshot.getInstanceGroups());
+        logger.info("Started AgentCache with instance groups: {}", dataSnapshot.getInstanceGroups());
 
         this.instanceCacheSubscription = instanceCache.events()
-                .compose(ObservableExt.head(() ->
-                        Collections.singletonList(new CacheUpdateEvent(CacheUpdateType.Refreshed, CacheUpdateEvent.EMPTY_ID)))
-                )
                 .subscribe(
                         event -> {
                             switch (event.getType()) {
-                                case Refreshed:
-                                    onEventLoop(this::updateOnFullRefreshInstanceCacheEvent);
+                                case InstanceGroupAdded:
+                                    onEventLoop(() -> updateOnInstanceGroupAddEvent(event.getResourceId()));
                                     break;
-                                case InstanceGroup:
-                                    onEventLoop(() -> updateOnInstanceGroupInstanceCacheEvent(event.getResourceId()));
+                                case InstanceGroupRemoved:
+                                    onEventLoop(() -> updateOnInstanceGroupRemoveEvent(event.getResourceId()));
                                     break;
-                                case Instance:
-                                    // Ignore, as instance group, and its instances are refreshed at the same time
+                                case InstanceGroupUpdated:
+                                    onEventLoop(() -> updateOnInstanceGroupUpdateEvent(event.getResourceId()));
                                     break;
                             }
                         },
                         e -> logger.error("InstanceCache events stream completed with an error", e),
                         () -> logger.info("InstanceCache events stream completed")
                 );
+
+        this.synchronizeWithInstanceCacheSubscription = ObservableExt.schedule(
+                METRIC_AGENT_CACHE, registry, "synchronizeWithInstanceCache",
+                onEventLoopWithSubscription(this::synchronizeWithInstanceCache),
+                0, configuration.getSynchronizeWithInstanceCacheIntervalMs(), TimeUnit.MILLISECONDS, scheduler
+        ).subscribe(
+                next -> next.ifPresent(throwable -> logger.warn("Synchronizing with instance cache failed with an error", throwable)),
+                e -> logger.error("Synchronizing with instance cache terminated with an error", e),
+                () -> logger.info("Synchronizing with instance cache terminated")
+        );
     }
 
     public void shutdown() {
         if (instanceCache != null) {
             instanceCache.shutdown();
         }
-        ObservableExt.safeUnsubscribe(instanceCacheSubscription);
+        ObservableExt.safeUnsubscribe(instanceCacheSubscription, synchronizeWithInstanceCacheSubscription);
     }
 
     @Override
@@ -239,61 +251,27 @@ public class DefaultAgentCache implements AgentCache {
     }
 
     @Override
-    public void forceRefresh() {
-        instanceCache.doFullInstanceGroupRefresh().subscribe(
-                () -> logger.info("Forced full instance cache refresh finished"),
-                e -> logger.info("Forced full instance cache refresh failed", e)
-        );
-    }
-
-    @Override
     public Observable<CacheUpdateEvent> events() {
-        return eventSubject;
+        return eventSubject.asObservable();
     }
 
-    private void updateOnFullRefreshInstanceCacheEvent() {
-        Set<String> knownInstanceGroupIds = dataSnapshot.getInstanceGroupIds();
-        List<InstanceGroup> allInstanceGroups = instanceCache.getInstanceGroups();
-        Set<String> allInstanceGroupIds = allInstanceGroups.stream().map(InstanceGroup::getId).collect(Collectors.toSet());
+    private void synchronizeWithInstanceCache() {
+        Set<String> existingInstanceGroupIds = dataSnapshot.getInstanceGroupIds();
+        Set<String> allInstanceGroupIds = instanceCache.getInstanceGroups().stream().map(InstanceGroup::getId).collect(Collectors.toSet());
+        Set<String> newInstanceGroupIds = allInstanceGroupIds.stream().filter(id -> !existingInstanceGroupIds.contains(id)).collect(Collectors.toSet());
+        Set<String> removedInstanceGroupIds = existingInstanceGroupIds.stream().filter(id -> !allInstanceGroupIds.contains(id)).collect(Collectors.toSet());
+        Set<String> currentInstanceGroupIds = existingInstanceGroupIds.stream().filter(allInstanceGroupIds::contains).collect(Collectors.toSet());
 
-        Set<String> newInstanceGroupIds = allInstanceGroups.stream()
-                .map(InstanceGroup::getId)
-                .filter(id -> !knownInstanceGroupIds.contains(id))
-                .collect(Collectors.toSet());
-        Set<String> removedInstanceGroupIds = knownInstanceGroupIds.stream().filter(id -> !allInstanceGroupIds.contains(id)).collect(Collectors.toSet());
-        List<AgentInstanceGroup> removedInstanceGroups = removedInstanceGroupIds.stream().map(id -> dataSnapshot.getInstanceGroup(id)).collect(Collectors.toList());
-
-        newInstanceGroupIds.forEach(this::syncInstanceGroupWithInstanceCache);
-        removedInstanceGroupIds.forEach(this::syncInstanceGroupWithInstanceCache);
-
-        newInstanceGroupIds.forEach(this::storeEagerly);
-        removedInstanceGroups.forEach(this::storeEagerlyWithRemoveFlag);
+        newInstanceGroupIds.forEach(this::updateOnInstanceGroupAddEvent);
+        removedInstanceGroupIds.forEach(this::updateOnInstanceGroupRemoveEvent);
+        currentInstanceGroupIds.forEach(this::updateOnInstanceGroupUpdateEvent);
     }
 
-    private void updateOnInstanceGroupInstanceCacheEvent(String instanceGroupId) {
-        AgentInstanceGroup instanceGroup = getInstanceGroup(instanceGroupId);
-        if (instanceGroup != null) {
-            syncInstanceGroupWithInstanceCache(instanceGroupId);
-            if (instanceCache.getInstanceGroup(instanceGroupId) == null) {
-                storeEagerlyWithRemoveFlag(instanceGroup);
-            }
-        }
-    }
-
-    private void syncInstanceGroupWithInstanceCache(String instanceGroupId) {
+    private void updateOnInstanceGroupAddEvent(String instanceGroupId) {
         InstanceGroup instanceGroup = instanceCache.getInstanceGroup(instanceGroupId);
+        AgentInstanceGroup existingInstanceGroup = dataSnapshot.getInstanceGroup(instanceGroupId);
 
-        if (instanceGroup == null) {
-            setDataSnapshot(dataSnapshot.removeInstanceGroup(instanceGroupId));
-            eventSubject.onNext(new CacheUpdateEvent(CacheUpdateType.InstanceGroup, instanceGroupId));
-            logger.debug("instance group: {} no longer exists", instanceGroupId);
-            return;
-        }
-
-        AgentInstanceGroup previous = dataSnapshot.getInstanceGroup(instanceGroupId);
-        AgentInstanceGroup agentInstanceGroup;
-        List<AgentInstance> agentInstances;
-        if (previous == null) {
+        if (instanceGroup != null && existingInstanceGroup == null) {
             String instanceType = instanceGroup.getInstanceType();
             ResourceDimension instanceResourceDimension;
             try {
@@ -303,18 +281,41 @@ public class DefaultAgentCache implements AgentCache {
                 instanceResourceDimension = ResourceDimension.empty();
             }
 
-            agentInstanceGroup = DataConverters.toAgentInstanceGroup(
-                    instanceGroup,
-                    instanceResourceDimension
-            );
-            agentInstances = instanceGroup.getInstanceIds().stream()
+            AgentInstanceGroup agentInstanceGroup = DataConverters.toAgentInstanceGroup(instanceGroup, instanceResourceDimension);
+            Set<AgentInstance> agentInstances = instanceGroup.getInstanceIds().stream()
                     .map(instanceCache::getAgentInstance)
                     .filter(Objects::nonNull)
                     .map(DataConverters::toAgentInstance)
-                    .collect(Collectors.toList());
-        } else {
-            agentInstanceGroup = DataConverters.updateAgentInstanceGroup(previous, instanceGroup);
-            agentInstances = instanceGroup.getInstanceIds().stream()
+                    .collect(Collectors.toCollection(() -> new TreeSet<>(AgentInstance.idComparator())));
+
+            setDataSnapshot(dataSnapshot.updateInstanceGroup(agentInstanceGroup, agentInstances));
+            storeEagerly(agentInstanceGroup);
+            logger.info("Updated cache for added instance group: {} with instances: {}", instanceGroupId, agentInstances);
+            eventSubject.onNext(new CacheUpdateEvent(CacheUpdateType.InstanceGroup, instanceGroupId));
+        }
+    }
+
+    private void updateOnInstanceGroupRemoveEvent(String instanceGroupId) {
+        InstanceGroup instanceGroup = instanceCache.getInstanceGroup(instanceGroupId);
+        AgentInstanceGroup existingInstanceGroup = dataSnapshot.getInstanceGroup(instanceGroupId);
+
+        if (instanceGroup == null && existingInstanceGroup != null) {
+            setDataSnapshot(dataSnapshot.removeInstanceGroup(instanceGroupId));
+            storeEagerlyWithRemoveFlag(existingInstanceGroup);
+            logger.info("Updated cache for removed instance group: {}", instanceGroupId);
+            eventSubject.onNext(new CacheUpdateEvent(CacheUpdateType.InstanceGroup, instanceGroupId));
+        }
+    }
+
+    private void updateOnInstanceGroupUpdateEvent(String instanceGroupId) {
+        InstanceGroup instanceGroup = instanceCache.getInstanceGroup(instanceGroupId);
+        AgentInstanceGroup existingInstanceGroup = dataSnapshot.getInstanceGroup(instanceGroupId);
+
+        if (instanceGroup != null && existingInstanceGroup != null) {
+            Set<AgentInstance> existingAgentInstances = dataSnapshot.getInstances(instanceGroupId);
+
+            AgentInstanceGroup agentInstanceGroup = DataConverters.updateAgentInstanceGroup(existingInstanceGroup, instanceGroup);
+            Set<AgentInstance> agentInstances = instanceGroup.getInstanceIds().stream()
                     .map(id -> {
                         Instance instance = instanceCache.getAgentInstance(id);
                         if (instance == null) {
@@ -327,18 +328,23 @@ public class DefaultAgentCache implements AgentCache {
                         return DataConverters.updateAgentInstance(previousInstance, instance);
                     })
                     .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-        }
-        TreeSet<AgentInstance> agentInstanceSet = new TreeSet<>(AgentInstance.idComparator());
-        agentInstanceSet.addAll(agentInstances);
-        logger.debug("Creating new agent data snapshot for instance group: {} with instances: {}", instanceGroupId, agentInstanceSet);
+                    .collect(Collectors.toCollection(() -> new TreeSet<>(AgentInstance.idComparator())));
 
-        setDataSnapshot(dataSnapshot.updateInstanceGroup(agentInstanceGroup, agentInstanceSet));
-        eventSubject.onNext(new CacheUpdateEvent(CacheUpdateType.InstanceGroup, instanceGroupId));
+            // Update store with removed attribute in case an instance group only temporarily was removed
+            if (isTaggedToRemove(existingInstanceGroup) && !isTaggedToRemove(agentInstanceGroup)) {
+                storeEagerly(agentInstanceGroup);
+            }
+
+            if (isAgentInstanceGroupUpdated(existingInstanceGroup, agentInstanceGroup)
+                    || isAgentInstancesUpdated(existingAgentInstances, agentInstances)) {
+                setDataSnapshot(dataSnapshot.updateInstanceGroup(agentInstanceGroup, agentInstances));
+                logger.info("Updated cache for updated instance group: {} with instances: {}", instanceGroupId, agentInstances);
+                eventSubject.onNext(new CacheUpdateEvent(CacheUpdateType.InstanceGroup, instanceGroupId));
+            }
+        }
     }
 
-    private void storeEagerly(String instanceGroupId) {
-        AgentInstanceGroup instanceGroup = dataSnapshot.getInstanceGroup(instanceGroupId);
+    private void storeEagerly(AgentInstanceGroup instanceGroup) {
         if (instanceGroup != null) {
             agentStore.storeAgentInstanceGroup(instanceGroup).subscribe(
                     () -> logger.info("Persisted instance group: {} to the store", instanceGroup.getId()),
@@ -348,7 +354,7 @@ public class DefaultAgentCache implements AgentCache {
     }
 
     private void storeEagerlyWithRemoveFlag(AgentInstanceGroup instanceGroup) {
-        if (!isTaggedToRemove(instanceGroup)) {
+        if (instanceGroup != null && !isTaggedToRemove(instanceGroup)) {
             agentStore.storeAgentInstanceGroup(tagToRemove(instanceGroup, scheduler)).subscribe(
                     () -> logger.info("Tagging instance group: {} as removed", instanceGroup.getId()),
                     e -> logger.warn("Could not persist instance group: {} into the store", instanceGroup.getId(), e)
@@ -396,5 +402,22 @@ public class DefaultAgentCache implements AgentCache {
     private void setDataSnapshot(AgentDataSnapshot dataSnapshot) {
         this.dataSnapshot = dataSnapshot;
         metrics.refresh(dataSnapshot);
+    }
+
+    private boolean isAgentInstanceGroupUpdated(AgentInstanceGroup first, AgentInstanceGroup second) {
+        // equals cannot be used due to changing timestamps
+        boolean notUpdated = first.getMin() == second.getMin() && first.getDesired() == second.getDesired() && first.getCurrent() == second.getCurrent()
+                && first.getMax() == second.getMax() && first.isLaunchEnabled() == second.isLaunchEnabled()
+                && first.isTerminateEnabled() == second.isTerminateEnabled() && Objects.equals(first.getId(), second.getId())
+                && Objects.equals(first.getInstanceType(), second.getInstanceType()) && first.getTier() == second.getTier()
+                && Objects.equals(first.getResourceDimension(), second.getResourceDimension())
+                && Objects.equals(first.getLifecycleStatus(), second.getLifecycleStatus())
+                && Objects.equals(first.getAttributes(), second.getAttributes());
+        return !notUpdated;
+    }
+
+    private boolean isAgentInstancesUpdated(Set<AgentInstance> first, Set<AgentInstance> second) {
+        // convert into HashSet because TreeSet does not use equals
+        return !Sets.symmetricDifference(new HashSet<>(first), new HashSet<>(second)).isEmpty();
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/InstanceCacheEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/InstanceCacheEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.agent.service.cache;
+
+import java.util.Objects;
+
+public class InstanceCacheEvent {
+
+    public enum InstanceCacheEventType {
+        // New instance group was detected and added
+        InstanceGroupAdded,
+
+        // Existing instance group was removed
+        InstanceGroupRemoved,
+
+        // Instance group was updated
+        InstanceGroupUpdated
+    }
+
+    public static String EMPTY_ID = "empty";
+
+    private final InstanceCacheEventType type;
+    private final String resourceId;
+
+    public InstanceCacheEvent(InstanceCacheEventType type, String resourceId) {
+        this.type = type;
+        this.resourceId = resourceId;
+    }
+
+    public InstanceCacheEventType getType() {
+        return type;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InstanceCacheEvent that = (InstanceCacheEvent) o;
+        return type == that.type &&
+                Objects.equals(resourceId, that.resourceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, resourceId);
+    }
+
+    @Override
+    public String toString() {
+        return "InstanceCacheEvent{" +
+                "type=" + type +
+                ", resourceId='" + resourceId + '\'' +
+                '}';
+    }
+}

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMasters.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMasters.java
@@ -31,6 +31,7 @@ public final class EmbeddedTitusMasters {
                 .withSimulatedCloud(simulatedCloud)
                 .withProperty("titus.agent.cacheRefreshIntervalMs", "500")
                 .withProperty("titus.agent.fullCacheRefreshIntervalMs", "500")
+                .withProperty("titus.agent.synchronizeWithInstanceCacheIntervalMs", "500")
                 .withProperty("titus.master.capacityManagement.availableCapacityUpdateIntervalMs", "10")
                 .withProperty("titus.scheduler.tierSlaUpdateIntervalMs", "10")
                 .withProperty("titus.master.grpcServer.shutdownTimeoutMs", "0")

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/AgentGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/AgentGenerator.java
@@ -141,10 +141,7 @@ public final class AgentGenerator {
                     builder.withIpAddress(ip);
                     builder.withHostname(ip.replace('.', '_') + ".titus.netflix.dev");
                 })
-                .map(builder -> builder
-                        .withTimestamp(System.currentTimeMillis())
-                        .build()
-                );
+                .map(AgentInstance.Builder::build);
     }
 
     public static DataGenerator<AgentInstance> agentInstances() {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/StubbedAgentManagementService.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/StubbedAgentManagementService.java
@@ -149,10 +149,6 @@ class StubbedAgentManagementService implements AgentManagementService {
     }
 
     @Override
-    public void forceRefresh() {
-    }
-
-    @Override
     public Observable<AgentEvent> events(boolean includeSnapshot) {
         return stubbedAgentData.observeAgents(includeSnapshot);
     }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/stub/connector/cloud/TestableInstanceCloudConnector.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/stub/connector/cloud/TestableInstanceCloudConnector.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
 import com.netflix.titus.api.connector.cloud.Instance;
 import com.netflix.titus.api.connector.cloud.InstanceCloudConnector;
 import com.netflix.titus.api.connector.cloud.InstanceGroup;
@@ -149,6 +150,15 @@ public class TestableInstanceCloudConnector implements InstanceCloudConnector {
         InstanceGroup instanceGroup = instanceGroupEntry.getFirst();
         launchConfigurationsById.remove(instanceGroup.getLaunchConfigurationName());
         instanceGroup.getInstanceIds().forEach(instancesById::remove);
+    }
+
+    public void updateInstanceGroup(String instanceGroupid, InstanceGroup instanceGroup) {
+        Triple<InstanceGroup, Integer, Integer> existing = instanceGroupsById.get(instanceGroupid);
+        Preconditions.checkNotNull(existing);
+        instanceGroupsById.put(
+                instanceGroup.getId(),
+                existing.mapFirst(previous -> instanceGroup.toBuilder().withInstanceIds(previous.getInstanceIds()).build())
+        );
     }
 
     public void addInstance(Instance instance) {


### PR DESCRIPTION
### Description of the Change

Improve how the agent cache integrates with the instance cache by subscribing to specific instance cache events as well as periodically synchronizing to ensure correct state.