### PR TITLE
Add job type (service or batch) field to passthrough attributes

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -63,6 +63,14 @@ public final class JobFunctions {
         return NO_DISRUPTION_BUDGET_MARKER;
     }
 
+    public static JobType getJobType(Job<?> job) {
+        return isServiceJob(job) ? JobType.SERVICE : JobType.BATCH;
+    }
+
+    public static JobType getJobType(JobDescriptor<?> jobDescriptor) {
+        return isServiceJob(jobDescriptor) ? JobType.SERVICE : JobType.BATCH;
+    }
+
     public static boolean isBatchJob(Job<?> job) {
         return job.getJobDescriptor().getExtensions() instanceof BatchJobExt;
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobType.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobType.java
@@ -1,0 +1,6 @@
+package com.netflix.titus.api.jobmanager.model.job;
+
+public enum JobType {
+    SERVICE,
+    BATCH
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
@@ -53,6 +53,7 @@ import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_PARAMETER_ATTRI
 import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_PARAMETER_ATTRIBUTES_ALLOW_NETWORK_BURSTING;
 import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_PARAMETER_ATTRIBUTES_KILL_WAIT_SECONDS;
 import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_PARAMETER_ATTRIBUTES_SCHED_BATCH;
+import static com.netflix.titus.api.jobmanager.model.job.JobFunctions.getJobType;
 import static com.netflix.titus.common.util.Evaluators.applyNotNull;
 
 /**
@@ -63,6 +64,7 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
 
     private static final String PASSTHROUGH_ATTRIBUTES_PREFIX = "titusParameter.agent.";
     private static final String OWNER_EMAIL_ATTRIBUTE = "titus.agent.ownerEmail";
+    private static final String JOB_TYPE_ATTRIBUTE = "titus.agent.jobType";
     private static final String EXECUTOR_PER_TASK_LABEL = "executorpertask";
     private static final String LEGACY_EXECUTOR_NAME = "docker-executor";
     private static final String EXECUTOR_PER_TASK_EXECUTOR_NAME = "docker-per-task-executor";
@@ -157,8 +159,11 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
             }
         });
 
-        // add owner email
+        // Add owner email
         containerInfoBuilder.putPassthroughAttributes(OWNER_EMAIL_ATTRIBUTE, jobDescriptor.getOwner().getTeamEmail());
+
+        // Add job type
+        containerInfoBuilder.putPassthroughAttributes(JOB_TYPE_ATTRIBUTE, getJobType(jobDescriptor).name());
 
         // Configure Environment Variables
         container.getEnv().forEach((k, v) -> {


### PR DESCRIPTION
### Description of the Change

The cpu prediction model requires the job type (service or batch) be available on the Agent.