### PR TITLE
transport client creation only when enabled

### DIFF
--- a/titus-ext/elasticsearch/src/main/java/com/netflix/titus/ext/elasticsearch/ElasticsearchModule.java
+++ b/titus-ext/elasticsearch/src/main/java/com/netflix/titus/ext/elasticsearch/ElasticsearchModule.java
@@ -49,12 +49,15 @@ public class ElasticsearchModule extends AbstractModule {
     @Provides
     @Singleton
     public Client getClient(ElasticsearchConfiguration configuration) throws UnknownHostException {
-        Settings settings = Settings.settingsBuilder()
-                .put("client.transport.ignore_cluster_name", true)
-                .build();
-        return TransportClient.builder().settings(settings).build().addTransportAddress(
-                new InetSocketTransportAddress(InetAddress.getByName(configuration.getTaskDocumentEsHostName()), configuration.getTaskDocumentEsPort())
-        );
+        if (configuration.isEnabled()) {
+            Settings settings = Settings.settingsBuilder()
+                    .put("client.transport.ignore_cluster_name", true)
+                    .build();
+            return TransportClient.builder().settings(settings).build().addTransportAddress(
+                    new InetSocketTransportAddress(InetAddress.getByName(configuration.getTaskDocumentEsHostName()), configuration.getTaskDocumentEsPort())
+            );
+        }
+        return TransportClient.builder().build();
     }
 
     @Provides


### PR DESCRIPTION
### Client creation fix

Transport client needs to be created only when elastic search publisher is enabled.