### PR TITLE
less verbose jooq logs during builds

### DIFF
--- a/titus-ext/jooq/build.gradle
+++ b/titus-ext/jooq/build.gradle
@@ -37,10 +37,19 @@ dependencies {
     testCompile project(':titus-testkit')
 
     jooqRuntime "postgresql:postgresql:${postgresqlVersion}"
+    jooqRuntime "org.slf4j:slf4j-log4j12:${slf4jVersion}"
+}
+
+sourceSets {
+   jooq {
+       resources {
+           srcDirs = ['src/jooq/resources']
+       }
+   }
 }
 
 jooq {
-    titus(sourceSets.main) {
+    relocation(sourceSets.main) {
         generator {
             name = 'org.jooq.codegen.DefaultGenerator'
             strategy {
@@ -99,3 +108,12 @@ jooq {
         }
     }
 }
+
+tasks.generateRelocationJooqSchemaSource.with {
+    jooqClasspath += sourceSets.jooq.resources.sourceDirectories
+}
+
+tasks.generateActivityJooqSchemaSource.with {
+    jooqClasspath += sourceSets.jooq.resources.sourceDirectories
+}
+

--- a/titus-ext/jooq/src/jooq/resources/log4j.properties
+++ b/titus-ext/jooq/src/jooq/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+log4j.logger.org.jooq=WARN
+


### PR DESCRIPTION
quiesce logs from the jooq source code generator that runs during gradle builds
