### PR TITLE
Add support for configuring shared memory size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.1-rc61'
+        titusApiDefinitionsVersion = '0.0.1-rc62'
 
         awsSdkVersion = '1.11.+'
         javaxElVersion = '3.+'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobConfiguration.java
@@ -85,6 +85,13 @@ public interface JobConfiguration {
     @DefaultValue("40000")
     int getNetworkMbpsMax();
 
+    /**
+     * Default value for shared memory size if none is provided. This value is derived from the Docker
+     * default value: https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources.
+     */
+    @DefaultValue("64")
+    int getShmMegabytesDefault();
+
     @DefaultValue("" + DEFAULT_RUNTIME_LIMIT_SEC)
     long getDefaultRuntimeLimitSec();
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/ContainerResourcesMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/ContainerResourcesMixin.java
@@ -30,6 +30,7 @@ public abstract class ContainerResourcesMixin {
                                    @JsonProperty("diskMB") int diskMB,
                                    @JsonProperty("networkMbps") int networkMbps,
                                    @JsonProperty("efsMounts") List<EfsMount> efsMounts,
-                                   @JsonProperty("allocateIP") boolean allocateIP) {
+                                   @JsonProperty("allocateIP") boolean allocateIP,
+                                   @JsonProperty("shmMB") int shmMB) {
     }
 }

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobModelSanitizationTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobModelSanitizationTest.java
@@ -244,6 +244,44 @@ public class JobModelSanitizationTest {
     }
 
     @Test
+    public void testJobWithShmTooLarge() {
+        JobDescriptor<BatchJobExt> jobDescriptor = oneTaskBatchJobDescriptor();
+        JobDescriptor<BatchJobExt> shmTooLarge = JobModel.newJobDescriptor(jobDescriptor)
+                .withContainer(JobModel.newContainer(jobDescriptor.getContainer())
+                        .withContainerResources(
+                                JobModel.newContainerResources(jobDescriptor.getContainer().getContainerResources())
+                                .withMemoryMB(1024)
+                                .witShmMB(2048)
+                                .build()
+                        ).build()
+                ).build();
+
+        Job<BatchJobExt> job = JobGenerator.batchJobs(shmTooLarge).getValue();
+        assertThat(entitySanitizer.validate(job)).hasSize(1);
+    }
+
+    @Test
+    public void testJobWithUnsetShm() {
+        JobDescriptor<BatchJobExt> jobDescriptor = oneTaskBatchJobDescriptor();
+        JobDescriptor<BatchJobExt> shmUnset = JobModel.newJobDescriptor(jobDescriptor)
+                .withContainer(JobModel.newContainer(jobDescriptor.getContainer())
+                        .withContainerResources(
+                                JobModel.newContainerResources(jobDescriptor.getContainer().getContainerResources())
+                                        .witShmMB(0)
+                                        .build()
+                        ).build()
+                ).build();
+        Job<BatchJobExt> job = JobGenerator.batchJobs(shmUnset).getValue();
+        assertThat(job.getJobDescriptor().getContainer().getContainerResources().getShmMB()).isZero();
+
+        // Now do cleanup
+        Job<BatchJobExt> sanitized = entitySanitizer.sanitize(job).get();
+        assertThat(entitySanitizer.validate(sanitized)).isEmpty();
+        assertThat(sanitized.getJobDescriptor().getContainer().getContainerResources().getShmMB())
+                .isEqualTo(constraints.getShmMegabytesDefault());
+    }
+
+    @Test
     public void testJobWithTooLargeEntryPoint() {
         // Make key/value pair size 1MB
         char[] manyChars = new char[1025];

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
@@ -210,6 +210,9 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
         // Configure EFS
         containerInfoBuilder.addAllEfsConfigInfo(setupEfsMounts(containerResources.getEfsMounts()));
 
+        // Configure shared memory size
+        containerInfoBuilder.setShmSizeMB(containerResources.getShmMB());
+
         return containerInfoBuilder;
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
@@ -191,6 +191,7 @@ public final class V3GrpcModelConverters {
                 .withNetworkMbps(grpcResources.getNetworkMbps())
                 .withAllocateIP(grpcResources.getAllocateIP())
                 .withEfsMounts(coreEfsMounts)
+                .witShmMB(grpcResources.getShmSizeMB())
                 .build();
     }
 
@@ -566,6 +567,7 @@ public final class V3GrpcModelConverters {
                 .setNetworkMbps(containerResources.getNetworkMbps())
                 .setAllocateIP(containerResources.isAllocateIP())
                 .addAllEfsMounts(grpcEfsMounts)
+                .setShmSizeMB(containerResources.getShmMB())
                 .build();
     }
 

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskDocument.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskDocument.java
@@ -96,6 +96,7 @@ public class TaskDocument {
     private double networkMbps;
     private double disk;
     private int gpu;
+    private int shm;
     private Map<String, String> env;
     private int retries;
     private boolean restartOnSuccess;
@@ -186,6 +187,10 @@ public class TaskDocument {
 
     public double getDisk() {
         return disk;
+    }
+
+    public int getShm() {
+        return shm;
     }
 
     public int getGpu() {
@@ -391,6 +396,7 @@ public class TaskDocument {
         taskDocument.networkMbps = containerResources.getNetworkMbps();
         taskDocument.disk = containerResources.getDiskMB();
         taskDocument.gpu = containerResources.getGpu();
+        taskDocument.shm = containerResources.getShmMB();
         taskDocument.allocateIpAddress = containerResources.isAllocateIP();
         taskDocument.env = container.getEnv();
         taskDocument.iamProfile = container.getSecurityProfile().getIamRole();

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/ContainersGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/ContainersGenerator.java
@@ -79,6 +79,7 @@ public final class ContainersGenerator {
                         .withMemoryMB((int) (cpu * ratio * 1024))
                         .withDiskMB((int) (cpu * ratio * 2 * 10_000))
                         .withNetworkMbps((int) (cpu * ratio * 128))
+                        .witShmMB((int) (cpu * ratio * 1024 / 8))
                         .build()
         );
     }


### PR DESCRIPTION
Adds the ability to configure the size of /dev/shm shared memory.

If no shm value is provided, a default value is used.
If the value provided is larger than the memory, the job is rejected.