### PR TITLE
spring config fix for task context map

### DIFF
--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisherCtrl.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisherCtrl.java
@@ -50,7 +50,6 @@ import reactor.core.scheduler.Schedulers;
 
 public class TasksPublisherCtrl {
     private static final Logger logger = LoggerFactory.getLogger(TasksPublisherCtrl.class);
-    public static final String TASK_DOCUMENT_CONTEXT = "taskDocumentContext";
     private final EsClient esClient;
     private final Map<String, String> taskDocumentBaseContext;
     private final Registry registry;
@@ -68,7 +67,7 @@ public class TasksPublisherCtrl {
 
     public TasksPublisherCtrl(EsClient esClient,
                               TitusClient titusClient,
-                              @Qualifier(TASK_DOCUMENT_CONTEXT) Map<String, String> taskDocumentBaseContext,
+                              Map<String, String> taskDocumentBaseContext,
                               Registry registry) {
         this.esClient = esClient;
         this.titusClient = titusClient;

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
@@ -81,6 +81,7 @@ public class TasksPublisherConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public TasksPublisherCtrl getTasksPublisherCtrl() {
         return new TasksPublisherCtrl(getEsClient(), getTitusClient(), Collections.emptyMap(), new DefaultRegistry());
     }

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
@@ -66,16 +66,19 @@ public class TasksPublisherConfiguration {
 
 
     @Bean
+    @ConditionalOnMissingBean
     public TitusClient getTitusClient() {
         return new TitusClientImpl(getJobManagementServiceStub(), new DefaultRegistry());
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public EsClient getEsClient() {
         return new EsClientHttp(esPublisherConfiguration, getEsWebClientFactory());
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public EsWebClientFactory getEsWebClientFactory() {
         return new DefaultEsWebClientFactory(esPublisherConfiguration);
     }


### PR DESCRIPTION
### Default spring configuration updated for TasksPublisher

Removing partial spring configuration override for building TasksPublisherCtrl objects. Changes to the default configuration makes it easy to override.