### PR TITLE
admission: split sanitization and validation into different interfaces

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
@@ -22,8 +22,8 @@ public interface AdmissionSanitizer<T> {
     /**
      * Async method to clean and add missing data elements to an entity
      *
-     * @return Returns a Mono/Single that emits an a cleaned up version. If no changes were made,
-     * the emitted item will share reference with the source parameter.
+     * @return Returns a Mono/Single that emits a cleaned up version. If no changes were made, the emitted item will
+     * share a reference with the source parameter.
      */
     Mono<T> sanitize(T entity);
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
@@ -16,22 +16,14 @@
 
 package com.netflix.titus.runtime.endpoint.admission;
 
-import java.util.Set;
-
-import com.netflix.titus.common.model.sanitizer.ValidationError;
 import reactor.core.publisher.Mono;
 
-/**
- * An <tt>AdmissionValidator</tt> determines whether an object of the parameterized type is valid.  If it finds an
- * object to be invalid it returns a non-empty set of {@link ValidationError}s.
- *
- * @param <T> The type of object this AdmissionValidator validates.
- */
-public interface AdmissionValidator<T> {
-    Mono<Set<ValidationError>> validate(T entity);
-
+public interface AdmissionSanitizer<T> {
     /**
-     * Returns the error type this validator will produce in the {@link AdmissionValidator#validate(Object)} method.
+     * Async method to clean and add missing data elements to an entity
+     *
+     * @return Returns a Mono/Single that emits an a cleaned up version. If no changes were made,
+     * the emitted item will share reference with the source parameter.
      */
-    ValidationError.Type getErrorType();
+    Mono<T> sanitize(T entity);
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidator.java
@@ -35,11 +35,11 @@ import reactor.core.scheduler.Schedulers;
  * An AggregatingValidator executes and aggregates the results of multiple {@link AdmissionValidator}s.
  */
 @Singleton
-public class AggregatingValidator implements AdmissionValidator<JobDescriptor> {
+public class AggregatingValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     private final TitusValidatorConfiguration configuration;
     private final Duration timeout;
     private final Collection<AdmissionValidator<JobDescriptor>> validators;
-    private final Collection<AdmissionValidator<JobDescriptor>> sanitizers;
+    private final Collection<AdmissionSanitizer<JobDescriptor>> sanitizers;
     private final ValidatorMetrics validatorMetrics;
 
     /**
@@ -57,7 +57,7 @@ public class AggregatingValidator implements AdmissionValidator<JobDescriptor> {
             TitusValidatorConfiguration configuration,
             Registry registry,
             Collection<AdmissionValidator<JobDescriptor>> validators,
-            Collection<AdmissionValidator<JobDescriptor>> sanitizers) {
+            Collection<AdmissionSanitizer<JobDescriptor>> sanitizers) {
         this.configuration = configuration;
         this.timeout = Duration.ofMillis(this.configuration.getTimeoutMs());
         this.validators = validators;
@@ -88,7 +88,7 @@ public class AggregatingValidator implements AdmissionValidator<JobDescriptor> {
     @Override
     public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
         Mono<JobDescriptor> sanitizedJobDescriptorMono = Mono.just(entity);
-        for (AdmissionValidator<JobDescriptor> sanitizer : sanitizers) {
+        for (AdmissionSanitizer<JobDescriptor> sanitizer : sanitizers) {
             sanitizedJobDescriptorMono = sanitizedJobDescriptorMono.flatMap(sanitizer::sanitize);
         }
         return sanitizedJobDescriptorMono.timeout(timeout);

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/FailJobValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/FailJobValidator.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Mono;
 /**
  * This {@link AdmissionValidator} implementation always causes validation to fail.  It is used for testing purposes.
  */
-public class FailJobValidator implements AdmissionValidator<JobDescriptor> {
+public class FailJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     public static final String ERR_FIELD = "fail-field";
     public static final String ERR_DESCRIPTION = "The FailJobValidator should always fail with a unique error:";
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobIamValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobIamValidator.java
@@ -37,7 +37,7 @@ import reactor.core.publisher.Mono;
  * This {@link AdmissionValidator} implementation validates and sanitizes Job IAM information.
  */
 @Singleton
-public class JobIamValidator implements AdmissionValidator<JobDescriptor> {
+public class JobIamValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     private final JobSecurityValidatorConfiguration configuration;
     private final IamConnector iamConnector;
     private final ValidatorMetrics validatorMetrics;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Mono;
  * should be overridden.
  */
 @Singleton
-public class PassJobValidator implements AdmissionValidator<JobDescriptor> {
+public class PassJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     private final ValidationError.Type errorType;
 
     public PassJobValidator() {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
@@ -23,7 +23,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.spectator.api.Registry;
-import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.runtime.TitusEntitySanitizerModule;
 
 /**
@@ -34,6 +33,8 @@ public class TitusAdmissionModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(AdmissionValidator.class).to(AggregatingValidator.class);
+        bind(AdmissionSanitizer.class).to(AggregatingValidator.class);
     }
 
     @Provides
@@ -44,14 +45,15 @@ public class TitusAdmissionModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public AdmissionValidator<JobDescriptor> getJobValidator(TitusValidatorConfiguration configuration,
-                                                             JobImageValidator jobImageValidator,
-                                                             JobIamValidator jobIamValidator,
-                                                             Registry registry) {
+    public AggregatingValidator getJobValidator(TitusValidatorConfiguration configuration,
+                                                JobImageSanitizer jobImageSanitizer,
+                                                JobIamValidator jobIamValidator,
+                                                Registry registry) {
         return new AggregatingValidator(
                 configuration,
                 registry,
                 Collections.singletonList(jobIamValidator),
-                Collections.singletonList(jobImageValidator));
+                Collections.singletonList(jobImageSanitizer)
+        );
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
@@ -21,20 +21,24 @@ import javax.inject.Singleton;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.TypeLiteral;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.spectator.api.Registry;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.runtime.TitusEntitySanitizerModule;
 
 /**
- * This module provides dependencies for Titus validation ({@link AdmissionValidator}) which is beyond syntactic
- * validation.  See {@link TitusEntitySanitizerModule} for syntactic sanitization and validation.
+ * This module provides dependencies for Titus validation ({@link AdmissionValidator} and {@link AdmissionSanitizer})
+ * which is beyond syntactic validation. See {@link TitusEntitySanitizerModule} for syntactic sanitization and validation.
  */
 public class TitusAdmissionModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(AdmissionValidator.class).to(AggregatingValidator.class);
-        bind(AdmissionSanitizer.class).to(AggregatingValidator.class);
+        bind(new TypeLiteral<AdmissionValidator<JobDescriptor>>() {
+        }).to(AggregatingValidator.class);
+        bind(new TypeLiteral<AdmissionSanitizer<JobDescriptor>>() {
+        }).to(AggregatingValidator.class);
     }
 
     @Provides

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidatorTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidatorTest.java
@@ -305,8 +305,8 @@ public class AggregatingValidatorTest {
     public void sanitizePassPass() {
         final String initialAppName = "initialAppName";
         final String initialCapacityGroup = "initialCapacityGroup";
-        AdmissionValidator appNameSanitizer = new TestingAppNameSanitizer();
-        AdmissionValidator capacityGroupSanitizer = new TestingCapacityGroupSanitizer();
+        AdmissionSanitizer<JobDescriptor> appNameSanitizer = new TestingAppNameSanitizer();
+        AdmissionSanitizer<JobDescriptor> capacityGroupSanitizer = new TestingCapacityGroupSanitizer();
 
         JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
                 .map(jd -> jd.toBuilder()
@@ -333,8 +333,8 @@ public class AggregatingValidatorTest {
     public void sanitizePassFail() {
         final String initialAppName = "initialAppName";
         final String initialCapacityGroup = "initialCapacityGroup";
-        AdmissionValidator appNameSanitizer = new TestingAppNameSanitizer();
-        AdmissionValidator failSanitizer = new FailJobValidator();
+        AdmissionSanitizer<JobDescriptor> appNameSanitizer = new TestingAppNameSanitizer();
+        AdmissionSanitizer<JobDescriptor> failSanitizer = new FailJobValidator();
 
         JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
                 .map(jd -> jd.toBuilder()
@@ -372,7 +372,7 @@ public class AggregatingValidatorTest {
         assertThat(hardErrors).allMatch(error -> error.getType().equals(errorType));
     }
 
-    private static class EmptyValidator implements AdmissionValidator<JobDescriptor> {
+    private static class EmptyValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
         @Override
         public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
             return Mono.empty();

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/NeverJobValidator.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/NeverJobValidator.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 /**
  * This validator never completes.  It is used to test validation in the face of unresponsive service calls.
  */
-class NeverJobValidator implements AdmissionValidator<JobDescriptor> {
+class NeverJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     private final ValidationError.Type errorType;
 
     public NeverJobValidator() {

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingAppNameSanitizer.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingAppNameSanitizer.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono;
  * This {@link AdmissionValidator} implementation ensures a job's appname matches a specific
  * string. It is only used for testing purposes.
  */
-class TestingAppNameSanitizer implements AdmissionValidator<JobDescriptor> {
+class TestingAppNameSanitizer implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     final static String desiredAppName = "desiredAppName";
     private static final String ERR_FIELD = "fail-field";
     private static final String ERR_DESCRIPTION =

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingCapacityGroupSanitizer.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingCapacityGroupSanitizer.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono;
  * This {@link AdmissionValidator} implementation ensures a job's capacity group matches a specific
  * string. It is only used for testing purposes.
  */
-class TestingCapacityGroupSanitizer implements AdmissionValidator<JobDescriptor> {
+class TestingCapacityGroupSanitizer implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     final static String desiredCapacityGroup = "desiredCapacityGroup";
     private static final String ERR_FIELD = "fail-field";
     private static final String ERR_DESCRIPTION =

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedTitusCell.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedTitusCell.java
@@ -19,6 +19,7 @@ package com.netflix.titus.testkit.embedded.cell;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
 import com.netflix.titus.testkit.embedded.EmbeddedTitusOperations;
@@ -81,6 +82,7 @@ public class EmbeddedTitusCell {
         private boolean enableREST;
         private boolean defaultGateway;
         private AdmissionValidator<JobDescriptor> validator = new PassJobValidator();
+        private AdmissionSanitizer<JobDescriptor> sanitizer = new PassJobValidator();
 
         public Builder withMaster(EmbeddedTitusMaster master) {
             this.master = master;
@@ -103,6 +105,11 @@ public class EmbeddedTitusCell {
             return this;
         }
 
+        public Builder withJobSanitizer(AdmissionSanitizer<JobDescriptor> sanitizer) {
+            this.sanitizer = sanitizer;
+            return this;
+        }
+
         public EmbeddedTitusCell build() {
             Preconditions.checkNotNull(master, "TitusMaster not set");
             Preconditions.checkState(gateway != null || defaultGateway, "TitusGateway not set, nor default gateway requested");
@@ -115,6 +122,7 @@ public class EmbeddedTitusCell {
                         .withStore(master.getJobStore())
                         .withEnableREST(enableREST)
                         .withJobValidator(validator)
+                        .withJobSanitizer(sanitizer)
                         .build();
             } else {
                 gateway = gateway.toBuilder()

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
@@ -38,6 +38,7 @@ import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.master.TitusMaster;
+import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
 import com.netflix.titus.runtime.endpoint.common.rest.EmbeddedJettyModule;
@@ -73,6 +74,7 @@ public class EmbeddedTitusGateway {
 
     private final DefaultSettableConfig config;
     private final AdmissionValidator<JobDescriptor> validator;
+    private final AdmissionSanitizer<JobDescriptor> sanitizer;
 
     private LifecycleInjector injector;
 
@@ -98,6 +100,7 @@ public class EmbeddedTitusGateway {
         this.config.setProperties(properties);
 
         this.validator = builder.validator;
+        this.sanitizer = builder.sanitizer;
 
         String resourceDir = TitusMaster.class.getClassLoader().getResource("static").toExternalForm();
         Properties props = new Properties();
@@ -145,6 +148,8 @@ public class EmbeddedTitusGateway {
 
                         bind(new TypeLiteral<AdmissionValidator<JobDescriptor>>() {
                         }).toInstance(validator);
+                        bind(new TypeLiteral<AdmissionSanitizer<JobDescriptor>>() {
+                        }).toInstance(sanitizer);
                     }
                 })
         ).createInjector();
@@ -252,6 +257,7 @@ public class EmbeddedTitusGateway {
         private JobStore store;
         private Properties properties = new Properties();
         private AdmissionValidator<JobDescriptor> validator = new PassJobValidator();
+        private AdmissionSanitizer<JobDescriptor> sanitizer = new PassJobValidator();
         private EmbeddedTitusMaster embeddedTitusMaster;
 
         public Builder withMasterEndpoint(String host, int grpcPort, int httpPort) {
@@ -298,6 +304,11 @@ public class EmbeddedTitusGateway {
 
         public Builder withJobValidator(AdmissionValidator<JobDescriptor> validator) {
             this.validator = validator;
+            return this;
+        }
+
+        public Builder withJobSanitizer(AdmissionSanitizer<JobDescriptor> sanitizer) {
+            this.sanitizer = sanitizer;
             return this;
         }
 


### PR DESCRIPTION
This prepares the ground for more advanced sanitization logic, and dedicated sanitizers that are not validators (and vice versa).