### PR TITLE
try to reduce test flakiness on Travis

### DIFF
--- a/titus-common/src/test/java/com/netflix/titus/common/framework/scheduler/internal/DefaultLocalSchedulerTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/framework/scheduler/internal/DefaultLocalSchedulerTest.java
@@ -111,7 +111,7 @@ public class DefaultLocalSchedulerTest {
         // Now cancel it
         assertThat(reference.isClosed()).isFalse();
         reference.close();
-        await().timeout(5, TimeUnit.SECONDS).until(reference::isClosed);
+        await().timeout(10, TimeUnit.SECONDS).until(reference::isClosed);
 
         assertThat(reference.isClosed()).isTrue();
         assertThat(reference.getSchedule().getCurrentAction().getStatus().getState().isFinal()).isTrue();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaControllerTest.java
@@ -110,7 +110,7 @@ public class SystemQuotaControllerTest {
         // Emit error
         budgetEmitter.onError(new RuntimeException("Simulated error"));
         budgetEmitter.onNext(SystemDisruptionBudget.newBasicSystemDisruptionBudget(5, 5));
-        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(() -> quotaController.getQuota(Reference.system()).getQuota() == 5);
+        Awaitility.await().timeout(10, TimeUnit.SECONDS).until(() -> quotaController.getQuota(Reference.system()).getQuota() == 5);
     }
 
     private SystemQuotaController newSystemQuotaController() {


### PR DESCRIPTION
... by increasing some test timeouts. I'm anecdotally noticing more flakiness in some unit tests after I added the `--parallel` flag. Let's see if this improves it.

cc @tbak @corindwyer (not asking for PR reviews since this is trivial)