### PR TITLE
add a timeout to image sanitization/validation

### DIFF
--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageValidatorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageValidatorTest.java
@@ -66,6 +66,7 @@ public class JobImageValidatorTest {
     @Before
     public void setUp() {
         when(configuration.isEnabled()).thenReturn(true);
+        when(configuration.getJobImageValidationTimeoutMs()).thenReturn(1000L);
         when(registryClient.getImageDigest(anyString(), anyString())).thenReturn(Mono.just(digest));
         validator = new JobImageValidator(configuration, registryClient);
     }
@@ -87,7 +88,7 @@ public class JobImageValidatorTest {
         StepVerifier.create(validator.sanitize(jobDescriptorWithTag))
                 .expectErrorSatisfies(throwable -> {
                     assertThat(throwable).isInstanceOf(TitusRegistryException.class);
-                    assertThat(((TitusRegistryException)throwable).getErrorCode()).isEqualByComparingTo(TitusRegistryException.ErrorCode.IMAGE_NOT_FOUND);
+                    assertThat(((TitusRegistryException) throwable).getErrorCode()).isEqualByComparingTo(TitusRegistryException.ErrorCode.IMAGE_NOT_FOUND);
                 })
                 .verify();
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
@@ -79,6 +79,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
     @Before
     public void setUp() throws Exception {
         when(configuration.isEnabled()).thenReturn(true);
+        when(configuration.getJobImageValidationTimeoutMs()).thenReturn(1000L);
         instanceGroupsScenarioBuilder.synchronizeWithCloud().template(InstanceGroupScenarioTemplates.basicCloudActivation());
         this.client = titusStackResource.getGateway().getV3BlockingGrpcClient();
     }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/registry/TitusRegistryClientConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/registry/TitusRegistryClientConfiguration.java
@@ -31,7 +31,7 @@ public interface TitusRegistryClientConfiguration {
     @DefaultValue("500")
     int getRegistryTimeoutMs();
 
-    @DefaultValue("3")
+    @DefaultValue("2")
     int getRegistryRetryCount();
 
     @DefaultValue("5")

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidator.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.runtime.endpoint.validator;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
 import javax.inject.Inject;
@@ -80,9 +81,11 @@ public class JobImageValidator implements EntityValidator<JobDescriptor> {
         }
 
         return sanitizeImage(jobDescriptor)
+                .timeout(Duration.ofMillis(configuration.getJobImageValidationTimeoutMs()))
                 // We are ignoring most image validation errors. We will propagate
                 // more errors as we going feature confidence.
                 .onErrorReturn(throwable -> {
+                    logger.error("Exception while checking image digest", throwable);
                     if (throwable instanceof TitusRegistryException) {
                         TitusRegistryException tre = (TitusRegistryException) throwable;
                         switch (tre.getErrorCode()) {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidatorConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidatorConfiguration.java
@@ -28,6 +28,6 @@ public interface JobImageValidatorConfiguration {
      * Since Image validations are on the job accept path the timeout value is aggressive.
      * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()}.
      */
-    @DefaultValue("1000")
+    @DefaultValue("1200")
     long getJobImageValidationTimeoutMs();
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidatorConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidatorConfiguration.java
@@ -23,4 +23,11 @@ import com.netflix.archaius.api.annotations.DefaultValue;
 public interface JobImageValidatorConfiguration {
     @DefaultValue("true")
     boolean isEnabled();
+
+    /**
+     * Since Image validations are on the job accept path the timeout value is aggressive.
+     * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()}.
+     */
+    @DefaultValue("1000")
+    long getJobImageValidationTimeoutMs();
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobSecurityValidatorConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobSecurityValidatorConfiguration.java
@@ -31,6 +31,7 @@ public interface JobSecurityValidatorConfiguration {
 
     /**
      * Since IAM validations are on the job accept path the timeout value is aggressive.
+     * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()}.
      */
     @DefaultValue("1000")
     long getIamValidationTimeoutMs();

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/registry/RegistryClientTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/registry/RegistryClientTest.java
@@ -52,7 +52,7 @@ public class RegistryClientTest {
         when(configuration.getRegistryUri()).thenReturn("http://localhost:" + mockServer.getPort());
         when(configuration.isSecure()).thenReturn(false);
         when(configuration.getRegistryTimeoutMs()).thenReturn(500);
-        when(configuration.getRegistryRetryCount()).thenReturn(3);
+        when(configuration.getRegistryRetryCount()).thenReturn(2);
         when(configuration.getRegistryRetryDelayMs()).thenReturn(5);
 
         registryClient = new DefaultDockerRegistryClient(configuration, titusRuntime);


### PR DESCRIPTION
Without an explicit timeout, the sanitization chain was failing with the default timeout from `AggregatingValidator` (2s), which does not provide a useful message. It fails with something like:

> Did not observe any item or terminal signal within 2000ms in 'flatMap' (and no fallback has been configured)