### PR TITLE
Enable task relocation for containers in  Eureka/OUT_OF_SERVICE state

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -101,6 +101,10 @@ public final class JobFunctions {
         return jobDescriptor.getExtensions() instanceof ServiceJobExt;
     }
 
+    public static boolean isDisabled(Job<?> job) {
+        return JobFunctions.isServiceJob(job) && !((ServiceJobExt) job.getJobDescriptor().getExtensions()).isEnabled();
+    }
+
     public static Job<ServiceJobExt> asServiceJob(Job<?> job) {
         if (isServiceJob(job)) {
             return (Job<ServiceJobExt>) job;

--- a/titus-ext/eureka/src/main/java/com/netflix/titus/ext/eureka/containerhealth/EurekaContainerHealthService.java
+++ b/titus-ext/eureka/src/main/java/com/netflix/titus/ext/eureka/containerhealth/EurekaContainerHealthService.java
@@ -128,7 +128,7 @@ public class EurekaContainerHealthService implements ContainerHealthService {
         List<InstanceInfo> instances = eurekaClient.getInstancesById(task.getId());
 
         // If a job is disabled, the real Eureka state is hidden. If the container is not registered with Eureka in
-        // the disabled job, we also do not put any constrains here. In both cases we report it is healthy.
+        // the disabled job, we also do not put any constraints here. In both cases we report it is healthy.
         if (JobFunctions.isDisabled(job)) {
             return ContainerHealthState.Healthy;
         }
@@ -222,7 +222,7 @@ public class EurekaContainerHealthService implements ContainerHealthService {
             return Flux.empty();
         }
 
-        // We need to examine in if a job 'enabled' status was changed.
+        // Examine if a job's 'enabled' status was changed.
         boolean isCurrentDisabled = JobFunctions.isDisabled(current);
         if (isCurrentDisabled == JobFunctions.isDisabled(previous)) {
             return Flux.empty();

--- a/titus-ext/eureka/src/main/java/com/netflix/titus/ext/eureka/containerhealth/EurekaContainerHealthService.java
+++ b/titus-ext/eureka/src/main/java/com/netflix/titus/ext/eureka/containerhealth/EurekaContainerHealthService.java
@@ -251,8 +251,10 @@ public class EurekaContainerHealthService implements ContainerHealthService {
 
     private ContainerHealthUpdateEvent recordNewState(ConcurrentMap<String, ContainerHealthEvent> state, Task task, ContainerHealthUpdateEvent newEvent) {
         if (task.getStatus().getState() != TaskState.Finished) {
+            logger.info("Recording new Eureka health state for a task: taskId={}, healthStatus={}", task.getId(), newEvent.getContainerHealthStatus());
             state.put(task.getId(), newEvent);
         } else {
+            logger.info("Removing Eureka health status for finished task: taskId={}", task.getId());
             state.remove(task.getId());
         }
         return newEvent;

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/RelocationConfiguration.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/RelocationConfiguration.java
@@ -51,7 +51,7 @@ public class RelocationConfiguration {
      * {@link #getRelocationScheduleIntervalMs()} interval, and should be a multiplication of the latter.
      */
     public long getDeschedulingIntervalMs() {
-        return SpringConfigurationUtil.getLong(environment, PREFIX + "deschedulingIntervalMs", 300_000);
+        return SpringConfigurationUtil.getLong(environment, PREFIX + "deschedulingIntervalMs", 120_000);
     }
 
     public long getRelocationTimeoutMs() {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/junit/asserts/ContainerHealthAsserts.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/junit/asserts/ContainerHealthAsserts.java
@@ -55,4 +55,9 @@ public final class ContainerHealthAsserts {
         assertThat(event).isInstanceOf(ContainerHealthUpdateEvent.class);
         assertContainerHealth(((ContainerHealthUpdateEvent) event).getContainerHealthStatus(), expectedTaskId, expectedHealthState);
     }
+
+    public static void assertContainerHealthAndEvent(ContainerHealthEvent event, ContainerHealthStatus healthStatus, String expectedTaskId, ContainerHealthState expectedHealthState) {
+        assertContainerHealth(healthStatus, expectedTaskId, expectedHealthState);
+        assertContainerHealthEvent(event, expectedTaskId, expectedHealthState);
+    }
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
@@ -29,11 +29,13 @@ import com.netflix.titus.api.containerhealth.service.ContainerHealthService;
 import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
 import com.netflix.titus.api.jobmanager.model.job.event.JobManagerEvent;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.common.data.generator.DataGenerator;
 import com.netflix.titus.common.data.generator.MutableDataGenerator;
@@ -83,6 +85,10 @@ public class JobComponentStub {
     }
 
     public JobComponentStub addBatchTemplate(String templateId, DataGenerator<JobDescriptor<BatchJobExt>> jobDescriptorGenerator) {
+        return addJobTemplate(templateId, (DataGenerator) jobDescriptorGenerator);
+    }
+
+    public JobComponentStub addServiceTemplate(String templateId, DataGenerator<JobDescriptor<ServiceJobExt>> jobDescriptorGenerator) {
         return addJobTemplate(templateId, (DataGenerator) jobDescriptorGenerator);
     }
 
@@ -150,6 +156,10 @@ public class JobComponentStub {
                         .withAttributes(CollectionsExt.copyAndAdd(task.getAttributes(), attributeName, attributeValue))
                         .build()
         );
+    }
+
+    public void changeJobEnabledStatus(Job<?> job, boolean enabled) {
+        stubbedJobData.changeJob(job.getId(), j -> JobFunctions.changeJobEnabledStatus(JobFunctions.asServiceJob(j), enabled));
     }
 
     public Job finishJob(Job job) {


### PR DESCRIPTION
If a container is in OUT_OF_SERVICE state in Eureka, its real state is lost. This forces us two chose between two strategies:
* assume containers are down, and report them as unhealthy
* assume containers are up, and report them as healthy
The former strategy was assumed before this change. This resulted in large pools of resources to be excluded from the relocation process. We switch to the latter strategy, accepting that this may increase the risk for service availability during rollbacks.