### PR TITLE
Minor refactor to support IAM Role authorization

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/spectator/AuthorizationMetrics.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/spectator/AuthorizationMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.util.spectator;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+public class AuthorizationMetrics {
+    private static final String AUTHORIZATION_METRICS_ROOT = "titus.authorization.";
+    private static final String AUTHORIZATION_RESULT_TAG = "result";
+    private static final String AUTHORIZATION_RESOURCE_TAG = "resource";
+    private static final String AUTHORIZATION_DOMAIN_TAG = "domain";
+    private static final String AUTHORIZATION_ERROR_TAG = "error";
+
+    private final Registry registry;
+    private final Id authorizationId;
+
+    public AuthorizationMetrics(String authorizationName, Registry registry) {
+        this.registry = registry;
+        authorizationId = registry.createId(AUTHORIZATION_METRICS_ROOT + authorizationName);
+    }
+
+    public void incrementAuthorizationSuccess(String resourceName, String securityDomain) {
+        registry.counter(authorizationId
+                .withTag(AUTHORIZATION_RESULT_TAG, "success")
+                .withTag(AUTHORIZATION_RESOURCE_TAG, resourceName)
+                .withTag(AUTHORIZATION_DOMAIN_TAG, securityDomain)
+        ).increment();
+    }
+
+    public void incrementAuthorizationError(String resourceName, String securityDomain, String errorReason) {
+        registry.counter(authorizationId
+                .withTag(AUTHORIZATION_RESULT_TAG, "failure")
+                .withTag(AUTHORIZATION_RESOURCE_TAG, resourceName)
+                .withTag(AUTHORIZATION_DOMAIN_TAG, securityDomain)
+                .withTag(AUTHORIZATION_ERROR_TAG, errorReason)
+        ).increment();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/JobAuthorizationService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/JobAuthorizationService.java
@@ -17,7 +17,6 @@
 package com.netflix.titus.master.jobmanager.endpoint.v3.grpc;
 
 import java.util.Map;
-import java.util.function.Predicate;
 
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Job;
@@ -31,12 +30,6 @@ import reactor.core.publisher.Mono;
 public abstract class JobAuthorizationService implements AuthorizationService {
 
     private static final String SECURITY_ATTRIBUTE_SECURITY_DOMAIN = "titus.securityDomain";
-
-    private final Predicate<String> callerIdPredicate;
-
-    protected JobAuthorizationService(Predicate<String> callerIdPredicate) {
-        this.callerIdPredicate = callerIdPredicate;
-    }
 
     @Override
     public <T> Mono<AuthorizationStatus> authorize(CallMetadata callMetadata, T object) {
@@ -75,10 +68,6 @@ public abstract class JobAuthorizationService implements AuthorizationService {
     }
 
     private Mono<AuthorizationStatus> authorizeCaller(JobDescriptor<?> jobDescriptor, String originalCallerId) {
-        if (!callerIdPredicate.test(originalCallerId)) {
-            return Mono.just(AuthorizationStatus.success("User not white listed for authorization; granted by default: callerId=" + originalCallerId));
-        }
-
         return authorize(originalCallerId, buildSecurityDomainId(jobDescriptor), jobDescriptor);
     }
 


### PR DESCRIPTION
This is change supports changes to nftitus. There are 2 main changes:
1. Adds common authorization metrics
2. Moves all feature predicate checking to the sub-class implementing `protected abstract Mono<AuthorizationStatus> authorize()`. Note that because this moves the predicate check it depends on the companion PR to properly scope which apps to check.