### PR TITLE
timestamp missing from conversion to core model

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
@@ -120,6 +120,7 @@ public final class V3GrpcModelConverters {
                 .withState(toCoreJobState(grpcJobStatus.getState()))
                 .withReasonCode(grpcJobStatus.getReasonCode())
                 .withReasonMessage(grpcJobStatus.getReasonMessage())
+                .withTimestamp(grpcJobStatus.getTimestamp())
                 .build();
     }
 
@@ -470,6 +471,7 @@ public final class V3GrpcModelConverters {
                 .withState(toCoreTaskState(grpcStatus.getState()))
                 .withReasonCode(grpcStatus.getReasonCode())
                 .withReasonMessage(grpcStatus.getReasonMessage())
+                .withTimestamp(grpcStatus.getTimestamp())
                 .build();
     }
 


### PR DESCRIPTION
### Core model conversion fix

Converting from grpc model to core Job/Task model is missing timestamp field. As a result Elastic search publishing (Es5) is recording incorrect timestamps for task fields.