### PR TITLE
Ignore JobDescriptor attributes for MoveTask compatibility checks

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibility.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibility.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.api.jobmanager.model.job;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +38,6 @@ import com.netflix.titus.api.jobmanager.model.job.retry.ImmediateRetryPolicy;
  * <li>Application name</li>
  * <li>Job group info (stack, details, sequence)</li>
  * <li>Disruption budget</li>
- * <li>Any attributes not prefixed with <tt>titus.</tt> or <tt>titusParameter.</tt></li>
  * <li>Any container attributes not prefixed with <tt>titus.</tt> or <tt>titusParameter.</tt></li>
  * <li>Any container.securityProfile attributes not prefixed with <tt>titus.</tt> or <tt>titusParameter.</tt></li>
  * <li>All information {@link ServiceJobExt specific to Service jobs}: capacity, retry policy, etc</li>
@@ -69,7 +69,6 @@ public class JobCompatibility {
     private static JobDescriptor<ServiceJobExt> unsetIgnoredFieldsForCompatibility(JobDescriptor<ServiceJobExt> descriptor) {
         Container container = descriptor.getContainer();
         SecurityProfile securityProfile = container.getSecurityProfile();
-        Map<String, String> onlyTitusAttributes = filterOutNonTitusAttributes(descriptor.getAttributes());
         Map<String, String> onlyTitusContainerAttributes = filterOutNonTitusAttributes(container.getAttributes());
         Map<String, String> onlyTitusSecurityAttributes = filterOutNonTitusAttributes(securityProfile.getAttributes());
 
@@ -77,7 +76,7 @@ public class JobCompatibility {
                 .withOwner(Owner.newBuilder().withTeamEmail("").build())
                 .withApplicationName("")
                 .withJobGroupInfo(JobGroupInfo.newBuilder().build())
-                .withAttributes(onlyTitusAttributes)
+                .withAttributes(Collections.emptyMap())
                 .withContainer(container.toBuilder()
                         .withAttributes(onlyTitusContainerAttributes)
                         .withSecurityProfile(securityProfile.toBuilder()

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibilityTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibilityTest.java
@@ -102,7 +102,7 @@ public class JobCompatibilityTest {
     }
 
     @Test
-    public void testAttributesNotPrefixedWithTitusAreCompatible() {
+    public void testJobAttributesAreIgnored() {
         JobDescriptor<ServiceJobExt> reference = JobDescriptorGenerator.oneTaskServiceJobDescriptor();
         JobDescriptor<ServiceJobExt> other = reference.toBuilder()
                 .withAttributes(CollectionsExt.copyAndAdd(reference.getAttributes(), "spinnaker.useApplicationDefaultSecurityGroup", "true"))
@@ -114,7 +114,7 @@ public class JobCompatibilityTest {
                 .withAttributes(CollectionsExt.copyAndAdd(reference.getAttributes(), "titus.value", "important"))
                 .build();
         JobCompatibility compatibility2 = JobCompatibility.of(reference, incompatible);
-        assertThat(compatibility2.isCompatible()).isFalse();
+        assertThat(compatibility2.isCompatible()).isTrue();
     }
 
     @Test

--- a/titus-common/src/main/java/com/netflix/titus/common/util/feature/FeatureComplianceLogger.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/feature/FeatureComplianceLogger.java
@@ -32,6 +32,10 @@ class FeatureComplianceLogger<T> extends FeatureComplianceDecorator<T> {
     @Override
     protected void processViolations(T value, NonComplianceList<T> nonCompliance) {
         String featureIds = nonCompliance.getViolations().stream().map(NonCompliance::getFeatureId).collect(Collectors.joining(","));
-        logger.info("[{}] Non compliant value: value={}, violations={}", featureIds, value, nonCompliance.getViolations());
+        if (logger.isDebugEnabled()) {
+            logger.debug("[{}] Non compliant value: value={}, violations={}", featureIds, value, nonCompliance.getViolations());
+        } else {
+            logger.info("[{}] Compliance violations={}", featureIds, nonCompliance.getViolations());
+        }
     }
 }


### PR DESCRIPTION
... since these are mutable and should never affect the runtime behavior of a Task.