### PR TITLE
prevent unavailable Mesos (blips) from crashing the JVM

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -249,7 +249,7 @@ public class DefaultSchedulingService implements SchedulingService {
         }
 
         TaskScheduler.Builder schedulerBuilder = new TaskScheduler.Builder()
-                .withLeaseRejectAction(virtualMachineService::rejectLease)
+                .withLeaseRejectAction(logExceptions("Failed to reject lease: ", virtualMachineService::rejectLease))
                 .withLeaseOfferExpirySecs(masterConfiguration.getMesosLeaseOfferExpirySecs())
                 .withFitnessCalculator(new TitusFitnessCalculator(schedulerConfiguration, agentManagementFitnessCalculator, agentResourceCache))
                 .withFitnessGoodEnoughFunction(TitusFitnessCalculator.fitnessGoodEnoughFunction)
@@ -782,4 +782,13 @@ public class DefaultSchedulingService implements SchedulingService {
         agentResourceCache.shutdown();
     }
 
+    private static <T> Action1<T> logExceptions(String prefix, Action1<T> action) {
+        return item -> {
+            try {
+                action.call(item);
+            } catch (Exception e) {
+                logger.error(prefix + item, e);
+            }
+        };
+    }
 }


### PR DESCRIPTION
`DefaultSchedulingService` will `System.exit` on any exceptions coming from the Fenzo scheduling loop. In case Mesos is unavailable and offers can't be rejected, this will cause Titus master to crash.

Since Mesos is unavailable, we ignore the fact that offers can't be declined for now, and rely on re-registration (and lease expirations) to later fix offer states when Mesos comes back up.

I found this while running performance tests, and an overloaded Mesos service wasn't able to handle all `declineOffer()` calls.

My read of the Fenzo code tells me the worst that can happen is that leases will be expired from Fenzo's point of view (hence tasks can't be scheduled on the associated agents), but may still be valid from Mesos point of view, so these offers won't be re-offered until they expire (or are reconciled by a re-registration of the framework when Mesos comes back up). That means some agents may be un-schedulable until offers expire after a Mesos blip.