### PR TITLE
Add status code to WebClient metrics

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/network/client/TitusWebClientAddOns.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/network/client/TitusWebClientAddOns.java
@@ -123,7 +123,8 @@ public final class TitusWebClientAddOns {
                     registry.counter(WEB_CLIENT_REQUEST,
                             "endpoint", endpointName,
                             "method", response.method().name(),
-                            "path", response.path()
+                            "path", response.path(),
+                            "statusCode", response.status().toString()
                     ).increment();
                 })
                 .doOnResponseError((response, error) -> {


### PR DESCRIPTION
Adds the statusCode tag to metrics emitted by WebClient. This value was emitted by RxNettyRestClient but missing from this new client.