### PR TITLE
Explicity set jOOQ autocommit and remove explicit transaction creation from jOOQ Stores

### DIFF
--- a/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqModule.java
+++ b/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqModule.java
@@ -58,6 +58,9 @@ public class JooqModule extends AbstractModule {
                     connectionProvider = new DefaultConnectionProvider(DriverManager.getConnection(configuration.getDatabaseUrl()));
                     dialect = SQLDialect.POSTGRES_9_5;
                 }
+
+                // Explicitly set autoCommit as jOOQ Store impls should expect automatic transaction management
+                ((DefaultConnectionProvider) connectionProvider).setAutoCommit(true);
             } catch (SQLException e) {
                 throw new IllegalStateException("Cannot initialize connection to Postgres database", e);
             }

--- a/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqUtils.java
+++ b/titus-ext/jooq/src/main/java/com/netflix/titus/ext/jooq/JooqUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.jooq;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import org.jooq.DSLContext;
+import reactor.core.publisher.Mono;
+
+public class JooqUtils {
+
+    // Returns a CompletableStage that asynchronously runs the supplier on the DSL's executor
+    public static <T> CompletionStage<T> executeAsync(Supplier<T> supplier, DSLContext dslContext) {
+        return CompletableFuture.supplyAsync(supplier, dslContext.configuration().executorProvider().provide());
+    }
+
+    // Returns a Mono that asynchronously runs the supplier on the DSL's executor
+    public static <T> Mono<T> executeAsyncMono(Supplier<T> supplier, DSLContext dslContext) {
+        return Mono.fromCompletionStage(executeAsync(supplier, dslContext));
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobactivity/service/JobActivityPublisher.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobactivity/service/JobActivityPublisher.java
@@ -121,14 +121,19 @@ public class JobActivityPublisher {
      * events will simply result in missed records being published to Job Activity.
      */
     private void handleJobManagerEvent(JobManagerEvent<?> jobManagerEvent) {
-        if (jobManagerEvent instanceof JobUpdateEvent) {
-            JobUpdateEvent jobUpdateEvent = (JobUpdateEvent)jobManagerEvent;
-            handleJobUpdateEvent(jobUpdateEvent);
-        } else if (jobManagerEvent instanceof TaskUpdateEvent) {
-            TaskUpdateEvent taskUpdateEvent = (TaskUpdateEvent)jobManagerEvent;
-            handleTaskUpdateEvent(taskUpdateEvent);
-        } else {
-            logger.error("Got other event type: {} on {}", jobManagerEvent.getClass(), Thread.currentThread().getId());
+        try {
+            if (jobManagerEvent instanceof JobUpdateEvent) {
+                JobUpdateEvent jobUpdateEvent = (JobUpdateEvent) jobManagerEvent;
+                handleJobUpdateEvent(jobUpdateEvent);
+            } else if (jobManagerEvent instanceof TaskUpdateEvent) {
+                TaskUpdateEvent taskUpdateEvent = (TaskUpdateEvent) jobManagerEvent;
+                handleTaskUpdateEvent(taskUpdateEvent);
+            } else {
+                logger.error("Got other event type: {} on {}", jobManagerEvent.getClass(), Thread.currentThread().getId());
+            }
+        } catch (Exception e) {
+            // Paranoid check to avoid Exception propagation to the event stream publisher
+            logger.error("Exception caught while processing event stream. DROPPING to avoid impacting publisher: {}", e);
         }
     }
 


### PR DESCRIPTION
This PR explicitly sets DB AutoCommit (https://docs.oracle.com/javase/6/docs/api/java/sql/Connection.html?is-external=true#setAutoCommit(boolean)) for all jOOQ stores. With autocommit, each store does not need to explicitly create their own transactions.

There is also a safety check in the Publisher that consumes the `observeJobs()` stream so that we don't accidentally propagate an Exception back to the publisher.