### PR TITLE
Refactoring/job client

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
@@ -90,6 +90,10 @@ public final class CollectionsExt {
         return it.hasNext() ? it.next() : null;
     }
 
+    public static <T> T firstOrDefault(Collection<T> collection, T defaultValue) {
+        return isNullOrEmpty(collection) ? defaultValue : collection.iterator().next();
+    }
+
     public static <T> T last(List<T> list) {
         return list.isEmpty() ? null : list.get(list.size() - 1);
     }

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
@@ -66,7 +66,7 @@ import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskMoveRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
@@ -90,8 +90,8 @@ import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createRequ
 import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
 
 @Singleton
-public class AggregatingJobManagementClient implements JobManagementClient {
-    private static final Logger logger = LoggerFactory.getLogger(AggregatingJobManagementClient.class);
+public class AggregatingJobServiceGateway implements JobServiceGateway {
+    private static final Logger logger = LoggerFactory.getLogger(AggregatingJobServiceGateway.class);
 
     // some fields are required from each cell, so pagination cursors can be generated
     private static final Set<String> JOB_FEDERATION_MINIMUM_FIELD_SET = CollectionsExt.asSet("id", "status", "statusHistory");
@@ -106,13 +106,13 @@ public class AggregatingJobManagementClient implements JobManagementClient {
     private final CallMetadataResolver callMetadataResolver;
 
     @Inject
-    public AggregatingJobManagementClient(GrpcConfiguration grpcConfiguration,
-                                          TitusFederationConfiguration federationConfiguration,
-                                          CellConnector connector,
-                                          CellRouter router,
-                                          CallMetadataResolver callMetadataResolver,
-                                          AggregatingCellClient aggregatingClient,
-                                          AggregatingJobManagementServiceHelper jobManagementServiceHelper) {
+    public AggregatingJobServiceGateway(GrpcConfiguration grpcConfiguration,
+                                        TitusFederationConfiguration federationConfiguration,
+                                        CellConnector connector,
+                                        CellRouter router,
+                                        CallMetadataResolver callMetadataResolver,
+                                        AggregatingCellClient aggregatingClient,
+                                        AggregatingJobManagementServiceHelper jobManagementServiceHelper) {
 
         this.grpcConfiguration = grpcConfiguration;
         this.federationConfiguration = federationConfiguration;

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/ServiceModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/ServiceModule.java
@@ -17,7 +17,7 @@
 package com.netflix.titus.federation.service;
 
 import com.google.inject.AbstractModule;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.runtime.service.AutoScalingService;
 import com.netflix.titus.runtime.service.HealthService;
 import com.netflix.titus.runtime.service.LoadBalancerService;
@@ -26,7 +26,7 @@ public class ServiceModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(HealthService.class).to(AggregatingHealthService.class);
-        bind(JobManagementClient.class).to(AggregatingJobManagementClient.class);
+        bind(JobServiceGateway.class).to(AggregatingJobServiceGateway.class);
         bind(AutoScalingService.class).to(AggregatingAutoScalingService.class);
         bind(LoadBalancerService.class).to(AggregatingLoadbalancerService.class);
     }

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayTest.java
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AggregatingJobManagementClientTest {
+public class AggregatingJobServiceGatewayTest {
     private static final JobStatus ACCEPTED_STATE = JobStatus.newBuilder().setState(JobStatus.JobState.Accepted).build();
     private static final JobStatus KILL_INITIATED_STATE = JobStatus.newBuilder().setState(JobStatus.JobState.KillInitiated).build();
     private static final JobStatus FINISHED_STATE = JobStatus.newBuilder().setState(JobStatus.JobState.Finished).build();
@@ -104,7 +104,7 @@ public class AggregatingJobManagementClientTest {
     private final PublishSubject<JobChangeNotification> cellTwoUpdates = PublishSubject.create();
 
     private String stackName;
-    private AggregatingJobManagementClient service;
+    private AggregatingJobServiceGateway service;
     private List<Cell> cells;
     private Map<Cell, GrpcServerRule> cellToServiceMap;
     private TestClock clock;
@@ -141,7 +141,7 @@ public class AggregatingJobManagementClientTest {
 
         final AggregatingCellClient aggregatingCellClient = new AggregatingCellClient(connector);
         final AnonymousCallMetadataResolver anonymousCallMetadataResolver = new AnonymousCallMetadataResolver();
-        service = new AggregatingJobManagementClient(
+        service = new AggregatingJobServiceGateway(
                 grpcConfiguration,
                 titusFederationConfiguration,
                 connector,

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayWithSingleCellTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayWithSingleCellTest.java
@@ -56,14 +56,14 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AggregatingJobManagementClientWithSingleCellTest {
+public class AggregatingJobServiceGatewayWithSingleCellTest {
     private static final int TASKS_IN_GENERATED_JOBS = 10;
 
     @Rule
     public final GrpcServerRule cell = new GrpcServerRule().directExecutor();
 
     private String stackName;
-    private AggregatingJobManagementClient service;
+    private AggregatingJobServiceGateway service;
     private Map<Cell, GrpcServerRule> cellToServiceMap;
     private TestClock clock;
     private ServiceDataGenerator dataGenerator;
@@ -96,7 +96,7 @@ public class AggregatingJobManagementClientWithSingleCellTest {
 
         final AggregatingCellClient aggregatingCellClient = new AggregatingCellClient(connector);
         final AnonymousCallMetadataResolver anonymousCallMetadataResolver = new AnonymousCallMetadataResolver();
-        service = new AggregatingJobManagementClient(
+        service = new AggregatingJobServiceGateway(
                 grpcClientConfiguration,
                 titusFederationConfiguration,
                 connector,

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/V3ServiceModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/V3ServiceModule.java
@@ -27,11 +27,11 @@ import com.netflix.titus.gateway.service.v3.internal.DefaultLoadBalancerService;
 import com.netflix.titus.gateway.service.v3.internal.DefaultSchedulerService;
 import com.netflix.titus.gateway.service.v3.internal.DefaultTitusManagementService;
 import com.netflix.titus.gateway.service.v3.internal.GatewayConfiguration;
-import com.netflix.titus.gateway.service.v3.internal.GatewayJobManagementClient;
+import com.netflix.titus.gateway.service.v3.internal.GatewayJobServiceGateway;
 import com.netflix.titus.runtime.connector.ChannelTunablesConfiguration;
 import com.netflix.titus.runtime.connector.GrpcClientConfiguration;
 import com.netflix.titus.runtime.connector.agent.AgentManagerConnectorModule;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.runtime.jobmanager.JobManagerConfiguration;
 import com.netflix.titus.runtime.service.AutoScalingService;
 import com.netflix.titus.runtime.service.HealthService;
@@ -43,7 +43,7 @@ public class V3ServiceModule extends AbstractModule {
         install(new AgentManagerConnectorModule());
 
         bind(HealthService.class).to(DefaultHealthService.class);
-        bind(JobManagementClient.class).to(GatewayJobManagementClient.class);
+        bind(JobServiceGateway.class).to(GatewayJobServiceGateway.class);
         bind(AutoScalingService.class).to(DefaultAutoScalingService.class);
         bind(LoadBalancerService.class).to(DefaultLoadBalancerService.class);
         bind(TitusManagementService.class).to(DefaultTitusManagementService.class);

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
@@ -60,10 +60,10 @@ import com.netflix.titus.grpc.protogen.TaskId;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
 import com.netflix.titus.runtime.connector.ChannelTunablesConfiguration;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
-import com.netflix.titus.runtime.connector.jobmanager.client.GrpcJobManagementClient;
-import com.netflix.titus.runtime.connector.jobmanager.client.JobManagementClientDelegate;
-import com.netflix.titus.runtime.connector.jobmanager.client.SanitizingJobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
+import com.netflix.titus.runtime.jobmanager.gateway.GrpcJobServiceGateway;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGatewayDelegate;
+import com.netflix.titus.runtime.jobmanager.gateway.SanitizingJobServiceGateway;
 import com.netflix.titus.runtime.endpoint.common.LogStorageInfo;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.v3.grpc.V3GrpcModelConverters;
@@ -86,12 +86,12 @@ import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createSimp
 import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
 
 /**
- * {@link JobManagementClient} implementation merging the active and the archived data sets with extra validation rules.
+ * {@link JobServiceGateway} implementation merging the active and the archived data sets with extra validation rules.
  */
 @Singleton
-public class GatewayJobManagementClient extends JobManagementClientDelegate {
+public class GatewayJobServiceGateway extends JobServiceGatewayDelegate {
 
-    private static Logger logger = LoggerFactory.getLogger(GatewayJobManagementClient.class);
+    private static Logger logger = LoggerFactory.getLogger(GatewayJobServiceGateway.class);
 
     private static final int MAX_CONCURRENT_JOBS_TO_RETRIEVE = 10;
 
@@ -107,22 +107,22 @@ public class GatewayJobManagementClient extends JobManagementClientDelegate {
     private final Clock clock;
 
     @Inject
-    public GatewayJobManagementClient(ChannelTunablesConfiguration tunablesConfiguration,
-                                      GatewayConfiguration gatewayConfiguration,
-                                      JobManagerConfiguration jobManagerConfiguration,
-                                      JobManagementServiceStub client,
-                                      CallMetadataResolver callMetadataResolver,
-                                      JobStore store,
-                                      LogStorageInfo<com.netflix.titus.api.jobmanager.model.job.Task> logStorageInfo,
-                                      TaskRelocationDataInjector taskRelocationDataInjector,
-                                      @Named(JOB_STRICT_SANITIZER) EntitySanitizer entitySanitizer,
-                                      @Named(SECURITY_GROUPS_REQUIRED_FEATURE) Predicate<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> securityGroupsRequiredPredicate,
-                                      @Named(ENVIRONMENT_VARIABLE_NAMES_STRICT_VALIDATION_FEATURE) Predicate<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> environmentVariableNamesStrictValidationPredicate,
-                                      JobAssertions jobAssertions,
-                                      EntityValidator<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> validator,
-                                      TitusRuntime titusRuntime) {
-        super(new SanitizingJobManagementClient(
-                new GrpcJobManagementClient(
+    public GatewayJobServiceGateway(ChannelTunablesConfiguration tunablesConfiguration,
+                                    GatewayConfiguration gatewayConfiguration,
+                                    JobManagerConfiguration jobManagerConfiguration,
+                                    JobManagementServiceStub client,
+                                    CallMetadataResolver callMetadataResolver,
+                                    JobStore store,
+                                    LogStorageInfo<com.netflix.titus.api.jobmanager.model.job.Task> logStorageInfo,
+                                    TaskRelocationDataInjector taskRelocationDataInjector,
+                                    @Named(JOB_STRICT_SANITIZER) EntitySanitizer entitySanitizer,
+                                    @Named(SECURITY_GROUPS_REQUIRED_FEATURE) Predicate<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> securityGroupsRequiredPredicate,
+                                    @Named(ENVIRONMENT_VARIABLE_NAMES_STRICT_VALIDATION_FEATURE) Predicate<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> environmentVariableNamesStrictValidationPredicate,
+                                    JobAssertions jobAssertions,
+                                    EntityValidator<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> validator,
+                                    TitusRuntime titusRuntime) {
+        super(new SanitizingJobServiceGateway(
+                new GrpcJobServiceGateway(
                         client,
                         callMetadataResolver,
                         tunablesConfiguration

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayModule.java
@@ -43,6 +43,7 @@ import com.netflix.titus.gateway.service.v3.V3ServiceModule;
 import com.netflix.titus.gateway.store.StoreModule;
 import com.netflix.titus.runtime.TitusEntitySanitizerModule;
 import com.netflix.titus.runtime.connector.eviction.EvictionConnectorModule;
+import com.netflix.titus.runtime.connector.jobmanager.JobManagerConnectorModule;
 import com.netflix.titus.runtime.connector.registry.TitusContainerRegistryModule;
 import com.netflix.titus.runtime.connector.relocation.RelocationClientModule;
 import com.netflix.titus.runtime.connector.relocation.RelocationClientTransportModule;
@@ -95,6 +96,7 @@ public final class TitusGatewayModule extends AbstractModule {
 
         install(new GatewayEndpointModule(enableREST));
         install(new TitusMasterConnectorModule());
+        install(new JobManagerConnectorModule());
         install(new EvictionConnectorModule());
 
         // Integration with the task relocation service is required, as we have to inject a migration plan

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGatewayTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGatewayTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import static com.netflix.titus.common.util.Evaluators.evaluateTimes;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class GatewayJobManagementClientTest {
+public class GatewayJobServiceGatewayTest {
 
     private static final int PAGE_SIZE = 2;
 
@@ -76,7 +76,7 @@ public class GatewayJobManagementClientTest {
         archivedTasks.add(Task.newBuilder().setId("task3").build());
         archivedTasks.add(Task.newBuilder().setId("task4").build());
 
-        List<Task> tasks = GatewayJobManagementClient.deDupTasks(activeTasks, archivedTasks);
+        List<Task> tasks = GatewayJobServiceGateway.deDupTasks(activeTasks, archivedTasks);
         assertThat(tasks.size()).isEqualTo(4);
 
         List<String> taskIds = tasks.stream().map(Task::getId).sorted().collect(Collectors.toList());
@@ -91,7 +91,7 @@ public class GatewayJobManagementClientTest {
         archivedTasks.add(Task.newBuilder().setId("task3").build());
         archivedTasks.add(Task.newBuilder().setId("task4").build());
 
-        tasks = GatewayJobManagementClient.deDupTasks(activeTasks, archivedTasks);
+        tasks = GatewayJobServiceGateway.deDupTasks(activeTasks, archivedTasks);
         assertThat(tasks.size()).isEqualTo(4);
         taskIds = tasks.stream().map(Task::getId).collect(Collectors.toList());
         Collections.sort(taskIds);
@@ -118,7 +118,7 @@ public class GatewayJobManagementClientTest {
         for (int p = 1; p < ARCHIVED_TASKS_COUNT / PAGE_SIZE; p++) {
             TaskQuery cursorQuery = queryFunction.apply(lastPagination);
 
-            TaskQueryResult cursorResult = GatewayJobManagementClient.combineTaskResults(cursorQuery, activePageResultFunction.apply(0), ARCHIVED_TASKS);
+            TaskQueryResult cursorResult = GatewayJobServiceGateway.combineTaskResults(cursorQuery, activePageResultFunction.apply(0), ARCHIVED_TASKS);
             checkCombinedResult(cursorResult, ARCHIVED_TASKS.subList(p * PAGE_SIZE, (p + 1) * PAGE_SIZE));
 
             lastPagination = cursorResult.getPagination();
@@ -128,7 +128,7 @@ public class GatewayJobManagementClientTest {
         for (int p = 0; p < JOB_SIZE / PAGE_SIZE; p++) {
             TaskQuery cursorQuery = queryFunction.apply(lastPagination);
 
-            TaskQueryResult cursorResult = GatewayJobManagementClient.combineTaskResults(cursorQuery, activePageResultFunction.apply(p), ARCHIVED_TASKS);
+            TaskQueryResult cursorResult = GatewayJobServiceGateway.combineTaskResults(cursorQuery, activePageResultFunction.apply(p), ARCHIVED_TASKS);
             checkCombinedResult(cursorResult, ACTIVE_TASKS.subList(p * PAGE_SIZE, (p + 1) * PAGE_SIZE));
 
             lastPagination = cursorResult.getPagination();
@@ -139,7 +139,7 @@ public class GatewayJobManagementClientTest {
         TaskQuery taskQuery = TaskQuery.newBuilder().setPage(FIRST_PAGE).build();
         TaskQueryResult page0ActiveSetResult = takeActivePage(0);
 
-        TaskQueryResult combinedResult = GatewayJobManagementClient.combineTaskResults(taskQuery, page0ActiveSetResult, ARCHIVED_TASKS);
+        TaskQueryResult combinedResult = GatewayJobServiceGateway.combineTaskResults(taskQuery, page0ActiveSetResult, ARCHIVED_TASKS);
         checkCombinedResult(combinedResult, ARCHIVED_TASKS.subList(0, PAGE_SIZE));
         return combinedResult;
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -102,8 +102,8 @@ import rx.Observable;
 import rx.Subscription;
 
 import static com.netflix.titus.api.jobmanager.model.job.sanitizer.JobSanitizerBuilder.JOB_STRICT_SANITIZER;
-import static com.netflix.titus.runtime.connector.jobmanager.JobManagementClient.JOB_MINIMUM_FIELD_SET;
-import static com.netflix.titus.runtime.connector.jobmanager.JobManagementClient.TASK_MINIMUM_FIELD_SET;
+import static com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway.JOB_MINIMUM_FIELD_SET;
+import static com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway.TASK_MINIMUM_FIELD_SET;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.toGrpcPagination;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.toJobQueryCriteria;
 import static com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters.toPage;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/FluxMethodBridge.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/FluxMethodBridge.java
@@ -18,11 +18,17 @@ package com.netflix.titus.runtime.connector.common.reactor;
 
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Empty;
+import com.netflix.titus.api.jobmanager.model.CallMetadata;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
+import io.grpc.Deadline;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServiceDescriptor;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
@@ -31,26 +37,46 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 
+import static com.netflix.titus.runtime.connector.common.reactor.GrpcToReactUtil.toMethodNameFromFullName;
+
 class FluxMethodBridge<GRPC_STUB extends AbstractStub<GRPC_STUB>> implements Function<Object[], Publisher> {
 
     private final Method grpcMethod;
-    private final Supplier<GRPC_STUB> grpcStubSupplier;
-    private final Duration reactorTimeout;
     private final boolean streamingResponse;
+    private final int grpcArgPos;
+    private final int callMetadataPos;
+    private final CallMetadataResolver callMetadataResolver;
+    private final GRPC_STUB grpcStub;
+    private final Duration timeout;
+    private final Duration reactorTimeout;
 
     FluxMethodBridge(Method reactMethod,
+                     ServiceDescriptor grpcServiceDescriptor,
                      Method grpcMethod,
-                     Supplier<GRPC_STUB> grpcStubSupplier,
-                     boolean streamingResponse,
-                     Duration reactorTimeout) {
-        this.streamingResponse = streamingResponse;
+                     int grpcArgPos,
+                     int callMetadataPos,
+                     CallMetadataResolver callMetadataResolver,
+                     GRPC_STUB grpcStub,
+                     Duration timeout,
+                     Duration streamingTimeout) {
+        this.grpcArgPos = grpcArgPos;
+        this.callMetadataPos = callMetadataPos;
+        this.callMetadataResolver = callMetadataResolver;
+        this.grpcStub = grpcStub;
+
+        this.streamingResponse = grpcServiceDescriptor.getMethods().stream()
+                .filter(m -> toMethodNameFromFullName(m.getFullMethodName()).equals(reactMethod.getName()))
+                .findFirst()
+                .map(m -> m.getType() == MethodDescriptor.MethodType.SERVER_STREAMING)
+                .orElse(false);
+
         Preconditions.checkArgument(
                 !GrpcToReactUtil.isEmptyToVoidResult(reactMethod, grpcMethod),
                 "Empty GRPC reply to Flux<Mono> mapping not supported (use Mono<Void> in API definition instead)"
         );
         this.grpcMethod = grpcMethod;
-        this.grpcStubSupplier = grpcStubSupplier;
-        this.reactorTimeout = reactorTimeout;
+        this.timeout = streamingResponse ? streamingTimeout : timeout;
+        this.reactorTimeout = Duration.ofMillis((long) (timeout.toMillis() * GrpcToReactUtil.RX_CLIENT_TIMEOUT_FACTOR));
     }
 
     @Override
@@ -85,14 +111,27 @@ class FluxMethodBridge<GRPC_STUB extends AbstractStub<GRPC_STUB>> implements Fun
             };
 
             Object[] grpcArgs = new Object[]{
-                    (args == null || args.length == 0) ? Empty.getDefaultInstance() : args[0],
+                    grpcArgPos < 0 ? Empty.getDefaultInstance() : args[grpcArgPos],
                     grpcStreamObserver
             };
+
+            GRPC_STUB invocationStub = handleCallMetadata(args)
+                    .withDeadline(Deadline.after(timeout.toMillis(), TimeUnit.MILLISECONDS));
+
             try {
-                grpcMethod.invoke(grpcStubSupplier.get(), grpcArgs);
+                grpcMethod.invoke(invocationStub, grpcArgs);
             } catch (Exception e) {
                 sink.error(e);
             }
+        }
+
+        private GRPC_STUB handleCallMetadata(Object[] args) {
+            if (callMetadataPos >= 0) {
+                return V3HeaderInterceptor.attachCallMetadata(grpcStub, (CallMetadata) args[callMetadataPos]);
+            }
+            return callMetadataResolver.resolve()
+                    .map(callMetadata -> V3HeaderInterceptor.attachCallMetadata(grpcStub, callMetadata))
+                    .orElse(grpcStub);
         }
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/FluxMethodBridge.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/FluxMethodBridge.java
@@ -50,6 +50,10 @@ class FluxMethodBridge<GRPC_STUB extends AbstractStub<GRPC_STUB>> implements Fun
     private final Duration timeout;
     private final Duration reactorTimeout;
 
+    /**
+     * If grpcArgPos is less then zero, it means no GRPC argument is provided, and instead {@link Empty} value should be used.
+     * If callMetadataPos is less then zero, it means the {@link CallMetadata} value should be resolved from the local context.
+     */
     FluxMethodBridge(Method reactMethod,
                      ServiceDescriptor grpcServiceDescriptor,
                      Method grpcMethod,

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/GrpcToReactUtil.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/GrpcToReactUtil.java
@@ -19,10 +19,12 @@ package com.netflix.titus.runtime.connector.common.reactor;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Set;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
+import com.netflix.titus.common.util.CollectionsExt;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.StreamObserver;
 import reactor.core.publisher.Flux;
@@ -30,11 +32,17 @@ import reactor.core.publisher.Mono;
 
 class GrpcToReactUtil {
 
-    static Method getGrpcMethod(AbstractStub<?> grpcStub, Method method) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        Preconditions.checkArgument(parameterTypes.length <= 1, "Expected method with none or one protobuf object parameter but is: %s", method);
+    /**
+     * For request/response GRPC calls, we set execution deadline at both Reactor and GRPC level. As we prefer the timeout
+     * be triggered by GRPC, which may give us potentially more insight, we adjust Reactor timeout value by this factor.
+     */
+    static final double RX_CLIENT_TIMEOUT_FACTOR = 1.2;
 
-        Class<?> requestType = parameterTypes.length == 0 ? Empty.class : parameterTypes[0];
+    static Method getGrpcMethod(AbstractStub<?> grpcStub, Method method, Set<Class> handlerTypes) {
+        Set<Class> transferredParameters = CollectionsExt.copyAndRemove(CollectionsExt.<Class>asSet((Class[]) method.getParameterTypes()), handlerTypes);
+        Preconditions.checkArgument(transferredParameters.size() <= 1, "Expected method with none or one protobuf object parameter but is: %s", method);
+
+        Class<?> requestType = transferredParameters.isEmpty() ? Empty.class : CollectionsExt.first(transferredParameters);
         Preconditions.checkArgument(Message.class.isAssignableFrom(requestType), "Not protobuf message in method parameter: %s", method);
 
         Class<?> returnType = method.getReturnType();

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/GrpcToReactUtil.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/GrpcToReactUtil.java
@@ -46,7 +46,7 @@ class GrpcToReactUtil {
                 .filter(type -> !handlerTypes.contains(type))
                 .collect(Collectors.toList());
 
-        Preconditions.checkArgument(transferredParameters.size() <= 1, "Expected method with none or one protobuf object parameter but is: %s", method);
+        Preconditions.checkArgument(transferredParameters.size() <= 1, "Method must have one or zero protobuf object parameters but is: %s", method);
 
         Class<?> requestType = CollectionsExt.firstOrDefault(transferredParameters, Empty.class);
         Preconditions.checkArgument(Message.class.isAssignableFrom(requestType), "Not protobuf message in method parameter: %s", method);

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/MonoMethodBridge.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/MonoMethodBridge.java
@@ -45,6 +45,10 @@ class MonoMethodBridge<GRPC_STUB extends AbstractStub<GRPC_STUB>> implements Fun
     private final Duration timeout;
     private final Duration reactorTimeout;
 
+    /**
+     * If grpcArgPos is less then zero, it means no GRPC argument is provided, and instead {@link Empty} value should be used.
+     * If callMetadataPos is less then zero, it means the {@link CallMetadata} value should be resolved from the local context.
+     */
     MonoMethodBridge(Method reactMethod,
                      Method grpcMethod,
                      int grpcArgPos,

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagementDataReplicationComponent.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagementDataReplicationComponent.java
@@ -19,6 +19,7 @@ package com.netflix.titus.runtime.connector.jobmanager;
 import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.runtime.connector.jobmanager.replicator.JobDataReplicatorProvider;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -26,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
 public class JobManagementDataReplicationComponent {
 
     @Bean
-    public JobDataReplicator getJobDataReplicator(JobManagementClient client, TitusRuntime titusRuntime) {
+    public JobDataReplicator getJobDataReplicator(JobServiceGateway client, TitusRuntime titusRuntime) {
         return new JobDataReplicatorProvider(client, titusRuntime).get();
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagerConnectorComponent.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagerConnectorComponent.java
@@ -21,8 +21,9 @@ import javax.inject.Named;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceStub;
 import com.netflix.titus.runtime.connector.ChannelTunablesConfiguration;
-import com.netflix.titus.runtime.connector.jobmanager.client.GrpcJobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.GrpcJobServiceGateway;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import io.grpc.Channel;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,9 +40,9 @@ public class JobManagerConnectorComponent {
 
 
     @Bean
-    public JobManagementClient getJobManagementClient(ChannelTunablesConfiguration configuration,
-                                                      JobManagementServiceStub clientStub,
-                                                      CallMetadataResolver callMetadataResolver) {
-        return new GrpcJobManagementClient(clientStub, callMetadataResolver, configuration);
+    public JobServiceGateway getJobManagementClient(ChannelTunablesConfiguration configuration,
+                                                    JobManagementServiceStub clientStub,
+                                                    CallMetadataResolver callMetadataResolver) {
+        return new GrpcJobServiceGateway(clientStub, callMetadataResolver, configuration);
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/ReactorJobManagementServiceStub.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/ReactorJobManagementServiceStub.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.jobmanager;
+
+import com.netflix.titus.api.jobmanager.model.CallMetadata;
+import com.netflix.titus.grpc.protogen.Job;
+import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
+import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
+import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
+import com.netflix.titus.grpc.protogen.JobChangeNotification;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+import com.netflix.titus.grpc.protogen.JobDisruptionBudgetUpdate;
+import com.netflix.titus.grpc.protogen.JobId;
+import com.netflix.titus.grpc.protogen.JobProcessesUpdate;
+import com.netflix.titus.grpc.protogen.JobQuery;
+import com.netflix.titus.grpc.protogen.JobQueryResult;
+import com.netflix.titus.grpc.protogen.JobStatusUpdate;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
+import com.netflix.titus.grpc.protogen.TaskAttributesDeleteRequest;
+import com.netflix.titus.grpc.protogen.TaskAttributesUpdate;
+import com.netflix.titus.grpc.protogen.TaskId;
+import com.netflix.titus.grpc.protogen.TaskKillRequest;
+import com.netflix.titus.grpc.protogen.TaskMoveRequest;
+import com.netflix.titus.grpc.protogen.TaskQuery;
+import com.netflix.titus.grpc.protogen.TaskQueryResult;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ReactorJobManagementServiceStub {
+
+    // ------------------------------------------------------------
+    // Job operations
+
+    Mono<JobId> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata);
+
+    Mono<Void> updateJobCapacity(JobCapacityUpdate jobCapacityUpdate, CallMetadata callMetadata);
+
+    Mono<Void> updateJobStatus(JobStatusUpdate jobStatusUpdate, CallMetadata callMetadata);
+
+    Mono<Void> updateJobProcesses(JobProcessesUpdate jobProcessesUpdate, CallMetadata callMetadata);
+
+    Mono<Void> updateJobDisruptionBudget(JobDisruptionBudgetUpdate jobDisruptionBudgetUpdate, CallMetadata callMetadata);
+
+    Mono<JobQueryResult> findJobs(JobQuery jobQuery);
+
+    Mono<Job> findJob(JobId jobId);
+
+    Flux<JobChangeNotification> observeJob(JobId jobId);
+
+    Flux<JobChangeNotification> observeJobs(ObserveJobsQuery observeJobsQuery);
+
+    Mono<Void> killJob(JobId jobId, CallMetadata callMetadata);
+
+    Mono<Void> updateJobAttributes(JobAttributesUpdate jobAttributesUpdate, CallMetadata callMetadata);
+
+    Mono<Void> deleteJobAttributes(JobAttributesDeleteRequest jobAttributesDeleteRequest, CallMetadata callMetadata);
+
+    // ------------------------------------------------------------
+    // Task operations
+
+    Mono<Void> findTask(TaskId taskId);
+
+    Mono<TaskQueryResult> findTasks(TaskQuery taskQuery);
+
+    Mono<Void> killTask(TaskKillRequest taskKillRequest, CallMetadata callMetadata);
+
+    Mono<Void> updateTaskAttributes(TaskAttributesUpdate taskAttributesUpdate, CallMetadata callMetadata);
+
+    Mono<Void> deleteTaskAttributes(TaskAttributesDeleteRequest taskAttributesDeleteRequest, CallMetadata callMetadata);
+
+    Mono<Void> moveTask(TaskMoveRequest taskMoveRequest, CallMetadata callMetadata);
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStream.java
@@ -37,7 +37,7 @@ import com.netflix.titus.grpc.protogen.TaskStatus;
 import com.netflix.titus.runtime.connector.common.replicator.AbstractReplicatorEventStream;
 import com.netflix.titus.runtime.connector.common.replicator.DataReplicatorMetrics;
 import com.netflix.titus.runtime.connector.common.replicator.ReplicatorEvent;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.runtime.connector.jobmanager.JobSnapshot;
 import com.netflix.titus.runtime.endpoint.v3.grpc.V3GrpcModelConverters;
 import org.slf4j.Logger;
@@ -49,9 +49,9 @@ public class GrpcJobReplicatorEventStream extends AbstractReplicatorEventStream<
 
     private static final Logger logger = LoggerFactory.getLogger(GrpcJobReplicatorEventStream.class);
 
-    private final JobManagementClient client;
+    private final JobServiceGateway client;
 
-    public GrpcJobReplicatorEventStream(JobManagementClient client,
+    public GrpcJobReplicatorEventStream(JobServiceGateway client,
                                         DataReplicatorMetrics metrics,
                                         TitusRuntime titusRuntime,
                                         Scheduler scheduler) {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/JobDataReplicatorProvider.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/jobmanager/replicator/JobDataReplicatorProvider.java
@@ -29,7 +29,7 @@ import com.netflix.titus.runtime.connector.common.replicator.DataReplicatorMetri
 import com.netflix.titus.runtime.connector.common.replicator.RetryableReplicatorEventStream;
 import com.netflix.titus.runtime.connector.common.replicator.StreamDataReplicator;
 import com.netflix.titus.runtime.connector.jobmanager.JobDataReplicator;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.runtime.connector.jobmanager.JobSnapshot;
 import reactor.core.scheduler.Schedulers;
 
@@ -45,7 +45,7 @@ public class JobDataReplicatorProvider implements Provider<JobDataReplicator> {
     private final JobDataReplicatorImpl replicator;
 
     @Inject
-    public JobDataReplicatorProvider(JobManagementClient client, TitusRuntime titusRuntime) {
+    public JobDataReplicatorProvider(JobServiceGateway client, TitusRuntime titusRuntime) {
         StreamDataReplicator<JobSnapshot, JobManagerEvent<?>> original = StreamDataReplicator.newStreamDataReplicator(
                 newReplicatorEventStream(client, titusRuntime),
                 new DataReplicatorMetrics(JOB_REPLICATOR, titusRuntime),
@@ -60,7 +60,7 @@ public class JobDataReplicatorProvider implements Provider<JobDataReplicator> {
         return replicator;
     }
 
-    private static RetryableReplicatorEventStream<JobSnapshot, JobManagerEvent<?>> newReplicatorEventStream(JobManagementClient client, TitusRuntime titusRuntime) {
+    private static RetryableReplicatorEventStream<JobSnapshot, JobManagerEvent<?>> newReplicatorEventStream(JobServiceGateway client, TitusRuntime titusRuntime) {
         GrpcJobReplicatorEventStream grpcEventStream = new GrpcJobReplicatorEventStream(
                 client,
                 new DataReplicatorMetrics(JOB_REPLICATOR_GRPC_STREAM, titusRuntime),

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/GrpcJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/GrpcJobServiceGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.connector.jobmanager.client;
+package com.netflix.titus.runtime.jobmanager.gateway;
 
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
@@ -44,7 +44,6 @@ import com.netflix.titus.grpc.protogen.TaskMoveRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
 import com.netflix.titus.runtime.connector.ChannelTunablesConfiguration;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
 import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
@@ -60,19 +59,19 @@ import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createSimp
 import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
 
 /**
- * {@link JobManagementClient} implementation that connects to TitusMaster over the GRPC channel.
+ * {@link JobServiceGateway} implementation that connects to TitusMaster over the GRPC channel.
  */
 @Singleton
-public class GrpcJobManagementClient implements JobManagementClient {
+public class GrpcJobServiceGateway implements JobServiceGateway {
 
     private final JobManagementServiceGrpc.JobManagementServiceStub client;
     private final CallMetadataResolver callMetadataResolver;
     private final ChannelTunablesConfiguration configuration;
 
     @Inject
-    public GrpcJobManagementClient(JobManagementServiceGrpc.JobManagementServiceStub client,
-                                   CallMetadataResolver callMetadataResolver,
-                                   ChannelTunablesConfiguration configuration) {
+    public GrpcJobServiceGateway(JobManagementServiceGrpc.JobManagementServiceStub client,
+                                 CallMetadataResolver callMetadataResolver,
+                                 ChannelTunablesConfiguration configuration) {
         this.client = client;
         this.callMetadataResolver = callMetadataResolver;
         this.configuration = configuration;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.connector.jobmanager;
+package com.netflix.titus.runtime.jobmanager.gateway;
 
 import java.util.Set;
 
@@ -47,7 +47,7 @@ import static com.netflix.titus.common.util.CollectionsExt.asSet;
 /**
  * Remote job management client API.
  */
-public interface JobManagementClient {
+public interface JobServiceGateway {
 
     Set<String> JOB_MINIMUM_FIELD_SET = asSet("id");
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGatewayDelegate.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGatewayDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.connector.jobmanager.client;
+package com.netflix.titus.runtime.jobmanager.gateway;
 
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.grpc.protogen.Job;
@@ -36,16 +36,15 @@ import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskMoveRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
 import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
-public class JobManagementClientDelegate implements JobManagementClient {
+public class JobServiceGatewayDelegate implements JobServiceGateway {
 
-    private final JobManagementClient delegate;
+    private final JobServiceGateway delegate;
 
-    public JobManagementClientDelegate(JobManagementClient delegate) {
+    public JobServiceGatewayDelegate(JobServiceGateway delegate) {
         this.delegate = delegate;
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.connector.jobmanager.client;
+package com.netflix.titus.runtime.jobmanager.gateway;
 
 import java.util.Set;
 import javax.inject.Named;
@@ -26,20 +26,19 @@ import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import com.netflix.titus.common.model.validator.ValidationError;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
 import com.netflix.titus.runtime.endpoint.v3.grpc.V3GrpcModelConverters;
 import rx.Completable;
 import rx.Observable;
 
 import static com.netflix.titus.api.jobmanager.model.job.sanitizer.JobSanitizerBuilder.JOB_STRICT_SANITIZER;
 
-public class SanitizingJobManagementClient extends JobManagementClientDelegate {
+public class SanitizingJobServiceGateway extends JobServiceGatewayDelegate {
 
-    private final JobManagementClient delegate;
+    private final JobServiceGateway delegate;
     private final EntitySanitizer entitySanitizer;
 
-    public SanitizingJobManagementClient(JobManagementClient delegate,
-                                         @Named(JOB_STRICT_SANITIZER) EntitySanitizer entitySanitizer) {
+    public SanitizingJobServiceGateway(JobServiceGateway delegate,
+                                       @Named(JOB_STRICT_SANITIZER) EntitySanitizer entitySanitizer) {
         super(delegate);
         this.delegate = delegate;
         this.entitySanitizer = entitySanitizer;

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/common/reactor/ReactorToGrpcClientBuilderTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/common/reactor/ReactorToGrpcClientBuilderTest.java
@@ -17,11 +17,12 @@
 package com.netflix.titus.runtime.connector.common.reactor;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import com.google.protobuf.Empty;
+import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.common.util.ExceptionExt;
 import com.netflix.titus.runtime.endpoint.metadata.AnonymousCallMetadataResolver;
-import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.runtime.endpoint.metadata.SimpleGrpcCallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
 import com.netflix.titus.testing.SampleGrpcService.SampleContainer;
@@ -33,13 +34,17 @@ import io.grpc.ServerInterceptors;
 import io.grpc.netty.shaded.io.grpc.netty.NegotiationType;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import static com.jayway.awaitility.Awaitility.await;
+import static com.netflix.titus.api.jobmanager.service.JobManagerConstants.GRPC_REPLICATOR_CALL_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReactorToGrpcClientBuilderTest {
@@ -47,6 +52,8 @@ public class ReactorToGrpcClientBuilderTest {
     private static final Duration TIMEOUT_DURATION = Duration.ofSeconds(30);
 
     private static final SampleContainer HELLO = SampleContainer.newBuilder().setStringValue("Hello").build();
+
+    private static final long TIMEOUT_MS = 30_000;
 
     private ManagedChannel channel;
     private Server server;
@@ -82,8 +89,21 @@ public class ReactorToGrpcClientBuilderTest {
     }
 
     @Test(timeout = 30_000)
+    public void testMonoGetWithCallMetadata() {
+        sampleService.expectedCallerId = GRPC_REPLICATOR_CALL_METADATA.getCallerId();
+        assertThat(client.getOneValue(GRPC_REPLICATOR_CALL_METADATA).block().getStringValue()).isEqualTo("Hello");
+    }
+
+    @Test(timeout = 30_000)
     public void testMonoSet() {
         assertThat(client.setOneValue(HELLO).block()).isNull();
+        assertThat(sampleService.lastSet).isEqualTo(HELLO);
+    }
+
+    @Test(timeout = 30_000)
+    public void testMonoSetWithCallMetadata() {
+        sampleService.expectedCallerId = GRPC_REPLICATOR_CALL_METADATA.getCallerId();
+        assertThat(client.setOneValue(HELLO, GRPC_REPLICATOR_CALL_METADATA).block()).isNull();
         assertThat(sampleService.lastSet).isEqualTo(HELLO);
     }
 
@@ -91,7 +111,19 @@ public class ReactorToGrpcClientBuilderTest {
     public void testFlux() throws InterruptedException {
         TitusRxSubscriber<SampleContainer> subscriber = new TitusRxSubscriber<>();
         client.stream().subscribe(subscriber);
+        checkTestFlux(subscriber);
+    }
 
+    @Test(timeout = 30_000)
+    public void testFluxWithCallMetadata() throws InterruptedException {
+        sampleService.expectedCallerId = GRPC_REPLICATOR_CALL_METADATA.getCallerId();
+        TitusRxSubscriber<SampleContainer> subscriber = new TitusRxSubscriber<>();
+
+        client.stream(GRPC_REPLICATOR_CALL_METADATA).subscribe(subscriber);
+        checkTestFlux(subscriber);
+    }
+
+    private void checkTestFlux(TitusRxSubscriber<SampleContainer> subscriber) throws InterruptedException {
         assertThat(subscriber.takeNext(TIMEOUT_DURATION).getStringValue()).isEqualTo("Event1");
         assertThat(subscriber.takeNext(TIMEOUT_DURATION).getStringValue()).isEqualTo("Event2");
         assertThat(subscriber.takeNext(TIMEOUT_DURATION).getStringValue()).isEqualTo("Event3");
@@ -99,47 +131,93 @@ public class ReactorToGrpcClientBuilderTest {
         assertThat(subscriber.hasError()).isFalse();
     }
 
+    @Test(timeout = 30_000)
+    public void testMonoCancel() {
+        sampleService.block = true;
+        testCancellation(client.getOneValue().subscribe());
+    }
+
+    @Test(timeout = 30_000)
+    public void testFluxStreamCancel() {
+        sampleService.block = true;
+        testCancellation(client.stream().subscribe());
+    }
+
+    private void testCancellation(Disposable disposable) {
+        await().timeout(TIMEOUT_MS, TimeUnit.MILLISECONDS).until(() -> sampleService.requestTimestamp > 0);
+        disposable.dispose();
+        await().timeout(TIMEOUT_MS, TimeUnit.MILLISECONDS).until(() -> sampleService.cancelled);
+    }
+
     private interface SampleServiceReactApi {
 
         Mono<SampleContainer> getOneValue();
 
+        Mono<SampleContainer> getOneValue(CallMetadata callMetadata);
+
         Mono<Void> setOneValue(SampleContainer value);
 
+        Mono<Void> setOneValue(SampleContainer value, CallMetadata callMetadata);
+
         Flux<SampleContainer> stream();
+
+        Flux<SampleContainer> stream(CallMetadata callMetadata);
     }
 
     private class SampleServiceImpl extends SampleServiceGrpc.SampleServiceImplBase {
 
         private final SimpleGrpcCallMetadataResolver metadataResolver = new SimpleGrpcCallMetadataResolver();
 
+        private long requestTimestamp;
         private SampleContainer lastSet;
+
+        private String expectedCallerId = AnonymousCallMetadataResolver.getInstance().resolve().get().getCallerId();
+        private boolean block;
+        private volatile boolean cancelled;
 
         @Override
         public void getOneValue(Empty request, StreamObserver<SampleContainer> responseObserver) {
-            checkMetadata();
-            responseObserver.onNext(HELLO);
+            onRequest(responseObserver);
+            if (!block) {
+                responseObserver.onNext(HELLO);
+            }
         }
 
         @Override
         public void setOneValue(SampleContainer request, StreamObserver<Empty> responseObserver) {
-            checkMetadata();
-            this.lastSet = request;
-            responseObserver.onNext(Empty.getDefaultInstance());
-            responseObserver.onCompleted();
+            onRequest(responseObserver);
+            if (!block) {
+                this.lastSet = request;
+                responseObserver.onNext(Empty.getDefaultInstance());
+                responseObserver.onCompleted();
+            }
         }
 
         @Override
         public void stream(Empty request, StreamObserver<SampleContainer> responseObserver) {
-            checkMetadata();
-            for (int i = 1; i <= 3; i++) {
-                responseObserver.onNext(SampleContainer.newBuilder().setStringValue("Event" + i).build());
+            onRequest(responseObserver);
+            if (!block) {
+                for (int i = 1; i <= 3; i++) {
+                    responseObserver.onNext(SampleContainer.newBuilder().setStringValue("Event" + i).build());
+                }
+                responseObserver.onCompleted();
             }
-            responseObserver.onCompleted();
+        }
+
+        private void onRequest(StreamObserver<?> responseObserver) {
+            registerCancellationCallback(responseObserver);
+            checkMetadata();
+        }
+
+        private void registerCancellationCallback(StreamObserver<?> responseObserver) {
+            ServerCallStreamObserver serverCallStreamObserver = (ServerCallStreamObserver) responseObserver;
+            serverCallStreamObserver.setOnCancelHandler(() -> cancelled = true);
         }
 
         private void checkMetadata() {
+            requestTimestamp = System.currentTimeMillis();
             CallMetadata metadata = metadataResolver.resolve().orElseThrow(() -> new IllegalStateException("no metadata found"));
-            assertThat(metadata.getCallerId()).isEqualTo("anonymous");
+            assertThat(metadata.getCallerId()).isEqualTo(expectedCallerId);
         }
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
@@ -37,7 +37,7 @@ import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.runtime.connector.common.replicator.DataReplicatorMetrics;
 import com.netflix.titus.runtime.connector.common.replicator.ReplicatorEvent;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.runtime.connector.jobmanager.JobSnapshot;
 import com.netflix.titus.testkit.model.job.JobComponentStub;
 import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
@@ -65,7 +65,7 @@ public class GrpcJobReplicatorEventStreamTest {
 
     private final JobComponentStub dataGenerator = new JobComponentStub(titusRuntime);
 
-    private final JobManagementClient client = mock(JobManagementClient.class);
+    private final JobServiceGateway client = mock(JobServiceGateway.class);
 
     @Before
     public void setUp() {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/ExecutionContext.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/ExecutionContext.java
@@ -28,7 +28,7 @@ import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
 import com.netflix.titus.runtime.connector.agent.ReactorAgentManagementServiceStub;
 import com.netflix.titus.runtime.connector.common.reactor.ReactorToGrpcClientBuilder;
 import com.netflix.titus.runtime.connector.eviction.EvictionServiceClient;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.simulator.SimulatedAgentServiceGrpc;
 import com.netflix.titus.simulator.SimulatedAgentServiceGrpc.SimulatedAgentServiceStub;
 import com.netflix.titus.testkit.embedded.cloud.connector.remote.SimulatedAgentClient;
@@ -44,7 +44,7 @@ public class ExecutionContext {
 
     private final String sessionId;
 
-    private final JobManagementClient jobManagementClient;
+    private final JobServiceGateway jobServiceGateway;
     private final ReadOnlyJobOperations cachedJobManagementClient;
 
     private final ReactorAgentManagementServiceStub agentManagementClient;
@@ -55,7 +55,7 @@ public class ExecutionContext {
     private final SimulatedAgentClient simulatedCloudClient;
 
     @Inject
-    public ExecutionContext(JobManagementClient jobManagementClient,
+    public ExecutionContext(JobServiceGateway jobServiceGateway,
                             ReadOnlyJobOperations cachedJobManagementClient,
                             ReactorAgentManagementServiceStub agentManagementClient,
                             ReadOnlyAgentOperations cachedAgentManagementClient,
@@ -63,7 +63,7 @@ public class ExecutionContext {
                             @Named(SimulatedRemoteInstanceCloudConnector.SIMULATED_CLOUD) Channel cloudSimulatorGrpcChannel) {
         this.sessionId = "session$" + TIMESTAMP_FORMATTER.format(Instant.now());
 
-        this.jobManagementClient = jobManagementClient;
+        this.jobServiceGateway = jobServiceGateway;
         this.cachedJobManagementClient = cachedJobManagementClient;
         this.agentManagementClient = agentManagementClient;
         this.cachedAgentManagementClient = cachedAgentManagementClient;
@@ -79,8 +79,8 @@ public class ExecutionContext {
         return sessionId;
     }
 
-    public JobManagementClient getJobManagementClient() {
-        return jobManagementClient;
+    public JobServiceGateway getJobServiceGateway() {
+        return jobServiceGateway;
     }
 
     public ReadOnlyJobOperations getCachedJobManagementClient() {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/LoadGeneratorComponent.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/LoadGeneratorComponent.java
@@ -26,7 +26,7 @@ import com.netflix.titus.runtime.connector.agent.ReactorAgentManagementServiceSt
 import com.netflix.titus.runtime.connector.common.reactor.GrpcToReactorClientFactoryComponent;
 import com.netflix.titus.runtime.connector.eviction.EvictionConnectorComponent;
 import com.netflix.titus.runtime.connector.eviction.EvictionServiceClient;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagementDataReplicationComponent;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagerConnectorComponent;
 import com.netflix.titus.testkit.embedded.cloud.connector.remote.SimulatedRemoteInstanceCloudConnector;
@@ -56,14 +56,14 @@ import org.springframework.context.annotation.Import;
 public class LoadGeneratorComponent {
 
     @Bean
-    public ExecutionContext getExecutionContext(JobManagementClient jobManagementClient,
+    public ExecutionContext getExecutionContext(JobServiceGateway jobServiceGateway,
                                                 ReadOnlyJobOperations cachedJobManagementClient,
                                                 ReactorAgentManagementServiceStub agentManagementClient,
                                                 ReadOnlyAgentOperations cachedAgentManagementClient,
                                                 EvictionServiceClient evictionServiceClient,
                                                 @Named(SimulatedRemoteInstanceCloudConnector.SIMULATED_CLOUD) Channel cloudSimulatorGrpcChannel) {
         return new ExecutionContext(
-                jobManagementClient,
+                jobServiceGateway,
                 cachedJobManagementClient,
                 agentManagementClient,
                 cachedAgentManagementClient,

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/report/MetricsCollector.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/report/MetricsCollector.java
@@ -89,7 +89,7 @@ public class MetricsCollector {
     public void watch(ExecutionContext context) {
         Preconditions.checkState(subscription == null);
 
-        this.subscription = Observable.defer(() -> V3ClientUtils.observeJobs(context.getJobManagementClient().observeJobs(ObserveJobsQuery.getDefaultInstance())))
+        this.subscription = Observable.defer(() -> V3ClientUtils.observeJobs(context.getJobServiceGateway().observeJobs(ObserveJobsQuery.getDefaultInstance())))
                 .doOnNext(event -> {
                     if (event instanceof JobUpdateEvent) {
                         JobUpdateEvent jobUpdate = (JobUpdateEvent) event;

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/JobExecutionPlanRunner.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/JobExecutionPlanRunner.java
@@ -140,7 +140,7 @@ public class JobExecutionPlanRunner extends ExecutionPlanRunner {
     }
 
     private Observable<Void> doFindOwnJob() {
-        return context.getJobManagementClient()
+        return context.getJobServiceGateway()
                 .findJobs(JobQuery.newBuilder()
                         .putFilteringCriteria("jobIds", executor.getJobId())
                         .setPage(PAGE_OF_500_ITEMS)
@@ -151,7 +151,7 @@ public class JobExecutionPlanRunner extends ExecutionPlanRunner {
     }
 
     private Observable<Void> doFindOwnTasks() {
-        return context.getJobManagementClient()
+        return context.getJobServiceGateway()
                 .findTasks(TaskQuery.newBuilder()
                         .putFilteringCriteria("jobIds", executor.getJobId())
                         .setPage(PAGE_OF_500_ITEMS)

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/JobTerminator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/JobTerminator.java
@@ -68,7 +68,7 @@ public class JobTerminator {
             logger.warn("Removing old jobs: {}", jobIdsToRemove);
 
             List<Observable<Void>> killActions = jobIdsToRemove.stream()
-                    .map(jid -> context.getJobManagementClient()
+                    .map(jid -> context.getJobServiceGateway()
                             .killJob(jid)
                             .toObservable()
                             .cast(Void.class)
@@ -91,7 +91,7 @@ public class JobTerminator {
 
     private boolean doTry(Set<String> jobIdsToRemove, Set<String> unknownJobs) {
         try {
-            Iterator<JobChangeNotification> it = context.getJobManagementClient()
+            Iterator<JobChangeNotification> it = context.getJobServiceGateway()
                     .observeJobs(ObserveJobsQuery.newBuilder().build())
                     .toBlocking()
                     .getIterator();

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/job/AbstractJobExecutor.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/job/AbstractJobExecutor.java
@@ -100,7 +100,7 @@ public abstract class AbstractJobExecutor<E extends JobDescriptor.JobDescriptorE
             if (!observeSubscription.isUnsubscribed()) {
                 this.activeTasks = Collections.emptyList();
                 observeSubscription.unsubscribe();
-                Throwable error = context.getJobManagementClient().killJob(jobId).get();
+                Throwable error = context.getJobServiceGateway().killJob(jobId).get();
                 if (error != null) {
                     logger.debug("Job {} cleanup failure", jobId, error);
                 }
@@ -109,7 +109,7 @@ public abstract class AbstractJobExecutor<E extends JobDescriptor.JobDescriptorE
     }
 
     private Subscription observeJob() {
-        return Observable.defer(() -> context.getJobManagementClient().observeJob(jobId))
+        return Observable.defer(() -> context.getJobServiceGateway().observeJob(jobId))
                 .doOnNext(event -> {
                     if (event.getNotificationCase() == NotificationCase.TASKUPDATE) {
                         com.netflix.titus.grpc.protogen.Task task = event.getTaskUpdate().getTask();
@@ -159,7 +159,7 @@ public abstract class AbstractJobExecutor<E extends JobDescriptor.JobDescriptorE
         Preconditions.checkState(doRun, "Job executor shut down already");
         Preconditions.checkNotNull(jobId);
 
-        return context.getJobManagementClient()
+        return context.getJobServiceGateway()
                 .killJob(jobId)
                 .toObservable()
                 .cast(Void.class)
@@ -172,7 +172,7 @@ public abstract class AbstractJobExecutor<E extends JobDescriptor.JobDescriptorE
         Preconditions.checkState(doRun, "Job executor shut down already");
         Preconditions.checkNotNull(jobId);
 
-        return context.getJobManagementClient()
+        return context.getJobServiceGateway()
                 .killTask(TaskKillRequest.newBuilder().setTaskId(taskId).setShrink(false).build())
                 .toObservable()
                 .cast(Void.class)

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/job/BatchJobExecutor.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/job/BatchJobExecutor.java
@@ -51,9 +51,9 @@ public class BatchJobExecutor extends AbstractJobExecutor {
     }
 
     public static Observable<BatchJobExecutor> submitJob(JobDescriptor<BatchJobExt> jobSpec, ExecutionContext context) {
-        return context.getJobManagementClient()
+        return context.getJobServiceGateway()
                 .createJob(V3GrpcModelConverters.toGrpcJobDescriptor(jobSpec), JobManagerConstants.UNDEFINED_CALL_METADATA)
-                .flatMap(jobRef -> context.getJobManagementClient().findJob(jobRef))
+                .flatMap(jobRef -> context.getJobServiceGateway().findJob(jobRef))
                 .map(job -> new BatchJobExecutor((Job<BatchJobExt>) V3GrpcModelConverters.toCoreJob(job), context));
     }
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/job/ServiceJobExecutor.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/load/runner/job/ServiceJobExecutor.java
@@ -48,7 +48,7 @@ public class ServiceJobExecutor extends AbstractJobExecutor<ServiceJobExt> {
         Preconditions.checkState(doRun, "Job executor shut down already");
         Preconditions.checkNotNull(jobId);
 
-        return context.getJobManagementClient().killTask(TaskKillRequest.newBuilder().setTaskId(taskId).setShrink(true).build())
+        return context.getJobServiceGateway().killTask(TaskKillRequest.newBuilder().setTaskId(taskId).setShrink(true).build())
                 .toObservable()
                 .cast(Void.class)
                 .onErrorResumeNext(e -> Observable.error(new IOException("Failed to terminate and shrink task " + taskId + " of job " + name, e)))
@@ -64,7 +64,7 @@ public class ServiceJobExecutor extends AbstractJobExecutor<ServiceJobExt> {
         Preconditions.checkState(doRun, "Job executor shut down already");
         Preconditions.checkNotNull(jobId);
 
-        return context.getJobManagementClient()
+        return context.getJobServiceGateway()
                 .updateJobCapacity(JobCapacityUpdate.newBuilder()
                         .setJobId(jobId)
                         .setCapacity(
@@ -96,9 +96,9 @@ public class ServiceJobExecutor extends AbstractJobExecutor<ServiceJobExt> {
     }
 
     public static Observable<ServiceJobExecutor> submitJob(JobDescriptor<ServiceJobExt> jobSpec, ExecutionContext context) {
-        return context.getJobManagementClient()
+        return context.getJobServiceGateway()
                 .createJob(V3GrpcModelConverters.toGrpcJobDescriptor(jobSpec), JobManagerConstants.UNDEFINED_CALL_METADATA)
-                .flatMap(jobRef -> context.getJobManagementClient().findJob(jobRef))
+                .flatMap(jobRef -> context.getJobServiceGateway().findJob(jobRef))
                 .map(job -> new ServiceJobExecutor((Job<ServiceJobExt>) V3GrpcModelConverters.toCoreJob(job), context));
     }
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/move/JobPairTasksMover.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/move/JobPairTasksMover.java
@@ -31,7 +31,7 @@ import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.service.JobManagerConstants;
 import com.netflix.titus.common.util.rx.ReactorExt;
 import com.netflix.titus.grpc.protogen.TaskMoveRequest;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -48,7 +48,7 @@ class JobPairTasksMover {
 
     private static final Logger logger = LoggerFactory.getLogger(JobPairTasksMover.class);
 
-    private final JobManagementClient client;
+    private final JobServiceGateway client;
     private final String jobId1;
     private final String jobId2;
     private final int jobSize;
@@ -58,7 +58,7 @@ class JobPairTasksMover {
     private volatile Job<ServiceJobExt> job2;
     private final ConcurrentMap<String, Task> tasks = new ConcurrentHashMap<>();
 
-    JobPairTasksMover(JobManagementClient client, String jobId1, String jobId2, int jobSize, int batchSize) {
+    JobPairTasksMover(JobServiceGateway client, String jobId1, String jobId2, int jobSize, int batchSize) {
         this.client = client;
         this.jobId1 = jobId1;
         this.jobId2 = jobId2;
@@ -110,7 +110,7 @@ class JobPairTasksMover {
         }
     }
 
-    static Mono<JobPairTasksMover> newTaskMover(JobManagementClient client, JobDescriptor<ServiceJobExt> jobDescriptor, int jobSize, int batchSize) {
+    static Mono<JobPairTasksMover> newTaskMover(JobServiceGateway client, JobDescriptor<ServiceJobExt> jobDescriptor, int jobSize, int batchSize) {
         JobDescriptor<ServiceJobExt> first = JobFunctions.changeServiceJobCapacity(
                 jobDescriptor,
                 Capacity.newBuilder()

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/move/MoveTaskPerf.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/perf/move/MoveTaskPerf.java
@@ -37,7 +37,7 @@ import com.netflix.titus.api.jobmanager.model.job.migration.SelfManagedMigration
 import com.netflix.titus.api.jobmanager.model.job.retry.ImmediateRetryPolicy;
 import com.netflix.titus.common.util.DateTimeExt;
 import com.netflix.titus.common.util.Evaluators;
-import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -52,7 +52,7 @@ public class MoveTaskPerf {
 
     private final List<JobPairTasksMover> movers;
 
-    public MoveTaskPerf(JobManagementClient client, int jobPairCount, int jobSize, int batchSize) {
+    public MoveTaskPerf(JobServiceGateway client, int jobPairCount, int jobSize, int batchSize) {
         JobDescriptor<ServiceJobExt> jobDescriptor = newJobDescriptor();
         this.movers = Flux.merge(Evaluators.evaluateTimes(jobPairCount, index -> JobPairTasksMover.newTaskMover(client, jobDescriptor, jobSize, batchSize)))
                 .collectList()

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/rx/RxGrpcJobManagementService.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/rx/RxGrpcJobManagementService.java
@@ -34,6 +34,7 @@ import com.netflix.titus.grpc.protogen.TaskId;
 import com.netflix.titus.grpc.protogen.TaskKillRequest;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
+import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
 import rx.Observable;
@@ -41,7 +42,7 @@ import rx.Observable;
 /**
  * Rx wrapper for {@link com.netflix.titus.grpc.protogen.JobManagementServiceGrpc}.
  *
- * @deprecated Use {@link com.netflix.titus.runtime.connector.jobmanager.JobManagementClient} and {@link com.netflix.titus.runtime.connector.jobmanager.CachedReadOnlyJobOperations} instead.
+ * @deprecated Use {@link JobServiceGateway} and {@link com.netflix.titus.runtime.connector.jobmanager.CachedReadOnlyJobOperations} instead.
  */
 @Deprecated
 public class RxGrpcJobManagementService {


### PR DESCRIPTION
This PR contains two big changes:
* extends `ReactorToGrpcClientBuilder` to support `CallMetadata` method parameters
* moves `JobManagementClient` out of the connectors package, and renames it to `JobServiceGateway`

This is first iteration only for a larger work item, which is aligning the job management connector implementation with other connectors, and the connector layer design principles.

In the second iteration I plan to finish the job manager connector implementation, which now is only partly done. The third step will be code cleanup in the `JobServiceGateway` class hierarchy.