### PR TITLE
basic circle ci config to run all tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     executor: java
     resource_class: large
     steps:
+      - run: apt update && apt install ca-certificates git
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
     docker:
       - image: azul/zulu-openjdk:8
 jobs:
-  test-all:
+  build:
     executor: java
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-gradle-cache
-      - run: ./gradlew testAll --stacktrace
+      - run: ./gradlew testAll --no-daemon --max-workers 8 --stacktrace
       - save_cache:
           paths:
             - ~/.gradle/caches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+executors:
+  java:
+    docker:
+      - image: azul/zulu-openjdk:8
+jobs:
+  test-all:
+    executor: java
+    steps:
+      - checkout
+      - run: ./gradlew testAll --stacktrace
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
 jobs:
   build:
     executor: java
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run:
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,12 @@ jobs:
     executor: java
     resource_class: large
     steps:
-      - run: apt update && apt install ca-certificates git
+      - run:
+          environment:
+            DEBIAN_FRONTEND: noninteractive
+          command: |
+            apt update
+            apt install -qy ca-certificates git
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,17 @@ executors:
 jobs:
   build:
     executor: java
+    resource_class: large
     steps:
       - checkout
       - restore_cache:
           keys:
-            - gradle-cache
+            - v1-gradle-cache
       - run: ./gradlew testAll --stacktrace
       - save_cache:
           paths:
             - ~/.gradle/caches
             - ~/.gradle/wrapper
-          key: gradle-cache
+          key: v1-gradle-cache
           when: always
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-gradle-cache
-      - run: ./gradlew testAll --no-daemon --max-workers 8 --stacktrace
+      - run: ./gradlew testAll --info --parallel --no-daemon --max-workers 8 --stacktrace
       - save_cache:
           paths:
             - ~/.gradle/caches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-gradle-cache
-      - run: ./gradlew testAll --info --parallel --no-daemon --max-workers 8 --stacktrace
+      - run: ./gradlew testAll --parallel --no-daemon --max-workers 8 --stacktrace
       - save_cache:
           paths:
             - ~/.gradle/caches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,5 +8,14 @@ jobs:
     executor: java
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - gradle-cache
       - run: ./gradlew testAll --stacktrace
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
+          key: gradle-cache
+          when: always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ jdk:
   - openjdk8
 install: "./installViaTravis.sh"
 script: travis_wait ./buildViaTravis.sh
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - "$HOME/.gradle"
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 git:
   depth: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+dist: xenial
 language: java
 jdk:
   - openjdk8
-sudo: false
 install: "./installViaTravis.sh"
 script: travis_wait ./buildViaTravis.sh
 cache:

--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -3,7 +3,7 @@
 
 if [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
   echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
-  ./gradlew testAll --stacktrace
+  ./gradlew testAll --parallel --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build --stacktrace


### PR DESCRIPTION
Travis is being a bit too slow when running integration tests. This is an experiment in using CircleCI to see if it does any better.

I left tests running in both Travis and Circle so we can compare after a while.