### PR TITLE
Tasks publisher refactoring

### DIFF
--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/EsPublisher.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/EsPublisher.java
@@ -63,13 +63,11 @@ public class EsPublisher implements TasksPublisher {
     }
 
 
-    @Override
     @PreDestroy
     public void stop() {
         ReactorExt.safeDispose(subscription, taskEventsSourceConnection);
     }
 
-    @Override
     @PostConstruct
     public void start() {
         ConnectableFlux<TaskDocument> taskEvents = taskEventsGenerator.getTaskEvents();
@@ -100,17 +98,17 @@ public class EsPublisher implements TasksPublisher {
     }
 
     @Override
-    public AtomicInteger getNumErrors() {
-        return numErrors;
+    public int getNumErrorsInPublishing() {
+        return numErrors.get();
     }
 
-    public AtomicInteger getNumIndexUpdated() {
-        return numIndexUpdated;
+    public int getNumIndexUpdated() {
+        return numIndexUpdated.get();
     }
 
     @Override
-    public AtomicInteger getNumTasksUpdated() {
-        return numTasksUpdated;
+    public int getNumTasksPublished() {
+        return numTasksUpdated.get();
     }
 
     private Function<Flux<Throwable>, Publisher<?>> buildLimitedRetryHandler() {

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/EsPublisher.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/EsPublisher.java
@@ -59,18 +59,20 @@ public class EsPublisher implements TasksPublisher {
         this.taskEventsGenerator = taskEventsGenerator;
         this.esClient = esClient;
         this.registry = registry;
+        configureMetrics();
     }
 
 
+    @Override
     @PreDestroy
     public void stop() {
         ReactorExt.safeDispose(subscription, taskEventsSourceConnection);
     }
 
+    @Override
     @PostConstruct
     public void start() {
         ConnectableFlux<TaskDocument> taskEvents = taskEventsGenerator.getTaskEvents();
-
         subscription = taskEvents.bufferTimeout(100, Duration.ofSeconds(5))
                 .flatMap(taskDocuments ->
                         esClient.bulkIndexTaskDocument(taskDocuments)
@@ -97,6 +99,7 @@ public class EsPublisher implements TasksPublisher {
         taskEventsSourceConnection = taskEvents.connect();
     }
 
+    @Override
     public AtomicInteger getNumErrors() {
         return numErrors;
     }
@@ -105,6 +108,7 @@ public class EsPublisher implements TasksPublisher {
         return numIndexUpdated;
     }
 
+    @Override
     public AtomicInteger getNumTasksUpdated() {
         return numTasksUpdated;
     }

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGenerator.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGenerator.java
@@ -64,7 +64,10 @@ public class TaskEventsGenerator {
                                 final com.netflix.titus.api.jobmanager.model.job.Task coreTask = V3GrpcModelConverters.toCoreTask(coreJob, task);
                                 return TaskDocument.fromV3Task(coreTask, coreJob, ElasticSearchUtils.DATE_FORMAT, buildTaskContext(task));
                             }).flux();
-                }).publish();
+                })
+                .retryWhen(TaskPublisherRetryUtil.buildRetryHandler(TaskPublisherRetryUtil.INITIAL_RETRY_DELAY_MS,
+                        TaskPublisherRetryUtil.MAX_RETRY_DELAY_MS, -1))
+                .publish();
     }
 
 

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGenerator.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGenerator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.titus.supplementary.taskspublisher;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.ext.elasticsearch.TaskDocument;
+import com.netflix.titus.grpc.protogen.Job;
+import com.netflix.titus.grpc.protogen.Task;
+import com.netflix.titus.runtime.endpoint.v3.grpc.V3GrpcModelConverters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+
+public class TaskEventsGenerator {
+    private static final Logger logger = LoggerFactory.getLogger(TaskEventsGenerator.class);
+    private final Map<String, String> taskDocumentBaseContext;
+    private TitusClient titusClient;
+    private ConnectableFlux<TaskDocument> taskEvents;
+
+    public TaskEventsGenerator(TitusClient titusClient,
+                               Map<String, String> taskDocumentBaseContext) {
+        this.titusClient = titusClient;
+        this.taskDocumentBaseContext = taskDocumentBaseContext;
+        buildEventStream();
+    }
+
+    public ConnectableFlux<TaskDocument> getTaskEvents() {
+        return taskEvents;
+    }
+
+
+    private void buildEventStream() {
+        taskEvents = titusClient.getTaskUpdates()
+                .publishOn(Schedulers.elastic())
+                .map(task -> {
+                    final Mono<Job> jobById = titusClient.getJobById(task.getJobId());
+                    return Pair.of(task, jobById);
+                })
+                .flatMap(taskMonoPair -> {
+                    final Task task = taskMonoPair.getLeft();
+                    return taskMonoPair.getRight()
+                            .map(job -> {
+                                final com.netflix.titus.api.jobmanager.model.job.Job coreJob = V3GrpcModelConverters.toCoreJob(job);
+                                final com.netflix.titus.api.jobmanager.model.job.Task coreTask = V3GrpcModelConverters.toCoreTask(coreJob, task);
+                                return TaskDocument.fromV3Task(coreTask, coreJob, ElasticSearchUtils.DATE_FORMAT, buildTaskContext(task));
+                            }).flux();
+                }).publish();
+    }
+
+
+    private Map<String, String> buildTaskContext(Task task) {
+        String stack = "";
+        if (task.getTaskContextMap().containsKey(JobAttributes.JOB_ATTRIBUTES_CELL)) {
+            stack = task.getTaskContextMap().get(JobAttributes.JOB_ATTRIBUTES_CELL);
+        }
+        final HashMap<String, String> taskContext = new HashMap<>(taskDocumentBaseContext);
+        taskContext.put("stack", stack);
+        return taskContext;
+    }
+
+
+}

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskPublisherRetryUtil.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskPublisherRetryUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.titus.supplementary.taskspublisher;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.netflix.titus.common.util.rx.RetryHandlerBuilder;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+public class TaskPublisherRetryUtil {
+    public static final long INITIAL_RETRY_DELAY_MS = 500;
+    public static final long MAX_RETRY_DELAY_MS = 2_000;
+
+    public static Function<Flux<Throwable>, Publisher<?>> buildRetryHandler(long initialRetryDelayMillis,
+                                                                            long maxRetryDelayMillis, int maxRetries) {
+        RetryHandlerBuilder retryHandlerBuilder = RetryHandlerBuilder.retryHandler();
+        if (maxRetries < 0) {
+            retryHandlerBuilder.withUnlimitedRetries();
+        } else {
+            retryHandlerBuilder.withRetryCount(maxRetries);
+        }
+
+        return retryHandlerBuilder
+                .withDelay(initialRetryDelayMillis, maxRetryDelayMillis, TimeUnit.MILLISECONDS)
+                .withReactorScheduler(Schedulers.elastic())
+                .buildReactorExponentialBackoff();
+    }
+
+}

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisher.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisher.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.titus.supplementary.taskspublisher;
+
+public interface TasksPublisher {
+}

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisher.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisher.java
@@ -15,14 +15,8 @@
  */
 package com.netflix.titus.supplementary.taskspublisher;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public interface TasksPublisher {
-    void start();
+    int getNumErrorsInPublishing();
 
-    void stop();
-
-    AtomicInteger getNumErrors();
-
-    AtomicInteger getNumTasksUpdated();
+    int getNumTasksPublished();
 }

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisher.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TasksPublisher.java
@@ -15,5 +15,14 @@
  */
 package com.netflix.titus.supplementary.taskspublisher;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public interface TasksPublisher {
+    void start();
+
+    void stop();
+
+    AtomicInteger getNumErrors();
+
+    AtomicInteger getNumTasksUpdated();
 }

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
@@ -25,7 +25,7 @@ import com.netflix.titus.supplementary.taskspublisher.DefaultEsWebClientFactory;
 import com.netflix.titus.supplementary.taskspublisher.EsClient;
 import com.netflix.titus.supplementary.taskspublisher.EsClientHttp;
 import com.netflix.titus.supplementary.taskspublisher.EsWebClientFactory;
-import com.netflix.titus.supplementary.taskspublisher.TasksPublisherCtrl;
+import com.netflix.titus.supplementary.taskspublisher.TaskEventsGenerator;
 import com.netflix.titus.supplementary.taskspublisher.TitusClient;
 import com.netflix.titus.supplementary.taskspublisher.TitusClientImpl;
 import io.grpc.ManagedChannel;
@@ -85,8 +85,8 @@ public class TasksPublisherConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public TasksPublisherCtrl getTasksPublisherCtrl() {
-        return new TasksPublisherCtrl(getEsClient(), getTitusClient(), Collections.emptyMap(), new DefaultRegistry());
+    public TaskEventsGenerator getTaskEventsGenerator() {
+        return new TaskEventsGenerator(getTitusClient(), Collections.emptyMap());
     }
 
 

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/config/TasksPublisherConfiguration.java
@@ -24,6 +24,7 @@ import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementSer
 import com.netflix.titus.supplementary.taskspublisher.DefaultEsWebClientFactory;
 import com.netflix.titus.supplementary.taskspublisher.EsClient;
 import com.netflix.titus.supplementary.taskspublisher.EsClientHttp;
+import com.netflix.titus.supplementary.taskspublisher.EsPublisher;
 import com.netflix.titus.supplementary.taskspublisher.EsWebClientFactory;
 import com.netflix.titus.supplementary.taskspublisher.TaskEventsGenerator;
 import com.netflix.titus.supplementary.taskspublisher.TitusClient;
@@ -87,6 +88,12 @@ public class TasksPublisherConfiguration {
     @ConditionalOnMissingBean
     public TaskEventsGenerator getTaskEventsGenerator() {
         return new TaskEventsGenerator(getTitusClient(), Collections.emptyMap());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public EsPublisher getEsPublisher() {
+        return new EsPublisher(getTaskEventsGenerator(), getEsClient(), new DefaultRegistry());
     }
 
 

--- a/titus-supplementary-component/tasks-publisher/src/test/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGeneratorTest.java
+++ b/titus-supplementary-component/tasks-publisher/src/test/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGeneratorTest.java
@@ -85,9 +85,9 @@ public class TaskEventsGeneratorTest {
         Flux.interval(Duration.ofSeconds(1), Schedulers.elastic())
                 .take(1)
                 .doOnNext(i -> {
-                    final int numTimesIndexUpdated = esPublisher.getNumIndexUpdated().get();
-                    final int numTasksUpdated = esPublisher.getNumTasksUpdated().get();
-                    final int numErrors = esPublisher.getNumErrors().get();
+                    final int numTimesIndexUpdated = esPublisher.getNumIndexUpdated();
+                    final int numTasksUpdated = esPublisher.getNumTasksPublished();
+                    final int numErrors = esPublisher.getNumErrorsInPublishing();
                     assertThat(numErrors).isEqualTo(0);
                     assertThat(numTasksUpdated).isEqualTo(numTasks);
                     assertThat(numTimesIndexUpdated).isEqualTo(numTasks);

--- a/titus-supplementary-component/tasks-publisher/src/test/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGeneratorTest.java
+++ b/titus-supplementary-component/tasks-publisher/src/test/java/com/netflix/titus/supplementary/taskspublisher/TaskEventsGeneratorTest.java
@@ -85,12 +85,10 @@ public class TaskEventsGeneratorTest {
         Flux.interval(Duration.ofSeconds(1), Schedulers.elastic())
                 .take(1)
                 .doOnNext(i -> {
-                    final int numTimesIndexUpdated = esPublisher.getNumIndexUpdated();
                     final int numTasksUpdated = esPublisher.getNumTasksPublished();
                     final int numErrors = esPublisher.getNumErrorsInPublishing();
                     assertThat(numErrors).isEqualTo(0);
-                    assertThat(numTasksUpdated).isEqualTo(numTasks);
-                    assertThat(numTimesIndexUpdated).isEqualTo(numTasks);
+                    assertThat(numTasksUpdated).isGreaterThanOrEqualTo(numTasks);
                     latch.countDown();
                 }).subscribe();
         try {


### PR DESCRIPTION
### Tasks publisher refactoring

Current implementation of tasks publisher needs to be broken into a few separate components. 
1. TaskEventsGenerator - it listens to TitusAPI stream for job and task updates, builds a document that contains all the task state + job metadata and is ready to be published
2. TasksPublisher - interface defines publisher contract
3. EsPublisher - implements TasksPublisher that grabs task events generated from TaskEventsGenerator and is responsible for managing elastic search integration that publishes task documents.

The design enables hooking up additional publishers by decoupling task document building and actual publishing mechanism.
