### PR TITLE
Run sanitizers concurrently

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/service/TitusServiceException.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/service/TitusServiceException.java
@@ -178,6 +178,16 @@ public class TitusServiceException extends RuntimeException {
                 .build();
     }
 
+    public static TitusServiceException internal(String message, Object... args) {
+        return internal(null, message, args);
+    }
+
+    public static TitusServiceException internal(Throwable cause, String message, Object... args) {
+        return TitusServiceException.newBuilder(ErrorCode.INTERNAL, format(message, args))
+                .withCause(cause)
+                .build();
+    }
+
     public static TitusServiceException notSupported() {
         return TitusServiceException.newBuilder(ErrorCode.NOT_SUPPORTED, "Not supported").build();
     }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
@@ -59,8 +59,8 @@ import com.netflix.titus.grpc.protogen.TaskId;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
 import com.netflix.titus.runtime.connector.GrpcRequestConfiguration;
-import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.AdmissionValidator;
+import com.netflix.titus.runtime.endpoint.admission.AggregatingSanitizer;
 import com.netflix.titus.runtime.endpoint.common.LogStorageInfo;
 import com.netflix.titus.runtime.endpoint.common.grpc.CommonGrpcModelConverters;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
@@ -106,7 +106,7 @@ public class GatewayJobServiceGateway extends JobServiceGatewayDelegate {
     private final TaskRelocationDataInjector taskRelocationDataInjector;
     private final NeedsMigrationQueryHandler needsMigrationQueryHandler;
     private final AdmissionValidator<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> validator;
-    private final AdmissionSanitizer<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> sanitizer;
+    private final AggregatingSanitizer sanitizer;
     private final Clock clock;
 
     @Inject
@@ -124,7 +124,7 @@ public class GatewayJobServiceGateway extends JobServiceGatewayDelegate {
                                     @Named(ENVIRONMENT_VARIABLE_NAMES_STRICT_VALIDATION_FEATURE) Predicate<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> environmentVariableNamesStrictValidationPredicate,
                                     JobAssertions jobAssertions,
                                     AdmissionValidator<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> validator,
-                                    AdmissionSanitizer<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> sanitizer,
+                                    AggregatingSanitizer sanitizer,
                                     TitusRuntime titusRuntime) {
         super(new SanitizingJobServiceGateway(
                 new GrpcJobServiceGateway(

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobSecurityValidatorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobSecurityValidatorTest.java
@@ -116,13 +116,9 @@ public class JobSecurityValidatorTest {
         when(iamConnector.getIamRole(INVALID_IAM_ROLE_NAME))
                 .thenReturn(Mono.error(IamConnectorException.iamRoleUnexpectedError(INVALID_IAM_ROLE_NAME)));
 
-        Mono<Optional<String>> sanitized = iamValidator.sanitize(jobDescriptorWithInvalidIam);
+        Mono<JobDescriptor> sanitized = iamValidator.sanitizeAndApply(jobDescriptorWithInvalidIam);
         StepVerifier.create(sanitized)
-                .assertNext(sanitizedIamRole -> {
-                    assertThat(sanitizedIamRole).isNotPresent();
-
-                    // Optional.empty() means sanitization was skipped
-                    JobDescriptor jobDescriptor = iamValidator.apply(jobDescriptorWithInvalidIam, sanitizedIamRole);
+                .assertNext(jobDescriptor -> {
                     assertThat(jobDescriptor.getContainer().getSecurityProfile().getIamRole())
                             .isEqualTo(jobDescriptorWithInvalidIam.getContainer().getSecurityProfile().getIamRole());
                     assertThat(((JobDescriptor<?>) jobDescriptor).getAttributes())

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
@@ -16,8 +16,6 @@
 
 package com.netflix.titus.master.integration.v3.job;
 
-import java.util.Collections;
-
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
@@ -168,7 +166,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
         assertTrue(resultJobDescriptor.getJobDescriptor().getContainer().getImage().getDigest().isEmpty());
     }
 
-    private TitusStackResource getTitusStackResource(AdmissionSanitizer<JobDescriptor, ?> sanitizer) {
+    private TitusStackResource getTitusStackResource(AdmissionSanitizer<JobDescriptor> sanitizer) {
         SimulatedCloud simulatedCloud = SimulatedClouds.basicCloud(2);
 
         return new TitusStackResource(EmbeddedTitusCell.aTitusCell()
@@ -176,7 +174,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
                         .withCellName("cell-name")
                         .build())
                 .withDefaultGateway()
-                .withJobSanitizers(Collections.singletonList(sanitizer))
+                .withJobSanitizer(sanitizer)
                 .build());
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
@@ -16,11 +16,11 @@
 
 package com.netflix.titus.master.integration.v3.job;
 
+import java.util.Collections;
+
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
-import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
-import com.netflix.titus.runtime.endpoint.admission.AdmissionValidator;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
 import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobId;
@@ -30,9 +30,9 @@ import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTem
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
 import com.netflix.titus.runtime.connector.registry.RegistryClient;
 import com.netflix.titus.runtime.connector.registry.TitusRegistryException;
+import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.JobImageValidatorConfiguration;
-import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
 import com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCell;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMasters;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
@@ -74,7 +74,6 @@ public class JobSanitizeTest extends BaseIntegrationTest {
     private final RegistryClient registryClient = mock(RegistryClient.class);
 
     private final TitusStackResource titusStackResource = getTitusStackResource(
-            new PassJobValidator(),
             new JobImageSanitizer(configuration, registryClient, new DefaultRegistry())
     );
     private final InstanceGroupsScenarioBuilder instanceGroupsScenarioBuilder = new InstanceGroupsScenarioBuilder(titusStackResource);
@@ -99,7 +98,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
     public void testJobDigestResolution() {
         when(registryClient.getImageDigest(anyString(), anyString())).thenReturn(Mono.just(digest));
 
-        final com.netflix.titus.grpc.protogen.JobDescriptor jobDescriptor =
+        com.netflix.titus.grpc.protogen.JobDescriptor jobDescriptor =
                 toGrpcJobDescriptor(batchJobDescriptors()
                         .map(jd -> jd.but(d -> d.getContainer().toBuilder()
                                 .withImage(Image.newBuilder()
@@ -169,8 +168,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
         assertTrue(resultJobDescriptor.getJobDescriptor().getContainer().getImage().getDigest().isEmpty());
     }
 
-    private TitusStackResource getTitusStackResource(AdmissionValidator<JobDescriptor> validator,
-                                                     AdmissionSanitizer<JobDescriptor> sanitizer) {
+    private TitusStackResource getTitusStackResource(AdmissionSanitizer<JobDescriptor, ?> sanitizer) {
         SimulatedCloud simulatedCloud = SimulatedClouds.basicCloud(2);
 
         return new TitusStackResource(EmbeddedTitusCell.aTitusCell()
@@ -178,8 +176,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
                         .withCellName("cell-name")
                         .build())
                 .withDefaultGateway()
-                .withJobValidator(validator)
-                .withJobSanitizer(sanitizer)
+                .withJobSanitizers(Collections.singletonList(sanitizer))
                 .build());
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
@@ -113,7 +113,7 @@ public class JobValidatorNegativeTest extends BaseIntegrationTest {
                 .build());
     }
 
-    private static TitusStackResource getTitusStackResource(AdmissionSanitizer<JobDescriptor, ?> jobSanitizer) {
+    private static TitusStackResource getTitusStackResource(AdmissionSanitizer<JobDescriptor> jobSanitizer) {
         SimulatedCloud simulatedCloud = SimulatedClouds.basicCloud(2);
 
         return new TitusStackResource(EmbeddedTitusCell.aTitusCell()
@@ -121,7 +121,7 @@ public class JobValidatorNegativeTest extends BaseIntegrationTest {
                         .withCellName("cell-name")
                         .build())
                 .withDefaultGateway()
-                .withJobSanitizers(Collections.singletonList(jobSanitizer))
+                .withJobSanitizer(jobSanitizer)
                 .build());
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
@@ -18,12 +18,34 @@ package com.netflix.titus.runtime.endpoint.admission;
 
 import reactor.core.publisher.Mono;
 
-public interface AdmissionSanitizer<T> {
+/**
+ * Sanitizers have a MapReduce-like interface, and are executed concurrently in two phases:
+ * <p>
+ * 1. <tt>sanitize(input)</tt> is called on all registered {@link AdmissionSanitizer sanitizers} concurrently. The input
+ * parameter may or may not have passed through other sanitizers, no assumptions on what data has been already changed
+ * during the sanitization process can be made. It is safer to assume no other sanitizers will touch the same data,
+ * and the input is the original value sent to the system.
+ * <p>
+ * 2. <tt>apply(input, changes)</tt> is chained through all sanitizers sequentially. Each sanitizer adds its partial
+ * update to the entity modified by its predecessor in the chain. The final result includes all partial updates from all
+ * sanitizers. No assumptions should be made on the order in which sanitizers will be called.
+ *
+ * @param <T> entity being sanitized
+ * @param <S> partial (sanitized) data to be merged back to the entity in the second step
+ */
+public interface AdmissionSanitizer<T, S> {
     /**
-     * Async method to clean and add missing data elements to an entity
+     * Async method that produces clean and missing data elements to an entity.
      *
-     * @return Returns a Mono/Single that emits a cleaned up version. If no changes were made, the emitted item will
-     * share a reference with the source parameter.
+     * @return Returns a Mono/Single with all necessary changes that need to be applied later. It may be a
+     * {@link Mono#empty()} when no changes are to be made, or a {@link Mono#error(Throwable)} when the entity is invalid
      */
-    Mono<T> sanitize(T entity);
+    Mono<S> sanitize(T entity);
+
+    /**
+     * Apply a partial update into the entity being sanitized.
+     *
+     * @return the modified entity with updates applied
+     */
+    T apply(T entity, S update);
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AdmissionSanitizer.java
@@ -16,6 +16,9 @@
 
 package com.netflix.titus.runtime.endpoint.admission;
 
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
 import reactor.core.publisher.Mono;
 
 /**
@@ -23,29 +26,34 @@ import reactor.core.publisher.Mono;
  * <p>
  * 1. <tt>sanitize(input)</tt> is called on all registered {@link AdmissionSanitizer sanitizers} concurrently. The input
  * parameter may or may not have passed through other sanitizers, no assumptions on what data has been already changed
- * during the sanitization process can be made. It is safer to assume no other sanitizers will touch the same data,
- * and the input is the original value sent to the system.
+ * during the sanitization process can be made. It is safer to assume no other sanitizers should touch the same data,
+ * and the input is the original value sent to the system. The behavior with multiple sanitizers with overlapping
+ * updates is unspecified.
  * <p>
- * 2. <tt>apply(input, changes)</tt> is chained through all sanitizers sequentially. Each sanitizer adds its partial
- * update to the entity modified by its predecessor in the chain. The final result includes all partial updates from all
- * sanitizers. No assumptions should be made on the order in which sanitizers will be called.
+ * 2. The previous call returns a {@link Function} that applies a partial update, and partial updates are chained
+ * through all sanitizers sequentially. Each sanitizer adds its partial update to the entity modified by its
+ * predecessor in the chain. The final result includes all partial updates from all sanitizers. No assumptions should be
+ * made on the order in which sanitizers will be called.
  *
  * @param <T> entity being sanitized
- * @param <S> partial (sanitized) data to be merged back to the entity in the second step
  */
-public interface AdmissionSanitizer<T, S> {
-    /**
-     * Async method that produces clean and missing data elements to an entity.
-     *
-     * @return Returns a Mono/Single with all necessary changes that need to be applied later. It may be a
-     * {@link Mono#empty()} when no changes are to be made, or a {@link Mono#error(Throwable)} when the entity is invalid
-     */
-    Mono<S> sanitize(T entity);
+public interface AdmissionSanitizer<T> {
 
     /**
-     * Apply a partial update into the entity being sanitized.
+     * Async method that produces clean and missing data elements to an entity. Its return should be a synchronous
+     * function (closure) that applies all necessary updates. All heavy lifting should be done asynchronously, with the
+     * returned <tt>apply</tt> function being cheap and only responsible for merging sanitized data back into the
+     * entity.
      *
-     * @return the modified entity with updates applied
+     * @return a closure that applies necessary changes to the entity. It may be a {@link Mono#empty()} when no changes
+     * are to be made, or a {@link Mono#error(Throwable)} when the entity is invalid
      */
-    T apply(T entity, S update);
+    Mono<UnaryOperator<T>> sanitize(T entity);
+
+    /**
+     * Helper to be used when there are no multiple sanitizers to be executed concurrently.
+     */
+    default Mono<T> sanitizeAndApply(T entity) {
+        return sanitize(entity).map(update -> update.apply(entity));
+    }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizer.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.service.TitusServiceException;
+import com.netflix.titus.common.util.CollectionsExt;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Singleton
+public class AggregatingSanitizer {
+    private final Collection<? extends AdmissionSanitizer<JobDescriptor, ?>> sanitizers;
+    private final Duration timeout;
+
+    @Inject
+    public AggregatingSanitizer(TitusValidatorConfiguration configuration, Collection<? extends AdmissionSanitizer<JobDescriptor, ?>> sanitizers) {
+        this.sanitizers = sanitizers;
+        this.timeout = Duration.ofMillis(configuration.getTimeoutMs());
+    }
+
+    /**
+     * Executes all sanitizers in parallel, collecting partial results in the first phase, and applying them all
+     * sequentially through each sanitizer in the second phase.
+     * <p>
+     * The iteration order of the sanitizers is not guaranteed. Any sanitization failure results in the Mono
+     * emitting an error.
+     */
+    public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
+        List<Mono<SanitizerWithResult>> sanitizersWithResults = sanitizers.stream()
+                .map(s -> s.sanitize(entity)
+                        .subscribeOn(Schedulers.parallel())
+                        .timeout(timeout)
+                        .map(r -> new SanitizerWithResult(s, Optional.of(r)))
+                        // important: Mono.zip will be short circuited if members are empty
+                        .switchIfEmpty(Mono.just(new SanitizerWithResult(s, Optional.empty())))
+                )
+                .collect(Collectors.toList());
+
+        Mono<JobDescriptor> merged = Mono.zip(sanitizersWithResults, partials -> {
+            if (CollectionsExt.isNullOrEmpty(partials)) {
+                return entity;
+            }
+
+            JobDescriptor result = entity;
+            for (Object partial : partials) {
+                SanitizerWithResult partialWithResult = (SanitizerWithResult) partial;
+                Optional<?> optionalResult = partialWithResult.getResult();
+                if (!optionalResult.isPresent()) {
+                    continue;
+                }
+                result = partialWithResult.getSanitizer().apply(result, optionalResult.get());
+            }
+            return result;
+        });
+
+        return merged.timeout(timeout, Mono.error(() -> TitusServiceException.internal("Job sanitization timed out")))
+                .switchIfEmpty(Mono.just(entity));
+    }
+
+    // Not using Pair<U, V> for generics sanity
+    private static class SanitizerWithResult {
+        private final AdmissionSanitizer<JobDescriptor, ?> sanitizer;
+        private final Optional<?> result;
+
+        private SanitizerWithResult(AdmissionSanitizer<JobDescriptor, ?> sanitizer, Optional<?> result) {
+            this.sanitizer = sanitizer;
+            this.result = result;
+        }
+
+        @SuppressWarnings("unchecked")
+        public AdmissionSanitizer<JobDescriptor, Object> getSanitizer() {
+            return (AdmissionSanitizer<JobDescriptor, Object>) sanitizer;
+        }
+
+        public Optional<?> getResult() {
+            return result;
+        }
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidator.java
@@ -38,7 +38,7 @@ import reactor.core.scheduler.Schedulers;
 public class AggregatingValidator implements AdmissionValidator<JobDescriptor> {
     private final TitusValidatorConfiguration configuration;
     private final Duration timeout;
-    private final Collection<AdmissionValidator<JobDescriptor>> validators;
+    private final Collection<? extends AdmissionValidator<JobDescriptor>> validators;
     private final ValidatorMetrics validatorMetrics;
 
     /**
@@ -55,7 +55,7 @@ public class AggregatingValidator implements AdmissionValidator<JobDescriptor> {
     public AggregatingValidator(
             TitusValidatorConfiguration configuration,
             Registry registry,
-            Collection<AdmissionValidator<JobDescriptor>> validators) {
+            Collection<? extends AdmissionValidator<JobDescriptor>> validators) {
         this.configuration = configuration;
         this.timeout = Duration.ofMillis(this.configuration.getTimeoutMs());
         this.validators = validators;
@@ -85,7 +85,7 @@ public class AggregatingValidator implements AdmissionValidator<JobDescriptor> {
     private Collection<Mono<Set<ValidationError>>> getMonos(
             JobDescriptor jobDescriptor,
             Duration timeout,
-            Collection<AdmissionValidator<JobDescriptor>> validators) {
+            Collection<? extends AdmissionValidator<JobDescriptor>> validators) {
 
         return validators.stream()
                 .map(v -> v.validate(jobDescriptor)

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/FailJobValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/FailJobValidator.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Mono;
 /**
  * This {@link AdmissionValidator} implementation always causes validation to fail.  It is used for testing purposes.
  */
-public class FailJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
+public class FailJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor, JobDescriptor> {
     public static final String ERR_FIELD = "fail-field";
     public static final String ERR_DESCRIPTION = "The FailJobValidator should always fail with a unique error:";
 
@@ -54,6 +54,11 @@ public class FailJobValidator implements AdmissionValidator<JobDescriptor>, Admi
     @Override
     public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
         return Mono.error(TitusServiceException.invalidArgument(ERR_DESCRIPTION));
+    }
+
+    @Override
+    public JobDescriptor apply(JobDescriptor entity, JobDescriptor update) {
+        return entity;
     }
 
     @Override

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/FailJobValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/FailJobValidator.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.UnaryOperator;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.service.TitusServiceException;
@@ -29,7 +30,7 @@ import reactor.core.publisher.Mono;
 /**
  * This {@link AdmissionValidator} implementation always causes validation to fail.  It is used for testing purposes.
  */
-public class FailJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor, JobDescriptor> {
+public class FailJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     public static final String ERR_FIELD = "fail-field";
     public static final String ERR_DESCRIPTION = "The FailJobValidator should always fail with a unique error:";
 
@@ -52,13 +53,8 @@ public class FailJobValidator implements AdmissionValidator<JobDescriptor>, Admi
     }
 
     @Override
-    public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
         return Mono.error(TitusServiceException.invalidArgument(ERR_DESCRIPTION));
-    }
-
-    @Override
-    public JobDescriptor apply(JobDescriptor entity, JobDescriptor update) {
-        return entity;
     }
 
     @Override

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobIamValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobIamValidator.java
@@ -21,7 +21,6 @@ package com.netflix.titus.runtime.endpoint.admission;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -102,7 +101,7 @@ public class JobIamValidator implements AdmissionValidator<JobDescriptor>, Admis
     }
 
     /**
-     * @return a {@link Function} that adds a sanitized role or job attributes when sanitization was skipped
+     * @return a {@link UnaryOperator} that adds a sanitized role or job attributes when sanitization was skipped
      */
     @Override
     public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor jobDescriptor) {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
@@ -17,7 +17,6 @@
 package com.netflix.titus.runtime.endpoint.admission;
 
 import java.time.Duration;
-import java.util.Optional;
 import java.util.function.UnaryOperator;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -53,7 +52,7 @@ public class JobImageSanitizer implements AdmissionSanitizer<JobDescriptor> {
     }
 
     /**
-     * @return sanitized Image or {@link Optional#empty()} when sanitization was skipped
+     * @return a {@link UnaryOperator} that adds a sanitized Image or job attributes when sanitization was skipped
      */
     @Override
     public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor jobDescriptor) {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Mono;
  * should be overridden.
  */
 @Singleton
-public class PassJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
+public class PassJobValidator implements AdmissionValidator<JobDescriptor> {
     private final ValidationError.Type errorType;
 
     public PassJobValidator() {
@@ -43,11 +43,6 @@ public class PassJobValidator implements AdmissionValidator<JobDescriptor>, Admi
     @Override
     public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
         return Mono.just(Collections.emptySet());
-    }
-
-    @Override
-    public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
-        return Mono.just(entity);
     }
 
     @Override

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
@@ -18,6 +18,7 @@ package com.netflix.titus.runtime.endpoint.admission;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import javax.inject.Singleton;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
@@ -29,7 +30,7 @@ import reactor.core.publisher.Mono;
  * should be overridden.
  */
 @Singleton
-public class PassJobValidator implements AdmissionValidator<JobDescriptor> {
+public class PassJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     private final ValidationError.Type errorType;
 
     public PassJobValidator() {
@@ -48,5 +49,10 @@ public class PassJobValidator implements AdmissionValidator<JobDescriptor> {
     @Override
     public ValidationError.Type getErrorType() {
         return errorType;
+    }
+
+    @Override
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
+        return Mono.empty();
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
@@ -22,7 +22,6 @@ import javax.inject.Singleton;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.TypeLiteral;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.spectator.api.Registry;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
@@ -36,10 +35,6 @@ public class TitusAdmissionModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(new TypeLiteral<AdmissionValidator<JobDescriptor>>() {
-        }).to(AggregatingValidator.class);
-        bind(new TypeLiteral<AdmissionSanitizer<JobDescriptor>>() {
-        }).to(AggregatingSanitizer.class);
     }
 
     @Provides
@@ -50,17 +45,17 @@ public class TitusAdmissionModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public AggregatingValidator getJobValidator(TitusValidatorConfiguration configuration,
-                                                JobIamValidator jobIamValidator,
-                                                Registry registry) {
+    public AdmissionValidator<JobDescriptor> getJobValidator(TitusValidatorConfiguration configuration,
+                                                             JobIamValidator jobIamValidator,
+                                                             Registry registry) {
         return new AggregatingValidator(configuration, registry, Collections.singletonList(jobIamValidator));
     }
 
     @Provides
     @Singleton
-    public AggregatingSanitizer getJobSanitizer(TitusValidatorConfiguration configuration,
-                                                JobImageSanitizer jobImageSanitizer,
-                                                JobIamValidator jobIamSanitizer) {
+    public AdmissionSanitizer<JobDescriptor> getJobSanitizer(TitusValidatorConfiguration configuration,
+                                                             JobImageSanitizer jobImageSanitizer,
+                                                             JobIamValidator jobIamSanitizer) {
         return new AggregatingSanitizer(configuration, Arrays.asList(jobImageSanitizer, jobIamSanitizer));
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
@@ -38,6 +38,8 @@ public class TitusAdmissionModule extends AbstractModule {
     protected void configure() {
         bind(new TypeLiteral<AdmissionValidator<JobDescriptor>>() {
         }).to(AggregatingValidator.class);
+        bind(new TypeLiteral<AdmissionSanitizer<JobDescriptor>>() {
+        }).to(AggregatingSanitizer.class);
     }
 
     @Provides

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.runtime.endpoint.admission;
 
+import java.util.Arrays;
 import java.util.Collections;
 import javax.inject.Singleton;
 
@@ -37,8 +38,6 @@ public class TitusAdmissionModule extends AbstractModule {
     protected void configure() {
         bind(new TypeLiteral<AdmissionValidator<JobDescriptor>>() {
         }).to(AggregatingValidator.class);
-        bind(new TypeLiteral<AdmissionSanitizer<JobDescriptor>>() {
-        }).to(AggregatingValidator.class);
     }
 
     @Provides
@@ -50,14 +49,16 @@ public class TitusAdmissionModule extends AbstractModule {
     @Provides
     @Singleton
     public AggregatingValidator getJobValidator(TitusValidatorConfiguration configuration,
-                                                JobImageSanitizer jobImageSanitizer,
                                                 JobIamValidator jobIamValidator,
                                                 Registry registry) {
-        return new AggregatingValidator(
-                configuration,
-                registry,
-                Collections.singletonList(jobIamValidator),
-                Collections.singletonList(jobImageSanitizer)
-        );
+        return new AggregatingValidator(configuration, registry, Collections.singletonList(jobIamValidator));
+    }
+
+    @Provides
+    @Singleton
+    public AggregatingSanitizer getJobSanitizer(TitusValidatorConfiguration configuration,
+                                                JobImageSanitizer jobImageSanitizer,
+                                                JobIamValidator jobIamSanitizer) {
+        return new AggregatingSanitizer(configuration, Arrays.asList(jobImageSanitizer, jobIamSanitizer));
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
@@ -114,7 +114,7 @@ public class AggregatingSanitizerTest {
                     }
                     TitusServiceException titusException = (TitusServiceException) error;
                     return titusException.getErrorCode().equals(TitusServiceException.ErrorCode.INTERNAL) &&
-                            error.getMessage().contains("Job sanitization timed out");
+                            error.getMessage().contains("NeverJobValidator timed out");
 
                 })
                 .verify();

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
@@ -56,7 +56,7 @@ public class AggregatingSanitizerTest {
         AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration, Arrays.asList(
                 appNameSanitizer, capacityGroupSanitizer
         ));
-        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
                 .assertNext(sanitizedJobDescriptor -> {
                     assertThat(sanitizedJobDescriptor.getApplicationName()).isEqualTo(appNameSanitizer.getDesiredAppName());
                     assertThat(sanitizedJobDescriptor.getCapacityGroup()).isEqualTo(capacityGroupSanitizer.getDesiredCapacityGroup());
@@ -78,7 +78,7 @@ public class AggregatingSanitizerTest {
                 new TestingAppNameSanitizer(),
                 new FailJobValidator()
         ));
-        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
                 .expectError(TitusServiceException.class)
                 .verify();
     }
@@ -87,7 +87,7 @@ public class AggregatingSanitizerTest {
     public void noSanitizersIsANoop() {
         AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration, Collections.emptyList());
         JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors().getValue();
-        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
                 .assertNext(sanitizedJobDescriptor -> assertThat(sanitizedJobDescriptor).isSameAs(jobDescriptor))
                 .verifyComplete();
     }
@@ -107,7 +107,7 @@ public class AggregatingSanitizerTest {
         AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration,
                 Arrays.asList(appNameSanitizer, neverSanitizer));
 
-        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
                 .expectErrorMatches(error -> {
                     if (!(error instanceof TitusServiceException)) {
                         return false;
@@ -135,7 +135,7 @@ public class AggregatingSanitizerTest {
                 appNameSanitizer,
                 new EmptyValidator()
         ));
-        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
                 .assertNext(sanitizedJobDescriptor -> assertThat(sanitizedJobDescriptor.getApplicationName())
                         .isEqualTo(appNameSanitizer.getDesiredAppName()))
                 .verifyComplete();
@@ -149,7 +149,7 @@ public class AggregatingSanitizerTest {
                 new EmptyValidator()
         ));
         JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors().getValue();
-        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
                 .assertNext(sanitizedJobDescriptor -> assertThat(sanitizedJobDescriptor).isSameAs(jobDescriptor))
                 .verifyComplete();
     }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.service.TitusServiceException;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AggregatingSanitizerTest {
+
+    private final TitusValidatorConfiguration configuration = mock(TitusValidatorConfiguration.class);
+
+    @Before
+    public void setUp() {
+        when(configuration.getTimeoutMs()).thenReturn(500);
+    }
+
+    @Test
+    public void mergeAllSanitizers() {
+        String initialAppName = "initialAppName";
+        String initialCapacityGroup = "initialCapacityGroup";
+        TestingAppNameSanitizer appNameSanitizer = new TestingAppNameSanitizer();
+        TestingCapacityGroupSanitizer capacityGroupSanitizer = new TestingCapacityGroupSanitizer();
+
+        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
+                .map(jd -> jd.toBuilder()
+                        .withApplicationName(initialAppName)
+                        .withCapacityGroup(initialCapacityGroup)
+                        .build())
+                .getValue();
+
+        AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration, Arrays.asList(
+                appNameSanitizer, capacityGroupSanitizer
+        ));
+        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+                .assertNext(sanitizedJobDescriptor -> {
+                    assertThat(sanitizedJobDescriptor.getApplicationName()).isEqualTo(appNameSanitizer.getDesiredAppName());
+                    assertThat(sanitizedJobDescriptor.getCapacityGroup()).isEqualTo(capacityGroupSanitizer.getDesiredCapacityGroup());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void sanitizeFail() {
+        String initialAppName = "initialAppName";
+
+        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
+                .map(jd -> jd.toBuilder()
+                        .withApplicationName(initialAppName)
+                        .build())
+                .getValue();
+
+        AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration, Arrays.asList(
+                new TestingAppNameSanitizer(),
+                new FailJobValidator()
+        ));
+        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+                .expectError(TitusServiceException.class)
+                .verify();
+    }
+
+    @Test
+    public void noSanitizersIsANoop() {
+        AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration, Collections.emptyList());
+        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors().getValue();
+        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+                .assertNext(sanitizedJobDescriptor -> assertThat(sanitizedJobDescriptor).isSameAs(jobDescriptor))
+                .verifyComplete();
+    }
+
+    @Test
+    public void timeoutForAllSanitizers() {
+        String initialAppName = "initialAppName";
+        TestingAppNameSanitizer appNameSanitizer = new TestingAppNameSanitizer();
+        NeverJobValidator neverSanitizer = new NeverJobValidator();
+
+        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
+                .map(jd -> jd.toBuilder()
+                        .withApplicationName(initialAppName)
+                        .build())
+                .getValue();
+
+        AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration,
+                Arrays.asList(appNameSanitizer, neverSanitizer));
+
+        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+                .expectErrorMatches(error -> {
+                    if (!(error instanceof TitusServiceException)) {
+                        return false;
+                    }
+                    TitusServiceException titusException = (TitusServiceException) error;
+                    return titusException.getErrorCode().equals(TitusServiceException.ErrorCode.INTERNAL) &&
+                            error.getMessage().contains("Job sanitization timed out");
+
+                })
+                .verify();
+    }
+
+    @Test
+    public void noopSanitizers() {
+        String initialAppName = "initialAppName";
+        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
+                .map(jd -> jd.toBuilder()
+                        .withApplicationName(initialAppName)
+                        .build())
+                .getValue();
+
+        TestingAppNameSanitizer appNameSanitizer = new TestingAppNameSanitizer();
+        AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration, Arrays.asList(
+                new EmptyValidator(),
+                appNameSanitizer,
+                new EmptyValidator()
+        ));
+        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+                .assertNext(sanitizedJobDescriptor -> assertThat(sanitizedJobDescriptor.getApplicationName())
+                        .isEqualTo(appNameSanitizer.getDesiredAppName()))
+                .verifyComplete();
+    }
+
+    @Test
+    public void allNoopSanitizers() {
+        AggregatingSanitizer sanitizer = new AggregatingSanitizer(configuration, Arrays.asList(
+                new EmptyValidator(),
+                new EmptyValidator(),
+                new EmptyValidator()
+        ));
+        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors().getValue();
+        StepVerifier.create(sanitizer.sanitize(jobDescriptor))
+                .assertNext(sanitizedJobDescriptor -> assertThat(sanitizedJobDescriptor).isSameAs(jobDescriptor))
+                .verifyComplete();
+    }
+}

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidatorTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidatorTest.java
@@ -26,9 +26,7 @@ import java.util.stream.Collectors;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
-import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
-import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
@@ -61,8 +59,8 @@ public class AggregatingValidatorTest {
         AggregatingValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(pass0, pass1),
-                Collections.emptySet());
+                Arrays.asList(pass0, pass1)
+        );
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -77,8 +75,7 @@ public class AggregatingValidatorTest {
         AggregatingValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(fail0, fail1),
-                Collections.emptySet());
+                Arrays.asList(fail0, fail1));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -97,8 +94,7 @@ public class AggregatingValidatorTest {
         AggregatingValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(pass, fail),
-                Collections.emptySet());
+                Arrays.asList(pass, fail));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -117,8 +113,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(pass, never),
-                Collections.emptySet());
+                Arrays.asList(pass, never));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -138,8 +133,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator parallelValidator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(pass, fail, never),
-                Collections.emptySet());
+                Arrays.asList(pass, fail, never));
         Mono<Set<ValidationError>> mono = parallelValidator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -170,8 +164,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(never),
-                Collections.emptySet());
+                Arrays.asList(never));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -189,8 +182,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(fail),
-                Collections.emptySet());
+                Arrays.asList(fail));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -208,8 +200,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(pass),
-                Collections.emptySet());
+                Arrays.asList(pass));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -226,8 +217,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(never0, never1),
-                Collections.emptySet());
+                Arrays.asList(never0, never1));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -254,8 +244,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(pass0, pass1),
-                Collections.emptySet());
+                Arrays.asList(pass0, pass1));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -270,8 +259,7 @@ public class AggregatingValidatorTest {
         AdmissionValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(fail0, fail1),
-                Collections.emptySet());
+                Arrays.asList(fail0, fail1));
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
 
         StepVerifier.create(mono)
@@ -290,68 +278,12 @@ public class AggregatingValidatorTest {
         AggregatingValidator validator = new AggregatingValidator(
                 configuration,
                 registry,
-                Arrays.asList(empty, pass, empty),
-                Collections.emptySet()
+                Arrays.asList(empty, pass, empty)
         );
         Mono<Set<ValidationError>> mono = validator.validate(MOCK_JOB);
         StepVerifier.create(mono)
                 .expectNext(Collections.emptySet())
                 .verifyComplete();
-    }
-
-    // Sanitizer tests
-
-    @Test
-    public void sanitizePassPass() {
-        final String initialAppName = "initialAppName";
-        final String initialCapacityGroup = "initialCapacityGroup";
-        AdmissionSanitizer<JobDescriptor> appNameSanitizer = new TestingAppNameSanitizer();
-        AdmissionSanitizer<JobDescriptor> capacityGroupSanitizer = new TestingCapacityGroupSanitizer();
-
-        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
-                .map(jd -> jd.toBuilder()
-                        .withApplicationName(initialAppName)
-                        .withCapacityGroup(initialCapacityGroup)
-                        .build())
-                .getValue();
-
-        AggregatingValidator validator = new AggregatingValidator(
-                configuration,
-                registry,
-                Collections.emptySet(),
-                Arrays.asList(appNameSanitizer, capacityGroupSanitizer));
-
-        StepVerifier.create(validator.sanitize(jobDescriptor))
-                .assertNext(sanitizedJobDescriptor -> {
-                    assertThat(sanitizedJobDescriptor.getApplicationName().equals(TestingAppNameSanitizer.desiredAppName)).isTrue();
-                    assertThat(sanitizedJobDescriptor.getCapacityGroup().equals(TestingCapacityGroupSanitizer.desiredCapacityGroup)).isTrue();
-                })
-                .verifyComplete();
-    }
-
-    @Test
-    public void sanitizePassFail() {
-        final String initialAppName = "initialAppName";
-        final String initialCapacityGroup = "initialCapacityGroup";
-        AdmissionSanitizer<JobDescriptor> appNameSanitizer = new TestingAppNameSanitizer();
-        AdmissionSanitizer<JobDescriptor> failSanitizer = new FailJobValidator();
-
-        JobDescriptor<?> jobDescriptor = JobDescriptorGenerator.batchJobDescriptors()
-                .map(jd -> jd.toBuilder()
-                        .withApplicationName(initialAppName)
-                        .withCapacityGroup(initialCapacityGroup)
-                        .build())
-                .getValue();
-
-        AggregatingValidator validator = new AggregatingValidator(
-                configuration,
-                registry,
-                Collections.emptySet(),
-                Arrays.asList(appNameSanitizer, failSanitizer));
-
-        StepVerifier.create(validator.sanitize(jobDescriptor))
-                .expectError(TitusServiceException.class)
-                .verify();
     }
 
     private void validateFailErrors(Collection<ValidationError> failErrors) {
@@ -372,20 +304,4 @@ public class AggregatingValidatorTest {
         assertThat(hardErrors).allMatch(error -> error.getType().equals(errorType));
     }
 
-    private static class EmptyValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
-        @Override
-        public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
-            return Mono.empty();
-        }
-
-        @Override
-        public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
-            return Mono.empty();
-        }
-
-        @Override
-        public ValidationError.Type getErrorType() {
-            return ValidationError.Type.HARD;
-        }
-    }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/EmptyValidator.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/EmptyValidator.java
@@ -16,35 +16,30 @@
 
 package com.netflix.titus.runtime.endpoint.admission;
 
+import java.util.Set;
+
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.sanitizer.ValidationError;
 import reactor.core.publisher.Mono;
 
-/**
- * This {@link AdmissionSanitizer} implementation ensures a job's appname matches a specific string.
- * It is only used for testing purposes.
- */
-class TestingAppNameSanitizer implements AdmissionSanitizer<JobDescriptor, String> {
-    private final String desiredAppName;
-
-    TestingAppNameSanitizer() {
-        this("desiredAppName");
-    }
-
-    TestingAppNameSanitizer(String desiredAppName) {
-        this.desiredAppName = desiredAppName;
+class EmptyValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor, JobDescriptor> {
+    @Override
+    public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
+        return Mono.empty();
     }
 
     @Override
-    public Mono<String> sanitize(JobDescriptor entity) {
-        return Mono.just(desiredAppName);
+    public ValidationError.Type getErrorType() {
+        return ValidationError.Type.HARD;
     }
 
     @Override
-    public JobDescriptor apply(JobDescriptor entity, String update) {
-        return entity.toBuilder().withApplicationName(update).build();
+    public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
+        return Mono.empty();
     }
 
-    public String getDesiredAppName() {
-        return desiredAppName;
+    @Override
+    public JobDescriptor apply(JobDescriptor entity, JobDescriptor update) {
+        throw new IllegalStateException("never called");
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/EmptyValidator.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/EmptyValidator.java
@@ -17,12 +17,13 @@
 package com.netflix.titus.runtime.endpoint.admission;
 
 import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
 import reactor.core.publisher.Mono;
 
-class EmptyValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor, JobDescriptor> {
+class EmptyValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     @Override
     public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
         return Mono.empty();
@@ -34,12 +35,7 @@ class EmptyValidator implements AdmissionValidator<JobDescriptor>, AdmissionSani
     }
 
     @Override
-    public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
         return Mono.empty();
-    }
-
-    @Override
-    public JobDescriptor apply(JobDescriptor entity, JobDescriptor update) {
-        throw new IllegalStateException("never called");
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/NeverJobValidator.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/NeverJobValidator.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 /**
  * This validator never completes.  It is used to test validation in the face of unresponsive service calls.
  */
-class NeverJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
+class NeverJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor, JobDescriptor> {
     private final ValidationError.Type errorType;
 
     public NeverJobValidator() {
@@ -44,6 +44,11 @@ class NeverJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionS
     @Override
     public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
         return Mono.never();
+    }
+
+    @Override
+    public JobDescriptor apply(JobDescriptor entity, JobDescriptor update) {
+        throw new IllegalStateException("never called");
     }
 
     @Override

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/NeverJobValidator.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/NeverJobValidator.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.runtime.endpoint.admission;
 
 import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
@@ -25,7 +26,7 @@ import reactor.core.publisher.Mono;
 /**
  * This validator never completes.  It is used to test validation in the face of unresponsive service calls.
  */
-class NeverJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor, JobDescriptor> {
+class NeverJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
     private final ValidationError.Type errorType;
 
     public NeverJobValidator() {
@@ -42,13 +43,8 @@ class NeverJobValidator implements AdmissionValidator<JobDescriptor>, AdmissionS
     }
 
     @Override
-    public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
         return Mono.never();
-    }
-
-    @Override
-    public JobDescriptor apply(JobDescriptor entity, JobDescriptor update) {
-        throw new IllegalStateException("never called");
     }
 
     @Override

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingAppNameSanitizer.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingAppNameSanitizer.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.runtime.endpoint.admission;
 
+import java.util.function.UnaryOperator;
+
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import reactor.core.publisher.Mono;
 
@@ -23,7 +25,7 @@ import reactor.core.publisher.Mono;
  * This {@link AdmissionSanitizer} implementation ensures a job's appname matches a specific string.
  * It is only used for testing purposes.
  */
-class TestingAppNameSanitizer implements AdmissionSanitizer<JobDescriptor, String> {
+class TestingAppNameSanitizer implements AdmissionSanitizer<JobDescriptor> {
     private final String desiredAppName;
 
     TestingAppNameSanitizer() {
@@ -35,13 +37,8 @@ class TestingAppNameSanitizer implements AdmissionSanitizer<JobDescriptor, Strin
     }
 
     @Override
-    public Mono<String> sanitize(JobDescriptor entity) {
-        return Mono.just(desiredAppName);
-    }
-
-    @Override
-    public JobDescriptor apply(JobDescriptor entity, String update) {
-        return entity.toBuilder().withApplicationName(update).build();
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
+        return Mono.just(jd -> entity.toBuilder().withApplicationName(desiredAppName).build());
     }
 
     public String getDesiredAppName() {

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingCapacityGroupSanitizer.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingCapacityGroupSanitizer.java
@@ -16,42 +16,35 @@
 
 package com.netflix.titus.runtime.endpoint.admission;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
-import com.netflix.titus.common.model.sanitizer.ValidationError;
 import reactor.core.publisher.Mono;
 
 /**
- * This {@link AdmissionValidator} implementation ensures a job's capacity group matches a specific
- * string. It is only used for testing purposes.
+ * This {@link AdmissionSanitizer} implementation ensures a job's capacity group matches a specific string.
+ * It is only used for testing purposes.
  */
-class TestingCapacityGroupSanitizer implements AdmissionValidator<JobDescriptor>, AdmissionSanitizer<JobDescriptor> {
-    final static String desiredCapacityGroup = "desiredCapacityGroup";
-    private static final String ERR_FIELD = "fail-field";
-    private static final String ERR_DESCRIPTION =
-            String.format("The job does not have desired capacity group %s", desiredCapacityGroup);
+class TestingCapacityGroupSanitizer implements AdmissionSanitizer<JobDescriptor, String> {
+    private final String desiredCapacityGroup;
 
-    @Override
-    public Mono<Set<ValidationError>> validate(JobDescriptor entity) {
-        if (entity.getCapacityGroup().equals(desiredCapacityGroup)) {
-            return Mono.just(Collections.emptySet());
-        }
-        final ValidationError error = new ValidationError(ERR_FIELD, ERR_DESCRIPTION);
-        return Mono.just(new HashSet<>(Collections.singletonList(error)));
+    TestingCapacityGroupSanitizer() {
+        this("desiredCapacityGroup");
+    }
+
+    TestingCapacityGroupSanitizer(String desiredCapacityGroup) {
+        this.desiredCapacityGroup = desiredCapacityGroup;
     }
 
     @Override
-    public Mono<JobDescriptor> sanitize(JobDescriptor entity) {
-        return Mono.just(entity.toBuilder()
-                .withCapacityGroup(desiredCapacityGroup)
-                .build());
+    public Mono<String> sanitize(JobDescriptor entity) {
+        return Mono.just(desiredCapacityGroup);
     }
 
     @Override
-    public ValidationError.Type getErrorType() {
-        return ValidationError.Type.HARD;
+    public JobDescriptor apply(JobDescriptor entity, String update) {
+        return entity.toBuilder().withCapacityGroup(update).build();
+    }
+
+    public String getDesiredCapacityGroup() {
+        return desiredCapacityGroup;
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingCapacityGroupSanitizer.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/TestingCapacityGroupSanitizer.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.runtime.endpoint.admission;
 
+import java.util.function.UnaryOperator;
+
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import reactor.core.publisher.Mono;
 
@@ -23,7 +25,7 @@ import reactor.core.publisher.Mono;
  * This {@link AdmissionSanitizer} implementation ensures a job's capacity group matches a specific string.
  * It is only used for testing purposes.
  */
-class TestingCapacityGroupSanitizer implements AdmissionSanitizer<JobDescriptor, String> {
+class TestingCapacityGroupSanitizer implements AdmissionSanitizer<JobDescriptor> {
     private final String desiredCapacityGroup;
 
     TestingCapacityGroupSanitizer() {
@@ -35,13 +37,8 @@ class TestingCapacityGroupSanitizer implements AdmissionSanitizer<JobDescriptor,
     }
 
     @Override
-    public Mono<String> sanitize(JobDescriptor entity) {
-        return Mono.just(desiredCapacityGroup);
-    }
-
-    @Override
-    public JobDescriptor apply(JobDescriptor entity, String update) {
-        return entity.toBuilder().withCapacityGroup(update).build();
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
+        return Mono.just(jd -> jd.toBuilder().withCapacityGroup(desiredCapacityGroup).build());
     }
 
     public String getDesiredCapacityGroup() {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedTitusCell.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedTitusCell.java
@@ -16,9 +16,6 @@
 
 package com.netflix.titus.testkit.embedded.cell;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
@@ -85,7 +82,7 @@ public class EmbeddedTitusCell {
         private boolean enableREST;
         private boolean defaultGateway;
         private AdmissionValidator<JobDescriptor> validator = new PassJobValidator();
-        private List<? extends AdmissionSanitizer<JobDescriptor, ?>> jobSanitizers = Collections.emptyList();
+        private AdmissionSanitizer<JobDescriptor> jobSanitizer = new PassJobValidator();
 
         public Builder withMaster(EmbeddedTitusMaster master) {
             this.master = master;
@@ -108,8 +105,8 @@ public class EmbeddedTitusCell {
             return this;
         }
 
-        public Builder withJobSanitizers(List<? extends AdmissionSanitizer<JobDescriptor, ?>> jobSanitizers) {
-            this.jobSanitizers = jobSanitizers;
+        public Builder withJobSanitizer(AdmissionSanitizer<JobDescriptor> jobSanitizer) {
+            this.jobSanitizer = jobSanitizer;
             return this;
         }
 
@@ -125,7 +122,7 @@ public class EmbeddedTitusCell {
                         .withStore(master.getJobStore())
                         .withEnableREST(enableREST)
                         .withJobValidator(validator)
-                        .withJobSanitizers(jobSanitizers)
+                        .withJobSanitizer(jobSanitizer)
                         .build();
             } else {
                 gateway = gateway.toBuilder()

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedTitusCell.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedTitusCell.java
@@ -16,6 +16,9 @@
 
 package com.netflix.titus.testkit.embedded.cell;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
@@ -82,7 +85,7 @@ public class EmbeddedTitusCell {
         private boolean enableREST;
         private boolean defaultGateway;
         private AdmissionValidator<JobDescriptor> validator = new PassJobValidator();
-        private AdmissionSanitizer<JobDescriptor> sanitizer = new PassJobValidator();
+        private List<? extends AdmissionSanitizer<JobDescriptor, ?>> jobSanitizers = Collections.emptyList();
 
         public Builder withMaster(EmbeddedTitusMaster master) {
             this.master = master;
@@ -105,8 +108,8 @@ public class EmbeddedTitusCell {
             return this;
         }
 
-        public Builder withJobSanitizer(AdmissionSanitizer<JobDescriptor> sanitizer) {
-            this.sanitizer = sanitizer;
+        public Builder withJobSanitizers(List<? extends AdmissionSanitizer<JobDescriptor, ?>> jobSanitizers) {
+            this.jobSanitizers = jobSanitizers;
             return this;
         }
 
@@ -122,7 +125,7 @@ public class EmbeddedTitusCell {
                         .withStore(master.getJobStore())
                         .withEnableREST(enableREST)
                         .withJobValidator(validator)
-                        .withJobSanitizer(sanitizer)
+                        .withJobSanitizers(jobSanitizers)
                         .build();
             } else {
                 gateway = gateway.toBuilder()


### PR DESCRIPTION
This will allow more (slow) sanitizers that call external services to be added.