### PR TITLE
add capacity management attribute to ignore instance group

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementAttributes.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementAttributes.java
@@ -1,0 +1,12 @@
+package com.netflix.titus.master.service.management;
+
+/**
+ * Collection of capacity management related attributes that can be associated with agent instance groups and agent instances.
+ */
+public final class CapacityManagementAttributes {
+
+    /**
+     * Mark an instance group such that capacity management will ignore the instance group when doing its operations.
+     */
+    public static final String IGNORE = "titus.capacityManagement.ignore";
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementFunctions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementFunctions.java
@@ -1,0 +1,19 @@
+package com.netflix.titus.master.service.management;
+
+import java.util.Map;
+
+import com.netflix.titus.api.agent.model.AgentInstanceGroup;
+import com.netflix.titus.api.agent.model.InstanceGroupLifecycleState;
+
+public class CapacityManagementFunctions {
+    public static boolean isAvailableToUse(AgentInstanceGroup instanceGroup) {
+        if (instanceGroup.getLifecycleStatus().getState() != InstanceGroupLifecycleState.Active &&
+                instanceGroup.getLifecycleStatus().getState() != InstanceGroupLifecycleState.PhasedOut) {
+            return false;
+        }
+
+        Map<String, String> attributes = instanceGroup.getAttributes();
+        boolean ignore = Boolean.parseBoolean(attributes.get(CapacityManagementAttributes.IGNORE));
+        return !ignore;
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/DefaultAvailableCapacityService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/DefaultAvailableCapacityService.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
 
-import static com.netflix.titus.api.agent.service.AgentManagementFunctions.isActiveOrPhasedOut;
+import static com.netflix.titus.master.service.management.CapacityManagementFunctions.isAvailableToUse;
 
 @Singleton
 public class DefaultAvailableCapacityService implements AvailableCapacityService {
@@ -126,7 +126,7 @@ public class DefaultAvailableCapacityService implements AvailableCapacityService
     private ResourceDimension resolveCapacityOf(Tier tier) {
         ResourceDimension total = ResourceDimension.empty();
         for (AgentInstanceGroup instanceGroup : agentManagementService.getInstanceGroups()) {
-            if (instanceGroup.getTier() == tier && isActiveOrPhasedOut(instanceGroup)) {
+            if (instanceGroup.getTier() == tier && isAvailableToUse(instanceGroup)) {
                 Optional<ServerInfo> serverInfo = serverInfoResolver.resolve(instanceGroup.getInstanceType());
                 if (serverInfo.isPresent()) {
                     long maxSize = tier == Tier.Critical ? instanceGroup.getCurrent() : instanceGroup.getMax();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/SimpleCapacityGuaranteeStrategy.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/SimpleCapacityGuaranteeStrategy.java
@@ -37,7 +37,7 @@ import com.netflix.titus.master.service.management.CapacityManagementConfigurati
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.netflix.titus.api.agent.service.AgentManagementFunctions.isActiveOrPhasedOut;
+import static com.netflix.titus.master.service.management.CapacityManagementFunctions.isAvailableToUse;
 
 /**
  * A simple strategy, where all resources required for a tier are first summed up, and next allocated on a first
@@ -87,7 +87,7 @@ public class SimpleCapacityGuaranteeStrategy implements CapacityGuaranteeStrateg
         List<AgentInstanceGroup> instanceGroups = agentManagementService.getInstanceGroups().stream()
                 .filter(instanceGroup -> instanceGroup.getTier() == tier &&
                         instanceGroup.getResourceDimension().getGpu() == 0 &&
-                        isActiveOrPhasedOut(instanceGroup))
+                        isAvailableToUse(instanceGroup))
                 .sorted(Comparator.comparing(AgentInstanceGroup::getId))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
### Description of the Change

Add capacity management attribute to ignore instance group when doing calculations and setting instance group mins.