### PR TITLE
pin the titus api definitions version to 0.0.1-rc61

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.1-rc+'
+        titusApiDefinitionsVersion = '0.0.1-rc61'
 
         awsSdkVersion = '1.11.+'
         javaxElVersion = '3.+'


### PR DESCRIPTION
### Description of the Change
Pin the titus api definitions version to `0.0.1-rc61`