### PR TITLE
track Jobs with sanitization (open) failures, and relax moveTask validation for them

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -48,12 +48,12 @@ public final class JobAttributes {
     /**
      * Set by {@link EntityValidator} for iam roles when failing open
      */
-    public static final String JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.iam";
+    public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IAM = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.iam";
 
     /**
      * Set by {@link EntityValidator} for container images (digest) when failing open
      */
-    public static final String JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.image";
+    public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IMAGE = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.image";
 
     // Container Attributes
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -26,6 +26,7 @@ public final class JobAttributes {
 
     public static final String TITUS_ATTRIBUTE_PREFIX = "titus.";
     public static final String TITUS_PARAMETER_ATTRIBUTE_PREFIX = "titusParameter.";
+    public static final String JOB_ATTRIBUTE_SANITIZATION_PREFIX = TITUS_ATTRIBUTE_PREFIX + "sanitization.";
 
     // Job Descriptor Attributes
 
@@ -47,12 +48,12 @@ public final class JobAttributes {
     /**
      * Set by {@link EntityValidator} for iam roles when failing open
      */
-    public static final String JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED = TITUS_ATTRIBUTE_PREFIX + ".sanitization.iam.skipped";
+    public static final String JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.iam";
 
     /**
      * Set by {@link EntityValidator} for container images (digest) when failing open
      */
-    public static final String JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED = TITUS_ATTRIBUTE_PREFIX + ".sanitization.image.skipped";
+    public static final String JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.image";
 
     // Container Attributes
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.api.jobmanager;
 
+import com.netflix.titus.common.model.validator.EntityValidator;
+
 /**
  * Constant keys for Job attributes. Attributes that begin with <b>titus.</b> are readonly system generated attributes
  * while attributes that begin with <b>titusParameter.</b> are user supplied parameters.
@@ -41,6 +43,16 @@ public final class JobAttributes {
      * Unique Cell name for a deployment.
      */
     public static final String JOB_ATTRIBUTES_CELL = TITUS_ATTRIBUTE_PREFIX + "cell";
+
+    /**
+     * Set by {@link EntityValidator} for iam roles when failing open
+     */
+    public static final String JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED = TITUS_ATTRIBUTE_PREFIX + ".sanitization.iam.skipped";
+
+    /**
+     * Set by {@link EntityValidator} for container images (digest) when failing open
+     */
+    public static final String JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED = TITUS_ATTRIBUTE_PREFIX + ".sanitization.image.skipped";
 
     // Container Attributes
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibility.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibility.java
@@ -70,11 +70,11 @@ public class JobCompatibility {
     }
 
     private static boolean isImageSanitizationSkipped(JobDescriptor<?> jobDescriptor) {
-        return Boolean.parseBoolean(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED));
+        return Boolean.parseBoolean(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IMAGE));
     }
 
     private static boolean isIamSanitizationSkipped(JobDescriptor<?> jobDescriptor) {
-        return Boolean.parseBoolean(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED));
+        return Boolean.parseBoolean(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IAM));
     }
 
     private static JobDescriptor<ServiceJobExt> unsetIgnoredFieldsForCompatibility(JobDescriptor<ServiceJobExt> descriptor,

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibility.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibility.java
@@ -61,13 +61,24 @@ public class JobCompatibility {
     }
 
     public static JobCompatibility of(JobDescriptor<ServiceJobExt> from, JobDescriptor<ServiceJobExt> to) {
-        JobDescriptor<ServiceJobExt> jobFromNormalized = unsetIgnoredFieldsForCompatibility(from);
-        JobDescriptor<ServiceJobExt> jobToNormalized = unsetIgnoredFieldsForCompatibility(to);
+        boolean ignoreImage = isImageSanitizationSkipped(from) || isImageSanitizationSkipped(to);
+        boolean ignoreIam = isIamSanitizationSkipped(from) || isIamSanitizationSkipped(to);
+        JobDescriptor<ServiceJobExt> jobFromNormalized = unsetIgnoredFieldsForCompatibility(from, ignoreImage, ignoreIam);
+        JobDescriptor<ServiceJobExt> jobToNormalized = unsetIgnoredFieldsForCompatibility(to, ignoreImage, ignoreIam);
         boolean identical = jobFromNormalized.equals(jobToNormalized);
         return new JobCompatibility(jobFromNormalized, jobToNormalized, identical);
     }
 
-    private static JobDescriptor<ServiceJobExt> unsetIgnoredFieldsForCompatibility(JobDescriptor<ServiceJobExt> descriptor) {
+    private static boolean isImageSanitizationSkipped(JobDescriptor<?> jobDescriptor) {
+        return Boolean.parseBoolean(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED));
+    }
+
+    private static boolean isIamSanitizationSkipped(JobDescriptor<?> jobDescriptor) {
+        return Boolean.parseBoolean(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED));
+    }
+
+    private static JobDescriptor<ServiceJobExt> unsetIgnoredFieldsForCompatibility(JobDescriptor<ServiceJobExt> descriptor,
+                                                                                   boolean ignoreImage, boolean ignoreIam) {
         Container container = descriptor.getContainer();
         SecurityProfile securityProfile = container.getSecurityProfile();
         Map<String, String> onlyTitusContainerAttributes = filterOutNonTitusAttributes(container.getAttributes());
@@ -79,9 +90,11 @@ public class JobCompatibility {
                 .withJobGroupInfo(JobGroupInfo.newBuilder().build())
                 .withAttributes(Collections.emptyMap())
                 .withContainer(container.toBuilder()
+                        .withImage(ignoreImage ? Image.newBuilder().build() : container.getImage())
                         .withAttributes(onlyTitusContainerAttributes)
                         .withSecurityProfile(securityProfile.toBuilder()
                                 .withAttributes(onlyTitusSecurityAttributes)
+                                .withIamRole(ignoreIam ? "" : container.getSecurityProfile().getIamRole())
                                 .build())
                         .build())
                 .withExtensions(ServiceJobExt.newBuilder()

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -172,10 +172,10 @@ public final class JobFunctions {
         return jobDescriptor.toBuilder().withExtensions(ext).build();
     }
 
-    public static JobDescriptor<?> filterOutTitusAttributes(JobDescriptor<?> jobDescriptor) {
+    public static JobDescriptor<?> filterOutSanitizationAttributes(JobDescriptor<?> jobDescriptor) {
         return jobDescriptor.toBuilder().withAttributes(
                 CollectionsExt.copyAndRemoveByKey(jobDescriptor.getAttributes(),
-                        key -> key.startsWith(JobAttributes.TITUS_ATTRIBUTE_PREFIX)
+                        key -> key.startsWith(JobAttributes.JOB_ATTRIBUTE_SANITIZATION_PREFIX)
                 )
         ).build();
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor.JobDescriptorExt;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.ContainerHealthProvider;
@@ -169,6 +170,14 @@ public final class JobFunctions {
     public static JobDescriptor<BatchJobExt> changeBatchJobSize(JobDescriptor<BatchJobExt> jobDescriptor, int size) {
         BatchJobExt ext = jobDescriptor.getExtensions().toBuilder().withSize(size).build();
         return jobDescriptor.toBuilder().withExtensions(ext).build();
+    }
+
+    public static JobDescriptor<?> filterOutTitusAttributes(JobDescriptor<?> jobDescriptor) {
+        return jobDescriptor.toBuilder().withAttributes(
+                CollectionsExt.copyAndRemoveByKey(jobDescriptor.getAttributes(),
+                        key -> key.startsWith(JobAttributes.TITUS_ATTRIBUTE_PREFIX)
+                )
+        ).build();
     }
 
     public static <E extends JobDescriptorExt> JobDescriptor<E> appendJobDescriptorAttribute(JobDescriptor<E> jobDescriptor,

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibilityTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibilityTest.java
@@ -184,7 +184,7 @@ public class JobCompatibilityTest {
         JobDescriptor<ServiceJobExt> base = JobDescriptorGenerator.oneTaskServiceJobDescriptor();
         JobDescriptor<ServiceJobExt> from = base.toBuilder()
                 .withContainer(base.getContainer().but(c -> c.getSecurityProfile().toBuilder().withIamRole("simpleName")))
-                .withAttributes(CollectionsExt.copyAndAdd(base.getAttributes(), JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED, "true"))
+                .withAttributes(CollectionsExt.copyAndAdd(base.getAttributes(), JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IAM, "true"))
                 .build();
         JobDescriptor<ServiceJobExt> to = base.toBuilder()
                 .withContainer(base.getContainer().but(c -> c.getSecurityProfile().toBuilder().withIamRole("arn:aws:fullyQualified/12345/simpleName")))
@@ -196,7 +196,7 @@ public class JobCompatibilityTest {
                 .build();
         JobDescriptor<ServiceJobExt> to2 = base.toBuilder()
                 .withContainer(base.getContainer().but(c -> c.getImage().toBuilder().withDigest("").build()))
-                .withAttributes(CollectionsExt.copyAndAdd(base.getAttributes(), JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED, "true"))
+                .withAttributes(CollectionsExt.copyAndAdd(base.getAttributes(), JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IMAGE, "true"))
                 .build();
         assertThat(JobCompatibility.of(from2, to2).isCompatible()).isTrue();
     }

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibilityTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobCompatibilityTest.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.api.jobmanager.model.job;
 
+import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.DisruptionBudget;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.SelfManagedDisruptionBudgetPolicy;
 import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
@@ -174,4 +175,30 @@ public class JobCompatibilityTest {
         JobCompatibility compatibility2 = JobCompatibility.of(reference, incompatible);
         assertThat(compatibility2.isCompatible()).isFalse();
     }
+
+    @Test
+    public void testSanitizationCanFailOpen() {
+        // when jobs are cloned, they can have different values for sanitized fields
+        // if sanitization fails open for one but not for the other
+
+        JobDescriptor<ServiceJobExt> base = JobDescriptorGenerator.oneTaskServiceJobDescriptor();
+        JobDescriptor<ServiceJobExt> from = base.toBuilder()
+                .withContainer(base.getContainer().but(c -> c.getSecurityProfile().toBuilder().withIamRole("simpleName")))
+                .withAttributes(CollectionsExt.copyAndAdd(base.getAttributes(), JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED, "true"))
+                .build();
+        JobDescriptor<ServiceJobExt> to = base.toBuilder()
+                .withContainer(base.getContainer().but(c -> c.getSecurityProfile().toBuilder().withIamRole("arn:aws:fullyQualified/12345/simpleName")))
+                .build();
+        assertThat(JobCompatibility.of(from, to).isCompatible()).isTrue();
+
+        JobDescriptor<ServiceJobExt> from2 = base.toBuilder()
+                .withContainer(base.getContainer().but(c -> c.getImage().toBuilder().withDigest("foo-digest-123").build()))
+                .build();
+        JobDescriptor<ServiceJobExt> to2 = base.toBuilder()
+                .withContainer(base.getContainer().but(c -> c.getImage().toBuilder().withDigest("").build()))
+                .withAttributes(CollectionsExt.copyAndAdd(base.getAttributes(), JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED, "true"))
+                .build();
+        assertThat(JobCompatibility.of(from2, to2).isCompatible()).isTrue();
+    }
+
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
@@ -223,6 +223,12 @@ public final class CollectionsExt {
         return result;
     }
 
+    public static <K, V> Map<K, V> copyAndRemoveByKey(Map<K, V> original, Predicate<K> keysPredicate) {
+        return original.entrySet().stream()
+                .filter(entry -> !keysPredicate.test(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
     public static <K, V> Map<K, V> copyAndRemoveByValue(Map<K, V> original, Predicate<V> removePredicate) {
         return original.entrySet().stream()
                 .filter(entry -> !removePredicate.test(entry.getValue()))

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
@@ -147,7 +147,7 @@ public class GatewayJobServiceGateway extends JobServiceGatewayDelegate {
     public Observable<String> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata) {
         com.netflix.titus.api.jobmanager.model.job.JobDescriptor coreJobDescriptor;
         try {
-            coreJobDescriptor = V3GrpcModelConverters.toCoreJobDescriptor(jobDescriptor);
+            coreJobDescriptor = JobFunctions.filterOutTitusAttributes(V3GrpcModelConverters.toCoreJobDescriptor(jobDescriptor));
         } catch (Exception e) {
             return Observable.error(TitusServiceException.invalidArgument(e));
         }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
@@ -147,7 +147,7 @@ public class GatewayJobServiceGateway extends JobServiceGatewayDelegate {
     public Observable<String> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata) {
         com.netflix.titus.api.jobmanager.model.job.JobDescriptor coreJobDescriptor;
         try {
-            coreJobDescriptor = JobFunctions.filterOutTitusAttributes(V3GrpcModelConverters.toCoreJobDescriptor(jobDescriptor));
+            coreJobDescriptor = JobFunctions.filterOutSanitizationAttributes(V3GrpcModelConverters.toCoreJobDescriptor(jobDescriptor));
         } catch (Exception e) {
             return Observable.error(TitusServiceException.invalidArgument(e));
         }

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageValidatorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageValidatorTest.java
@@ -111,7 +111,7 @@ public class JobImageValidatorTest {
                     assertThat(jd.getContainer().getImage().getDigest()).isNullOrEmpty();
                     assertThat(jd.getContainer().getImage()).isEqualTo(jobDescriptorWithTag.getContainer().getImage());
                     assertThat(((JobDescriptor<?>) jd).getAttributes())
-                            .containsEntry(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED, "true");
+                            .containsEntry(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IMAGE, "true");
                 })
                 .verifyComplete();
     }

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageValidatorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageValidatorTest.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.gateway.service.v3.internal;
 
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.validator.ValidationError;
@@ -108,7 +109,9 @@ public class JobImageValidatorTest {
         StepVerifier.create(validator.sanitize(jobDescriptorWithTag))
                 .assertNext(jd -> {
                     assertThat(jd.getContainer().getImage().getDigest()).isNullOrEmpty();
-                    assertThat(jd.getContainer().getImage().equals(jobDescriptorWithTag.getContainer().getImage())).isTrue();
+                    assertThat(jd.getContainer().getImage()).isEqualTo(jobDescriptorWithTag.getContainer().getImage());
+                    assertThat(((JobDescriptor<?>) jd).getAttributes())
+                            .containsEntry(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED, "true");
                 })
                 .verifyComplete();
     }

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobSecurityValidatorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobSecurityValidatorTest.java
@@ -121,7 +121,7 @@ public class JobSecurityValidatorTest {
                     assertThat(jobDescriptor.getContainer().getSecurityProfile().getIamRole())
                             .isEqualTo(jobDescriptorWithInvalidIam.getContainer().getSecurityProfile().getIamRole());
                     assertThat(((JobDescriptor<?>) jobDescriptor).getAttributes())
-                            .containsEntry(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED, "true");
+                            .containsEntry(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IAM, "true");
                 })
                 .verifyComplete();
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobAttributesTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobAttributesTest.java
@@ -57,11 +57,11 @@ public class JobAttributesTest extends BaseIntegrationTest {
     @Test(timeout = TEST_TIMEOUT_MS)
     public void testIgnoreTitusAttributesFromInput() throws Exception {
         JobDescriptor<ServiceJobExt> job = oneTaskServiceJobDescriptor().but(jd ->
-                jd.toBuilder().withAttributes(CollectionsExt.copyAndAdd(jd.getAttributes(), "titus.something", "foo"))
+                jd.toBuilder().withAttributes(CollectionsExt.copyAndAdd(jd.getAttributes(), "titus.sanitization.something", "foo"))
         );
         jobsScenarioBuilder.schedule(job, jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.jobAccepted())
-                .assertJob(j -> !j.getJobDescriptor().getAttributes().containsKey("titus.something"))
+                .assertJob(j -> !j.getJobDescriptor().getAttributes().containsKey("titus.sanitization.something"))
         );
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobIamValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobIamValidator.java
@@ -112,7 +112,7 @@ public class JobIamValidator implements EntityValidator<JobDescriptor> {
         JobDescriptor onErrorFallback = jobDescriptor.toBuilder()
                 .withAttributes(CollectionsExt.copyAndAdd(
                         ((JobDescriptor<?>) jobDescriptor).getAttributes(),
-                        JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IAM_SKIPPED, "true"))
+                        JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IAM, "true"))
                 .build();
 
         return iamConnector.getIamRole(iamRoleName)

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/validator/JobImageValidator.java
@@ -94,7 +94,7 @@ public class JobImageValidator implements EntityValidator<JobDescriptor> {
         JobDescriptor onErrorFallback = jobDescriptor.toBuilder()
                 .withAttributes(CollectionsExt.copyAndAdd(
                         ((JobDescriptor<?>) jobDescriptor).getAttributes(),
-                        JobAttributes.JOB_ATTRIBUTES_SANITIZATION_IMAGE_SKIPPED, "true"))
+                        JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IMAGE, "true"))
                 .build();
         Image image = jobDescriptor.getContainer().getImage();
 


### PR DESCRIPTION
When a job is cloned and either one of the copies had sanitization failures, they can have different values for the non-sanitized field(s), but are still compatible.

This PR also ignores all user-supplied `titus.sanitization.*` attributes for new jobs, since these are reserved and automatically filled by Titus.