### PR TITLE
Add property to initialize Jooq with an in-memory DB instead of Postgres

### DIFF
--- a/titus-ext/jooq/build.gradle
+++ b/titus-ext/jooq/build.gradle
@@ -28,12 +28,12 @@ dependencies {
 
     compile "org.jooq:jooq:${jooqVersion}"
     compile "org.postgresql:postgresql:${postgresqlVersion}"
+    compile "org.hsqldb:hsqldb:${hsqldbVersion}"
 
     // TODO Remove
     compile "org.jooq:jooq-meta:${jooqVersion}"
     compile "org.jooq:jooq-codegen:${jooqVersion}"
 
-    testCompile "org.hsqldb:hsqldb:${hsqldbVersion}"
     testCompile project(':titus-testkit')
 
     jooqRuntime "postgresql:postgresql:${postgresqlVersion}"

--- a/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqConfiguration.java
+++ b/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqConfiguration.java
@@ -24,4 +24,7 @@ public interface JooqConfiguration {
 
     @DefaultValue("jdbc://localhost")
     String getDatabaseUrl();
+
+    @DefaultValue("false")
+    boolean isInMemoryDb();
 }

--- a/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqConfigurationBean.java
+++ b/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqConfigurationBean.java
@@ -38,4 +38,9 @@ public class JooqConfigurationBean implements JooqConfiguration {
     public String getDatabaseUrl() {
         return SpringConfigurationUtil.getString(environment, PREFIX + "databaseUrl", "jdbc://notSet");
     }
+
+    @Override
+    public boolean isInMemoryDb() {
+        return SpringConfigurationUtil.getBoolean(environment, PREFIX + "inMemoryDb", false);
+    }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/util/SpringConfigurationUtil.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/util/SpringConfigurationUtil.java
@@ -44,4 +44,8 @@ public class SpringConfigurationUtil {
     public static String getString(Environment environment, String key, String defaultValue) {
         return environment.getProperty(key, defaultValue);
     }
+
+    public static boolean getBoolean(Environment environment, String key, boolean defaultValue) {
+        return environment.getProperty(key, Boolean.class, defaultValue);
+    }
 }


### PR DESCRIPTION
Adds the ability for the JooqModule to use an in-memory DB during injection based on a property. We use HSQL, which is what was used previously for test.