### PR TITLE
Disable the TaskRelocation connector in TitusGateway

### DIFF
--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGateway.java
@@ -48,7 +48,7 @@ public class TitusGateway {
 
         try {
             LifecycleInjector injector = InjectorBuilder.fromModules(
-                    new TitusGatewayModule(),
+                    new TitusGatewayModule(true, false),
                     new Archaius2JettyModule(),
                     new ArchaiusModule() {
                         @Override


### PR DESCRIPTION
`TitusGateway` is used in the docker-compose integration test, which
does not include TaskRelocation service yet.
