### PR TITLE
pin spring-boot to 2.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,8 @@ subprojects {
 
         awsSdkVersion = '1.11.+'
         javaxElVersion = '3.+'
-        springBootVersion = '2.1.+'
+        // pinned because of SSL incompatibilities with tomcat-embed-core 9.0.17
+        springBootVersion = '2.1.3.RELEASE'
         springReactor = '3.1.+'
         springReactorNetty = '0.8.+'
         springVersion = '5.1.+'
@@ -90,7 +91,7 @@ subprojects {
         elasticsearchVersion = '2.4.2'
         caffeineVersion = '2.6.+'
         rxJavaInteropVersion = '0.13.+'
-        
+
         // Test
         junitVersion = '4.10'
         mockitoVersion = '2.+'

--- a/titus-api/dependencies.lock
+++ b/titus-api/dependencies.lock
@@ -3986,6 +3986,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -4276,26 +4277,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -4454,7 +4455,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -4520,7 +4521,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -4634,13 +4635,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -4701,20 +4702,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4722,38 +4723,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -4829,7 +4830,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -5903,6 +5904,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -6193,26 +6195,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -6371,7 +6373,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -6437,7 +6439,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -6551,13 +6553,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -6618,20 +6620,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -6639,38 +6641,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -6746,7 +6748,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -7820,6 +7822,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -8110,26 +8113,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -8288,7 +8291,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -8354,7 +8357,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -8468,13 +8471,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -8536,20 +8539,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -8557,38 +8560,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -8664,7 +8667,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9738,6 +9741,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -10028,26 +10032,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -10206,7 +10210,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -10272,7 +10276,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -10386,13 +10390,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -10454,20 +10458,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -10475,38 +10479,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -10582,7 +10586,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-common/dependencies.lock
+++ b/titus-common/dependencies.lock
@@ -3714,6 +3714,7 @@
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -4010,26 +4011,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -4191,7 +4192,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -4258,7 +4259,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -4372,13 +4373,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -4439,20 +4440,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4460,38 +4461,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -4570,7 +4571,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -5668,6 +5669,7 @@
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -5964,26 +5966,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -6145,7 +6147,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -6212,7 +6214,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -6326,13 +6328,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -6393,20 +6395,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -6414,38 +6416,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -6524,7 +6526,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -7622,6 +7624,7 @@
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7918,26 +7921,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -8099,7 +8102,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -8166,7 +8169,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -8280,13 +8283,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -8348,20 +8351,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -8369,38 +8372,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -8479,7 +8482,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9577,6 +9580,7 @@
             "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9873,26 +9877,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -10054,7 +10058,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -10121,7 +10125,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -10235,13 +10239,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -10303,20 +10307,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -10324,38 +10328,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -10434,7 +10438,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-ext/aws/dependencies.lock
+++ b/titus-ext/aws/dependencies.lock
@@ -7,7 +7,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -38,7 +38,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -697,7 +697,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -728,7 +728,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -1387,7 +1387,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -1418,7 +1418,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -2141,7 +2141,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -2172,7 +2172,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -2832,7 +2832,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -2863,7 +2863,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -3547,7 +3547,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -3578,7 +3578,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -4609,6 +4609,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -4912,26 +4913,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -5090,7 +5091,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -5156,7 +5157,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -5270,13 +5271,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -5337,20 +5338,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5358,38 +5359,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -5465,7 +5466,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -5556,7 +5557,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -5587,7 +5588,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -6618,6 +6619,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -6921,26 +6923,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7099,7 +7101,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7165,7 +7167,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -7279,13 +7281,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7346,20 +7348,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7367,38 +7369,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7474,7 +7476,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -7565,7 +7567,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -7596,7 +7598,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -8627,6 +8629,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -8930,26 +8933,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9108,7 +9111,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9174,7 +9177,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -9288,13 +9291,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9356,20 +9359,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9377,38 +9380,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9484,7 +9487,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9575,7 +9578,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -9606,7 +9609,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.533",
+            "locked": "1.11.534",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
@@ -10637,6 +10640,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -10940,26 +10944,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11118,7 +11122,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11184,7 +11188,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -11298,13 +11302,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11366,20 +11370,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11387,38 +11391,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11494,7 +11498,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-ext/cassandra-testkit/dependencies.lock
+++ b/titus-ext/cassandra-testkit/dependencies.lock
@@ -5679,7 +5679,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {
@@ -6684,7 +6684,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {
@@ -7689,7 +7689,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {
@@ -8695,7 +8695,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {

--- a/titus-ext/cassandra/dependencies.lock
+++ b/titus-ext/cassandra/dependencies.lock
@@ -4478,6 +4478,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -4768,26 +4769,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -4947,7 +4948,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -5013,7 +5014,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -5127,13 +5128,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -5194,20 +5195,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5215,38 +5216,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -5322,7 +5323,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -6398,6 +6399,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -6688,26 +6690,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -6867,7 +6869,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -6933,7 +6935,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -7047,13 +7049,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7114,20 +7116,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7135,38 +7137,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7242,7 +7244,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -8318,6 +8320,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -8608,26 +8611,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -8787,7 +8790,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -8853,7 +8856,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -8967,13 +8970,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9035,20 +9038,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9056,38 +9059,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9163,7 +9166,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10239,6 +10242,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -10529,26 +10533,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -10708,7 +10712,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -10774,7 +10778,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -10888,13 +10892,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -10956,20 +10960,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -10977,38 +10981,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11084,7 +11088,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-ext/elasticsearch/dependencies.lock
+++ b/titus-ext/elasticsearch/dependencies.lock
@@ -8586,7 +8586,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -10085,7 +10085,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -11584,7 +11584,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -13084,7 +13084,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {

--- a/titus-ext/eureka/dependencies.lock
+++ b/titus-ext/eureka/dependencies.lock
@@ -8403,6 +8403,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -8715,26 +8716,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -8899,7 +8900,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -8965,7 +8966,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -9079,13 +9080,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9150,20 +9151,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9171,38 +9172,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9278,7 +9279,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10467,6 +10468,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -10779,26 +10781,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -10963,7 +10965,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11029,7 +11031,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -11143,13 +11145,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11214,20 +11216,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11235,38 +11237,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11342,7 +11344,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12531,6 +12533,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -12843,26 +12846,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13027,7 +13030,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13093,7 +13096,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13207,13 +13210,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13279,20 +13282,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13300,38 +13303,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13407,7 +13410,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -14596,6 +14599,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -14908,26 +14912,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -15092,7 +15096,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -15158,7 +15162,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -15272,13 +15276,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -15344,20 +15348,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -15365,38 +15369,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -15472,7 +15476,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-ext/jooq/dependencies.lock
+++ b/titus-ext/jooq/dependencies.lock
@@ -1154,7 +1154,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -2403,7 +2403,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -3653,7 +3653,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -4994,7 +4994,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -6244,7 +6244,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -7373,6 +7373,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7669,26 +7670,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7847,7 +7848,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7936,7 +7937,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -8054,13 +8055,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -8127,7 +8128,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -8137,13 +8138,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -8151,38 +8152,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -8261,7 +8262,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9349,6 +9350,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9645,26 +9647,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9823,7 +9825,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9912,7 +9914,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -10030,13 +10032,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -10103,7 +10105,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -10113,13 +10115,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -10127,38 +10129,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -10237,7 +10239,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -11325,6 +11327,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11621,26 +11624,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11799,7 +11802,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11888,7 +11891,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -12006,13 +12009,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -12080,7 +12083,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -12090,13 +12093,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -12104,38 +12107,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -12214,7 +12217,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -13302,6 +13305,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13598,26 +13602,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13776,7 +13780,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13865,7 +13869,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13983,13 +13987,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -14057,7 +14061,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "com.netflix.titus:titus-supplementary-component-job-activity-history",
@@ -14067,13 +14071,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -14081,38 +14085,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -14191,7 +14195,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-ext/zookeeper/dependencies.lock
+++ b/titus-ext/zookeeper/dependencies.lock
@@ -7649,6 +7649,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7966,26 +7967,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -8150,7 +8151,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -8217,7 +8218,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -8331,13 +8332,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -8400,20 +8401,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -8421,38 +8422,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -8528,7 +8529,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9605,6 +9606,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9922,26 +9924,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -10106,7 +10108,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -10173,7 +10175,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -10287,13 +10289,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -10356,20 +10358,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -10377,38 +10379,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -10484,7 +10486,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -11561,6 +11563,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11878,26 +11881,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -12062,7 +12065,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -12129,7 +12132,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -12243,13 +12246,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -12313,20 +12316,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -12334,38 +12337,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -12441,7 +12444,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -13518,6 +13521,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13835,26 +13839,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -14019,7 +14023,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -14086,7 +14090,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -14200,13 +14204,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -14270,20 +14274,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -14291,38 +14295,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -14398,7 +14402,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-grpc-api/dependencies.lock
+++ b/titus-grpc-api/dependencies.lock
@@ -756,7 +756,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {
@@ -924,7 +924,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {
@@ -1098,7 +1098,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {
@@ -1279,7 +1279,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.objenesis:objenesis": {

--- a/titus-server-federation/dependencies.lock
+++ b/titus-server-federation/dependencies.lock
@@ -7020,6 +7020,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7313,26 +7314,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7491,7 +7492,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7558,7 +7559,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -7675,13 +7676,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7742,20 +7743,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7763,38 +7764,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7870,7 +7871,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -8973,6 +8974,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9266,26 +9268,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9444,7 +9446,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9511,7 +9513,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -9628,13 +9630,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9695,20 +9697,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9716,38 +9718,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9823,7 +9825,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10926,6 +10928,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11219,26 +11222,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11397,7 +11400,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11464,7 +11467,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -11581,13 +11584,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11649,20 +11652,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11670,38 +11673,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11777,7 +11780,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12880,6 +12883,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13173,26 +13177,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13351,7 +13355,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13418,7 +13422,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -13535,13 +13539,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13603,20 +13607,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13624,38 +13628,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13731,7 +13735,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-server-gateway/dependencies.lock
+++ b/titus-server-gateway/dependencies.lock
@@ -7091,6 +7091,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7385,26 +7386,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7565,7 +7566,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7632,7 +7633,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -7748,13 +7749,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7815,20 +7816,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7836,38 +7837,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7943,7 +7944,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9047,6 +9048,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9341,26 +9343,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9521,7 +9523,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9588,7 +9590,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -9704,13 +9706,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9771,20 +9773,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9792,38 +9794,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9899,7 +9901,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -11003,6 +11005,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11297,26 +11300,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11477,7 +11480,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11544,7 +11547,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -11660,13 +11663,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11728,20 +11731,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11749,38 +11752,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11856,7 +11859,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12960,6 +12963,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13254,26 +13258,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13434,7 +13438,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13501,7 +13505,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.governator:governator-test-junit",
@@ -13617,13 +13621,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13685,20 +13689,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13706,38 +13710,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13813,7 +13817,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-server-master/dependencies.lock
+++ b/titus-server-master/dependencies.lock
@@ -7415,6 +7415,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7723,26 +7724,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7906,7 +7907,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7972,7 +7973,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit",
@@ -8089,13 +8090,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -8157,7 +8158,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -8165,14 +8166,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -8181,55 +8182,55 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -8290,7 +8291,7 @@
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -8313,7 +8314,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9418,6 +9419,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9726,26 +9728,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9909,7 +9911,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9975,7 +9977,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit",
@@ -10092,13 +10094,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -10160,7 +10162,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -10168,14 +10170,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -10184,55 +10186,55 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -10293,7 +10295,7 @@
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -10316,7 +10318,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -11421,6 +11423,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11729,26 +11732,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11912,7 +11915,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11978,7 +11981,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit",
@@ -12095,13 +12098,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -12164,7 +12167,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -12172,14 +12175,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -12188,55 +12191,55 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -12297,7 +12300,7 @@
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -12320,7 +12323,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -13425,6 +13428,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13733,26 +13737,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13916,7 +13920,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13982,7 +13986,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit",
@@ -14099,13 +14103,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -14168,7 +14172,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -14176,14 +14180,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -14192,55 +14196,55 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -14301,7 +14305,7 @@
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -14324,7 +14328,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-server-runtime-spring/dependencies.lock
+++ b/titus-server-runtime-spring/dependencies.lock
@@ -1099,8 +1099,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -2287,8 +2287,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -3476,8 +3476,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -4728,8 +4728,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -5917,8 +5917,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -7026,6 +7026,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7316,26 +7317,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7494,7 +7495,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7560,7 +7561,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -7674,13 +7675,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7741,21 +7742,21 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7763,38 +7764,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7871,7 +7872,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -8945,6 +8946,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9235,26 +9237,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9413,7 +9415,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9479,7 +9481,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -9593,13 +9595,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9660,21 +9662,21 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9682,38 +9684,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9790,7 +9792,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10864,6 +10866,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11154,26 +11157,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11332,7 +11335,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11398,7 +11401,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -11512,13 +11515,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11580,21 +11583,21 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11602,38 +11605,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11710,7 +11713,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12784,6 +12787,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13074,26 +13078,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13252,7 +13256,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13318,7 +13322,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13432,13 +13436,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13500,21 +13504,21 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13522,38 +13526,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13630,7 +13634,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-server-runtime/dependencies.lock
+++ b/titus-server-runtime/dependencies.lock
@@ -6867,6 +6867,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7159,26 +7160,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7339,7 +7340,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7407,7 +7408,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -7521,13 +7522,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7588,20 +7589,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7609,38 +7610,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7716,7 +7717,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -8796,6 +8797,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9088,26 +9090,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9268,7 +9270,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9336,7 +9338,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -9450,13 +9452,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9517,20 +9519,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9538,38 +9540,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9645,7 +9647,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10725,6 +10727,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11017,26 +11020,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11197,7 +11200,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11265,7 +11268,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -11379,13 +11382,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11447,20 +11450,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11468,38 +11471,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11575,7 +11578,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12655,6 +12658,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -12947,26 +12951,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13127,7 +13131,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13195,7 +13199,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13309,13 +13313,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13377,20 +13381,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13398,38 +13402,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13505,7 +13509,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-supplementary-component/job-activity-history-springboot/dependencies.lock
+++ b/titus-supplementary-component/job-activity-history-springboot/dependencies.lock
@@ -1007,6 +1007,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -2909,6 +2910,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -3683,7 +3685,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -4838,6 +4840,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -5613,7 +5616,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -6823,6 +6826,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -8726,6 +8730,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -9501,7 +9506,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -10658,6 +10663,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11186,7 +11192,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -12582,6 +12588,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13117,7 +13124,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13368,7 +13375,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -14525,6 +14532,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -15053,7 +15061,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -16450,6 +16458,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -16985,7 +16994,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -17237,7 +17246,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]

--- a/titus-supplementary-component/job-activity-history/dependencies.lock
+++ b/titus-supplementary-component/job-activity-history/dependencies.lock
@@ -1107,8 +1107,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -2307,8 +2307,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -3508,8 +3508,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -4772,8 +4772,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -5973,8 +5973,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -7090,6 +7090,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7380,26 +7381,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7558,7 +7559,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7624,7 +7625,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -7738,13 +7739,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7807,8 +7808,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -7816,13 +7817,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7830,38 +7831,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7939,7 +7940,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9017,6 +9018,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9307,26 +9309,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9485,7 +9487,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9551,7 +9553,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -9665,13 +9667,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9734,8 +9736,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -9743,13 +9745,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9757,38 +9759,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9866,7 +9868,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10944,6 +10946,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11234,26 +11237,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11412,7 +11415,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11478,7 +11481,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -11592,13 +11595,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11662,8 +11665,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -11671,13 +11674,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11685,38 +11688,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11794,7 +11797,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12872,6 +12875,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13162,26 +13166,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13340,7 +13344,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13406,7 +13410,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13520,13 +13524,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13590,8 +13594,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -13599,13 +13603,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13613,38 +13617,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13722,7 +13726,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-supplementary-component/task-relocation-springboot/dependencies.lock
+++ b/titus-supplementary-component/task-relocation-springboot/dependencies.lock
@@ -7515,7 +7515,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -8830,7 +8830,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -10155,7 +10155,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -11471,7 +11471,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {

--- a/titus-supplementary-component/task-relocation/dependencies.lock
+++ b/titus-supplementary-component/task-relocation/dependencies.lock
@@ -1107,8 +1107,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -2307,8 +2307,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -3508,8 +3508,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -4772,8 +4772,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -5973,8 +5973,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring"
             ]
@@ -7090,6 +7090,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -7380,26 +7381,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7558,7 +7559,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7624,7 +7625,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -7738,13 +7739,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7807,8 +7808,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -7816,13 +7817,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7830,38 +7831,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7944,7 +7945,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -9022,6 +9023,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -9312,26 +9314,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9490,7 +9492,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9556,7 +9558,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -9670,13 +9672,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9739,8 +9741,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -9748,13 +9750,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9762,38 +9764,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9876,7 +9878,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10954,6 +10956,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -11244,26 +11247,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11422,7 +11425,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11488,7 +11491,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -11602,13 +11605,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11672,8 +11675,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -11681,13 +11684,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11695,38 +11698,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11809,7 +11812,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12887,6 +12890,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13177,26 +13181,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13355,7 +13359,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13421,7 +13425,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13535,13 +13539,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13605,8 +13609,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -13614,13 +13618,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13628,38 +13632,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13742,7 +13746,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-supplementary-component/tasks-publisher-springboot/dependencies.lock
+++ b/titus-supplementary-component/tasks-publisher-springboot/dependencies.lock
@@ -1037,6 +1037,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -3105,6 +3106,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -4014,7 +4016,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -5200,6 +5202,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -6110,7 +6113,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -7351,6 +7354,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -9420,6 +9424,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework:spring-webflux"
@@ -10330,7 +10335,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11518,6 +11523,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -12178,7 +12184,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13608,6 +13614,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -14275,7 +14282,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -14529,7 +14536,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -15717,6 +15724,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -16377,7 +16385,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -17808,6 +17816,7 @@
             "locked": "3.2.5.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -18475,7 +18484,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -18730,7 +18739,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.2.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]

--- a/titus-supplementary-component/tasks-publisher/dependencies.lock
+++ b/titus-supplementary-component/tasks-publisher/dependencies.lock
@@ -1372,16 +1372,16 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -2849,16 +2849,16 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -4327,16 +4327,16 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -5868,16 +5868,16 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -7346,16 +7346,16 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -8515,6 +8515,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -8908,26 +8909,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -9099,7 +9100,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9165,7 +9166,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -9279,13 +9280,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9350,8 +9351,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -9359,14 +9360,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9374,38 +9375,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -9483,7 +9484,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10602,6 +10603,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -10995,26 +10997,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -11186,7 +11188,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -11252,7 +11254,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -11366,13 +11368,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11437,8 +11439,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -11446,14 +11448,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11461,38 +11463,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -11570,7 +11572,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12689,6 +12691,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -13082,26 +13085,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -13273,7 +13276,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -13339,7 +13342,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -13453,13 +13456,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13525,8 +13528,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -13534,14 +13537,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13549,38 +13552,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -13658,7 +13661,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -14777,6 +14780,7 @@
             "locked": "3.2.8.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-common",
+                "com.netflix.titus:titus-testkit",
                 "io.projectreactor.addons:reactor-adapter",
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor:reactor-test",
@@ -15170,26 +15174,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -15361,7 +15365,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -15427,7 +15431,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
@@ -15541,13 +15545,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -15613,8 +15617,8 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-server-runtime-spring",
                 "org.springframework.boot:spring-boot-autoconfigure",
@@ -15622,14 +15626,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+",
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -15637,38 +15641,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "com.netflix.titus:titus-testkit"
             ]
@@ -15746,7 +15750,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/titus-testkit/dependencies.lock
+++ b/titus-testkit/dependencies.lock
@@ -993,6 +993,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -1277,26 +1278,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -1449,7 +1450,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -1515,7 +1516,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -1625,13 +1626,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -1690,20 +1691,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1711,37 +1712,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -1814,7 +1815,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -2861,6 +2862,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -3145,26 +3147,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -3317,7 +3319,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -3383,7 +3385,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -3493,13 +3495,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -3558,20 +3560,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3579,37 +3581,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -3682,7 +3684,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -4729,6 +4731,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -5013,26 +5016,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -5185,7 +5188,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -5251,7 +5254,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -5361,13 +5364,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -5427,20 +5430,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5448,37 +5451,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -5551,7 +5554,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -6661,6 +6664,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -6945,26 +6949,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -7117,7 +7121,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7183,7 +7187,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -7293,13 +7297,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -7359,20 +7363,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7380,37 +7384,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -7483,7 +7487,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -8530,6 +8534,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -8814,26 +8819,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -8986,7 +8991,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -9052,7 +9057,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -9162,13 +9167,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -9228,20 +9233,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -9249,37 +9254,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -9352,7 +9357,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -10409,6 +10414,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -10698,26 +10704,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -10873,7 +10879,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -10939,7 +10945,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -11050,13 +11056,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -11115,20 +11121,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -11136,37 +11142,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -11239,7 +11245,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -12296,6 +12302,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -12585,26 +12592,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -12760,7 +12767,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -12826,7 +12833,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -12937,13 +12944,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -13002,20 +13009,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -13023,37 +13030,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -13126,7 +13133,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -14183,6 +14190,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -14472,26 +14480,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -14647,7 +14655,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -14713,7 +14721,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -14824,13 +14832,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -14890,20 +14898,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -14911,37 +14919,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -15014,7 +15022,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -16071,6 +16079,7 @@
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.2.8.RELEASE",
+            "requested": "3.1.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "io.projectreactor.addons:reactor-adapter",
@@ -16360,26 +16369,26 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat:tomcat-annotations-api": {
-            "locked": "9.0.17",
+            "locked": "9.0.16",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-core"
             ]
@@ -16535,7 +16544,7 @@
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
-            "locked": "6.0.16.Final",
+            "locked": "6.0.14.Final",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -16601,7 +16610,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "2.26.0",
+            "locked": "2.27.0",
             "requested": "2.+"
         },
         "org.mozilla:rhino": {
@@ -16712,13 +16721,13 @@
             ]
         },
         "org.slf4j:jul-to-slf4j": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.26",
+            "locked": "1.7.25",
             "requested": "1.7.0",
             "transitive": [
                 "com.addthis.metrics:reporter-config-base",
@@ -16778,20 +16787,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -16799,37 +16808,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.1.4.RELEASE",
+            "locked": "2.1.3.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.1.4.RELEASE",
-            "requested": "2.1.+"
+            "locked": "2.1.3.RELEASE",
+            "requested": "2.1.3.RELEASE"
         },
         "org.springframework:spring-aop": {
             "locked": "5.1.6.RELEASE",
@@ -16902,7 +16911,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.1.6.RELEASE",
+            "locked": "5.1.5.RELEASE",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]


### PR DESCRIPTION
spring-boot 2.1.4 brings in tomcat-embed-core 9.0.17 which has incompatibilities with an internal TLS library used at Netflix.

Pin to 2.1.3, which is the recommended version ATM.