### PR TITLE
Updating job capacity attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.1-rc63'
+        titusApiDefinitionsVersion = '0.0.1-rc64'
 
         awsSdkVersion = '1.11.+'
         javaxElVersion = '3.+'

--- a/titus-api/dependencies.lock
+++ b/titus-api/dependencies.lock
@@ -20,7 +20,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -589,7 +589,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -1158,7 +1158,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -1791,7 +1791,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -2361,7 +2361,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -2988,7 +2988,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5000,7 +5000,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -7012,7 +7012,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -9025,7 +9025,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/Capacity.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/Capacity.java
@@ -109,7 +109,7 @@ public class Capacity {
     public static final class Builder {
         private int min = Integer.MIN_VALUE;
         private int desired;
-        private int max = Integer.MIN_VALUE;
+        private int max = Integer.MAX_VALUE;
 
         private Builder() {
         }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/CapacityAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/CapacityAttributes.java
@@ -1,13 +1,24 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.titus.api.jobmanager.model.job;
 
 import java.util.Objects;
 import java.util.Optional;
 
 import com.netflix.titus.common.model.sanitizer.ClassInvariant;
-import com.netflix.titus.common.util.Evaluators;
-import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 @ClassInvariant.List({
         @ClassInvariant(condition = "!min.isPresent() || min.get() >=0", message = "'min'(#{min}) must be >= 0"),
@@ -95,7 +106,7 @@ public class CapacityAttributes {
         }
 
         public CapacityAttributes.Builder withDesired(int desired) {
-            this.desired= Optional.of(desired);
+            this.desired = Optional.of(desired);
             return this;
         }
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/CapacityAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/CapacityAttributes.java
@@ -1,0 +1,111 @@
+package com.netflix.titus.api.jobmanager.model.job;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.netflix.titus.common.model.sanitizer.ClassInvariant;
+import com.netflix.titus.common.util.Evaluators;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+@ClassInvariant.List({
+        @ClassInvariant(condition = "!min.isPresent() || min.get() >=0", message = "'min'(#{min}) must be >= 0"),
+        @ClassInvariant(condition = "!max.isPresent() || max.get() >=0", message = "'max'(#{max}) must be >= 0"),
+        @ClassInvariant(condition = "!desired.isPresent() || desired.get() >=0", message = "'desired'(#{desired}) must be >= 0")
+})
+public class CapacityAttributes {
+    private final Optional<Integer> min;
+    private final Optional<Integer> desired;
+    private final Optional<Integer> max;
+
+    public CapacityAttributes(Optional<Integer> min, Optional<Integer> desired, Optional<Integer> max) {
+        this.min = min;
+        this.desired = desired;
+        this.max = max;
+    }
+
+    public Optional<Integer> getMin() {
+        return min;
+    }
+
+    public Optional<Integer> getDesired() {
+        return desired;
+    }
+
+    public Optional<Integer> getMax() {
+        return max;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CapacityAttributes that = (CapacityAttributes) o;
+        return Objects.equals(min, that.min) &&
+                Objects.equals(desired, that.desired) &&
+                Objects.equals(max, that.max);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(min, desired, max);
+    }
+
+    @Override
+    public String toString() {
+        return "CapacityAttributes{" +
+                "min=" + min +
+                ", desired=" + desired +
+                ", max=" + max +
+                '}';
+    }
+
+    public Builder toBuilder() {
+        return newBuilder(this);
+    }
+
+    public static CapacityAttributes.Builder newBuilder() {
+        return new CapacityAttributes.Builder();
+    }
+
+    public static Builder newBuilder(CapacityAttributes capacityAttributes) {
+        Builder builder = new Builder();
+        builder.min = capacityAttributes.getMin();
+        builder.max = capacityAttributes.getMax();
+        builder.desired = capacityAttributes.getDesired();
+        return builder;
+    }
+
+    public static final class Builder {
+        private Optional<Integer> min = Optional.empty();
+        private Optional<Integer> desired = Optional.empty();
+        private Optional<Integer> max = Optional.empty();
+
+        private Builder() {
+        }
+
+        public CapacityAttributes.Builder withMin(int min) {
+            this.min = Optional.of(min);
+            return this;
+        }
+
+        public CapacityAttributes.Builder withDesired(int desired) {
+            this.desired= Optional.of(desired);
+            return this;
+        }
+
+        public CapacityAttributes.Builder withMax(int max) {
+            this.max = Optional.of(max);
+            return this;
+        }
+
+        public CapacityAttributes build() {
+            return new CapacityAttributes(min, desired, max);
+        }
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -41,6 +41,7 @@ import com.netflix.titus.api.jobmanager.model.job.retry.ImmediateRetryPolicy;
 import com.netflix.titus.api.jobmanager.model.job.retry.RetryPolicy;
 import com.netflix.titus.api.jobmanager.service.JobManagerException;
 import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.retry.Retryer;
 import com.netflix.titus.common.util.retry.Retryers;
 import com.netflix.titus.common.util.time.Clock;
@@ -221,6 +222,14 @@ public final class JobFunctions {
 
     public static Job<ServiceJobExt> changeServiceJobCapacity(Job<ServiceJobExt> job, Capacity capacity) {
         return job.toBuilder().withJobDescriptor(changeServiceJobCapacity(job.getJobDescriptor(), capacity)).build();
+    }
+
+    public static Job<ServiceJobExt> changeServiceJobCapacity(Job<ServiceJobExt> job, CapacityAttributes capacityAttributes) {
+        Capacity.Builder newCapacityBuilder = job.getJobDescriptor().getExtensions().getCapacity().toBuilder();
+        Evaluators.acceptIfTrue(capacityAttributes.getDesired().isPresent(), valueAccepted -> newCapacityBuilder.withDesired(capacityAttributes.getDesired().get()));
+        Evaluators.acceptIfTrue(capacityAttributes.getMax().isPresent(), valueAccepted -> newCapacityBuilder.withMax(capacityAttributes.getMax().get()));
+        Evaluators.acceptIfTrue(capacityAttributes.getMin().isPresent(), valueAccepted -> newCapacityBuilder.withMin(capacityAttributes.getMin().get()));
+        return job.toBuilder().withJobDescriptor(changeServiceJobCapacity(job.getJobDescriptor(), newCapacityBuilder.build())).build();
     }
 
     public static <E extends JobDescriptorExt> JobDescriptor<E> incrementJobDescriptorSize(JobDescriptor<E> jobDescriptor, int delta) {

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -226,9 +226,9 @@ public final class JobFunctions {
 
     public static Job<ServiceJobExt> changeServiceJobCapacity(Job<ServiceJobExt> job, CapacityAttributes capacityAttributes) {
         Capacity.Builder newCapacityBuilder = job.getJobDescriptor().getExtensions().getCapacity().toBuilder();
-        Evaluators.acceptIfTrue(capacityAttributes.getDesired().isPresent(), valueAccepted -> newCapacityBuilder.withDesired(capacityAttributes.getDesired().get()));
-        Evaluators.acceptIfTrue(capacityAttributes.getMax().isPresent(), valueAccepted -> newCapacityBuilder.withMax(capacityAttributes.getMax().get()));
-        Evaluators.acceptIfTrue(capacityAttributes.getMin().isPresent(), valueAccepted -> newCapacityBuilder.withMin(capacityAttributes.getMin().get()));
+        capacityAttributes.getDesired().ifPresent(newCapacityBuilder::withDesired);
+        capacityAttributes.getMax().ifPresent(newCapacityBuilder::withMax);
+        capacityAttributes.getMin().ifPresent(newCapacityBuilder::withMin);
         return job.toBuilder().withJobDescriptor(changeServiceJobCapacity(job.getJobDescriptor(), newCapacityBuilder.build())).build();
     }
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
@@ -39,6 +39,17 @@ public final class JobModel {
         return Capacity.newBuilder();
     }
 
+    public static CapacityAttributes.Builder newCapacityAttributes() {
+        return CapacityAttributes.newBuilder();
+    }
+
+    public static CapacityAttributes.Builder newCapacityAttributes(Capacity capacity) {
+        return CapacityAttributes.newBuilder()
+                .withMin(capacity.getMin())
+                .withMax(capacity.getMax())
+                .withDesired(capacity.getDesired());
+    }
+
     public static ServiceJobProcesses.Builder newServiceJobProcesses() {
         return ServiceJobProcesses.newBuilder();
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/V3JobOperations.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/V3JobOperations.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
+import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
 import com.netflix.titus.api.jobmanager.model.job.Task;
@@ -55,12 +56,12 @@ public interface V3JobOperations extends ReadOnlyJobOperations {
     }
 
     /**
-     * @deprecated Use {@link #updateJobCapacityReactor(String, Capacity, CallMetadata)}
+     * @deprecated Use {@link #updateJobCapacityAttributesReactor(String, CapacityAttributes, CallMetadata)}
      */
-    Observable<Void> updateJobCapacity(String jobId, Capacity capacity, CallMetadata callMetadata);
+    Observable<Void> updateJobCapacityAttributes(String jobId, CapacityAttributes capacityAttributes, CallMetadata callMetadata);
 
-    default Mono<Void> updateJobCapacityReactor(String jobId, Capacity capacity, CallMetadata callMetadata) {
-        return ReactorExt.toMono(updateJobCapacity(jobId, capacity, callMetadata));
+    default Mono<Void> updateJobCapacityAttributesReactor(String jobId, CapacityAttributes capacityAttributes, CallMetadata callMetadata) {
+        return ReactorExt.toMono(updateJobCapacityAttributes(jobId, capacityAttributes, callMetadata));
     }
 
     /**

--- a/titus-common/dependencies.lock
+++ b/titus-common/dependencies.lock
@@ -20,7 +20,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
@@ -526,7 +526,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
@@ -1032,7 +1032,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
@@ -1612,7 +1612,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
@@ -2129,7 +2129,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
@@ -2703,7 +2703,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4751,7 +4751,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -6799,7 +6799,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -8848,7 +8848,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "requested": "2.9.+",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",

--- a/titus-ext/aws/dependencies.lock
+++ b/titus-ext/aws/dependencies.lock
@@ -7,19 +7,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -30,19 +30,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -67,7 +67,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -686,19 +686,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -709,19 +709,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -746,7 +746,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -1365,19 +1365,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1388,19 +1388,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1425,7 +1425,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -2108,19 +2108,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2131,19 +2131,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2168,7 +2168,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -2788,19 +2788,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2811,19 +2811,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2848,7 +2848,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -3486,19 +3486,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3509,19 +3509,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3585,7 +3585,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -5590,19 +5590,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -5613,19 +5613,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -5689,7 +5689,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -7694,19 +7694,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7717,19 +7717,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7793,7 +7793,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",
@@ -9799,19 +9799,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9822,19 +9822,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.585",
+            "locked": "1.11.593",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9898,7 +9898,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-core",
                 "com.amazonaws:jmespath-java",

--- a/titus-ext/cassandra-testkit/dependencies.lock
+++ b/titus-ext/cassandra-testkit/dependencies.lock
@@ -63,7 +63,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -1007,7 +1007,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -1951,7 +1951,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -2959,7 +2959,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -3904,7 +3904,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -4855,7 +4855,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -5849,7 +5849,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -6843,7 +6843,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -7838,7 +7838,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"

--- a/titus-ext/cassandra/dependencies.lock
+++ b/titus-ext/cassandra/dependencies.lock
@@ -31,7 +31,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -698,7 +698,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -1365,7 +1365,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -2096,7 +2096,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -2764,7 +2764,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.netflix.titus:titus-common"
@@ -3480,7 +3480,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5495,7 +5495,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -7510,7 +7510,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -9526,7 +9526,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-ext/eureka/dependencies.lock
+++ b/titus-ext/eureka/dependencies.lock
@@ -36,7 +36,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1584,7 +1584,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3132,7 +3132,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4744,7 +4744,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6293,7 +6293,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -7887,7 +7887,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10056,7 +10056,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12225,7 +12225,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -14395,7 +14395,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-ext/jooq/dependencies.lock
+++ b/titus-ext/jooq/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1279,7 +1279,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2533,7 +2533,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3939,7 +3939,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -5194,7 +5194,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6501,7 +6501,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -8572,7 +8572,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10643,7 +10643,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12715,7 +12715,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-ext/zookeeper/dependencies.lock
+++ b/titus-ext/zookeeper/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1431,7 +1431,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2837,7 +2837,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4307,7 +4307,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -5714,7 +5714,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -7173,7 +7173,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -9224,7 +9224,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -11275,7 +11275,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -13327,7 +13327,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-grpc-api/dependencies.lock
+++ b/titus-grpc-api/dependencies.lock
@@ -375,8 +375,8 @@
     },
     "protobuf": {
         "com.netflix.titus:titus-api-definitions": {
-            "locked": "0.0.1-rc63",
-            "requested": "0.0.1-rc63"
+            "locked": "0.0.1-rc64",
+            "requested": "0.0.1-rc64"
         }
     },
     "protobufToolsLocator_grpc": {

--- a/titus-server-federation/dependencies.lock
+++ b/titus-server-federation/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1211,7 +1211,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2397,7 +2397,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3647,7 +3647,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4834,7 +4834,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6073,7 +6073,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -8121,7 +8121,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10169,7 +10169,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12218,7 +12218,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
@@ -44,6 +44,7 @@ import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
 import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
+import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobChangeNotification.JobUpdate;
 import com.netflix.titus.grpc.protogen.JobChangeNotification.TaskUpdate;
@@ -153,6 +154,16 @@ public class AggregatingJobServiceGateway implements JobServiceGateway {
         Observable<Empty> result = jobManagementServiceHelper.findJobInAllCells(request.getJobId())
                 .flatMap(response -> singleCellCall(response.getCell(),
                         (client, streamObserver) -> wrap(context, client).updateJobCapacity(request, streamObserver))
+                );
+        return result.toCompletable();
+    }
+
+    @Override
+    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes request) {
+        Optional<CallMetadata> context = callMetadataResolver.resolve();
+        Observable<Empty> result = jobManagementServiceHelper.findJobInAllCells(request.getJobId())
+                .flatMap(response -> singleCellCall(response.getCell(),
+                        (client, streamObserver) -> wrap(context, client).updateJobCapacityWithOptionalAttributes(request, streamObserver))
                 );
         return result.toCompletable();
     }

--- a/titus-server-gateway/dependencies.lock
+++ b/titus-server-gateway/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1225,7 +1225,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2425,7 +2425,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3689,7 +3689,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4890,7 +4890,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6143,7 +6143,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -8194,7 +8194,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10245,7 +10245,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12297,7 +12297,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-server-master/dependencies.lock
+++ b/titus-server-master/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1380,7 +1380,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2735,7 +2735,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4154,7 +4154,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -5510,7 +5510,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6918,7 +6918,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -9015,7 +9015,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -11112,7 +11112,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -13210,7 +13210,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -808,28 +808,28 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
     }
 
     private void sanitizeAndUpdateJobCapacity(String jobId, Capacity newJobCapacity,
-                      com.netflix.titus.api.jobmanager.model.job.JobDescriptor<ServiceJobExt> jobDescriptor,
-                      CallMetadata callMetadata, StreamObserver<Empty> responseObserver) {
+                                              com.netflix.titus.api.jobmanager.model.job.JobDescriptor<ServiceJobExt> jobDescriptor,
+                                              CallMetadata callMetadata, StreamObserver<Empty> responseObserver) {
         Set<ValidationError> violations = CollectionsExt.merge(
-                    entitySanitizer.validate(newJobCapacity),
-                    validateCustomJobLimits(JobFunctions.changeServiceJobCapacity(jobDescriptor, newJobCapacity))
-            );
-            if (!violations.isEmpty()) {
-                safeOnError(logger, TitusServiceException.invalidArgument(violations), responseObserver);
-                return;
-            }
+                entitySanitizer.validate(newJobCapacity),
+                validateCustomJobLimits(JobFunctions.changeServiceJobCapacity(jobDescriptor, newJobCapacity))
+        );
+        if (!violations.isEmpty()) {
+            safeOnError(logger, TitusServiceException.invalidArgument(violations), responseObserver);
+            return;
+        }
 
-            authorizeJobUpdate(callMetadata, jobId)
-                    .concatWith(jobOperations.updateJobCapacityReactor(jobId, newJobCapacity, callMetadata))
-                    .subscribe(
-                            nothing -> {
-                            },
-                            e -> safeOnError(logger, e, responseObserver),
-                            () -> {
-                                responseObserver.onNext(Empty.getDefaultInstance());
-                                responseObserver.onCompleted();
-                            }
-                    );
+        authorizeJobUpdate(callMetadata, jobId)
+                .concatWith(jobOperations.updateJobCapacityReactor(jobId, newJobCapacity, callMetadata))
+                .subscribe(
+                        nothing -> {
+                        },
+                        e -> safeOnError(logger, e, responseObserver),
+                        () -> {
+                            responseObserver.onNext(Empty.getDefaultInstance());
+                            responseObserver.onCompleted();
+                        }
+                );
     }
 
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import com.netflix.titus.api.FeatureActivationConfiguration;
@@ -34,6 +35,7 @@ import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
+import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobCompatibility;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
@@ -59,6 +61,7 @@ import com.netflix.titus.common.framework.reconciler.ModelActionHolder;
 import com.netflix.titus.common.framework.reconciler.ModelActionHolder.Model;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
 import com.netflix.titus.common.framework.reconciler.ReconciliationFramework;
+import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.ProtobufExt;
@@ -92,6 +95,7 @@ import rx.Observable;
 import rx.Subscription;
 import rx.functions.Func1;
 
+import static com.netflix.titus.api.jobmanager.model.job.sanitizer.JobSanitizerBuilder.JOB_STRICT_SANITIZER;
 import static com.netflix.titus.common.util.FunctionExt.alwaysTrue;
 
 @Singleton
@@ -110,7 +114,9 @@ public class DefaultV3JobOperations implements V3JobOperations {
     private final FeatureActivationConfiguration featureActivationConfiguration;
     private final JobReconciliationFrameworkFactory jobReconciliationFrameworkFactory;
     private final JobSubmitLimiter jobSubmitLimiter;
+    private final ManagementSubsystemInitializer managementSubsystemInitializer;
     private final TitusRuntime titusRuntime;
+    private final EntitySanitizer entitySanitizer;
 
     private ReconciliationFramework<JobManagerReconcilerEvent> reconciliationFramework;
     private Subscription transactionLoggerSubscription;
@@ -127,14 +133,17 @@ public class DefaultV3JobOperations implements V3JobOperations {
                                   JobReconciliationFrameworkFactory jobReconciliationFrameworkFactory,
                                   JobSubmitLimiter jobSubmitLimiter,
                                   ManagementSubsystemInitializer managementSubsystemInitializer,
-                                  TitusRuntime titusRuntime) {
+                                  TitusRuntime titusRuntime,
+                                  @Named(JOB_STRICT_SANITIZER) EntitySanitizer entitySanitizer) {
         this.featureActivationConfiguration = featureActivationConfiguration;
         this.store = store;
         this.vmService = vmService;
         this.jobManagerConfiguration = jobManagerConfiguration;
         this.jobReconciliationFrameworkFactory = jobReconciliationFrameworkFactory;
         this.jobSubmitLimiter = jobSubmitLimiter;
+        this.managementSubsystemInitializer = managementSubsystemInitializer;
         this.titusRuntime = titusRuntime;
+        this.entitySanitizer = entitySanitizer;
     }
 
     @Activator
@@ -217,6 +226,7 @@ public class DefaultV3JobOperations implements V3JobOperations {
                             .doOnError(e -> logger.info("Job {} creation failure", jobId, e));
                 });
     }
+
 
     @Override
     public List<Job> getJobs() {
@@ -335,19 +345,8 @@ public class DefaultV3JobOperations implements V3JobOperations {
     }
 
     @Override
-    public Observable<Void> updateJobCapacity(String jobId, Capacity capacity, CallMetadata callMetadata) {
-        return inServiceJob(jobId).flatMap(engine -> {
-                    Job<ServiceJobExt> serviceJob = engine.getReferenceView().getEntity();
-                    if (serviceJob.getJobDescriptor().getExtensions().getCapacity().equals(capacity)) {
-                        return Observable.empty();
-                    }
-                    if (isDesiredCapacityInvalid(capacity, serviceJob)) {
-                        return Observable.error(JobManagerException.invalidDesiredCapacity(jobId, capacity.getDesired(),
-                                serviceJob.getJobDescriptor().getExtensions().getServiceJobProcesses()));
-                    }
-                    return engine.changeReferenceModel(BasicServiceJobActions.updateJobCapacityAction(engine, capacity, store, callMetadata));
-                }
-        );
+    public Observable<Void> updateJobCapacityAttributes(String jobId, CapacityAttributes capacityAttributes, CallMetadata callMetadata) {
+        return inServiceJob(jobId).flatMap(engine -> engine.changeReferenceModel(BasicServiceJobActions.updateJobCapacityAction(engine, capacityAttributes, store, callMetadata, entitySanitizer)));
     }
 
     @Override
@@ -645,13 +644,5 @@ public class DefaultV3JobOperations implements V3JobOperations {
             return TaskUpdateEvent.newTaskFromAnotherJob(job, newTask, callMetadata);
         }
         return TaskUpdateEvent.newTask(job, newTask, callMetadata);
-    }
-
-    private boolean isDesiredCapacityInvalid(Capacity targetCapacity, Job<ServiceJobExt> serviceJob) {
-        ServiceJobProcesses serviceJobProcesses = serviceJob.getJobDescriptor().getExtensions().getServiceJobProcesses();
-        Capacity currentCapacity = serviceJob.getJobDescriptor().getExtensions().getCapacity();
-        return (serviceJobProcesses.isDisableIncreaseDesired() && targetCapacity.getDesired() > currentCapacity.getDesired()) ||
-                (serviceJobProcesses.isDisableDecreaseDesired() && targetCapacity.getDesired() < currentCapacity.getDesired());
-
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
@@ -16,8 +16,11 @@
 
 package com.netflix.titus.master.jobmanager.service.service.action;
 
+import java.util.Set;
+
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
+import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.JobState;
@@ -26,9 +29,13 @@ import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.service.JobManagerException;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.api.jobmanager.store.JobStore;
+import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.framework.reconciler.ModelActionHolder;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
 import com.netflix.titus.api.jobmanager.service.JobManagerConstants;
+import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
+import com.netflix.titus.common.model.sanitizer.ValidationError;
+import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.master.jobmanager.service.common.action.TitusChangeAction;
 import com.netflix.titus.master.jobmanager.service.common.action.TitusModelAction;
 import com.netflix.titus.master.jobmanager.service.event.JobManagerReconcilerEvent;
@@ -39,19 +46,47 @@ public class BasicServiceJobActions {
     /**
      * Update job capacity.
      */
-    public static TitusChangeAction updateJobCapacityAction(ReconciliationEngine<JobManagerReconcilerEvent> engine, Capacity capacity, JobStore jobStore, CallMetadata callMetadata) {
+    public static TitusChangeAction updateJobCapacityAction(ReconciliationEngine<JobManagerReconcilerEvent> engine,
+                                                            CapacityAttributes capacityAttributes,
+                                                            JobStore jobStore,
+                                                            CallMetadata callMetadata,
+                                                            EntitySanitizer entitySanitizer) {
         return TitusChangeAction.newAction("updateJobCapacityAction")
                 .id(engine.getReferenceView().getId())
                 .trigger(V3JobOperations.Trigger.API)
-                .summary("Changing job capacity to: %s", capacity)
+                .summary("Changing job capacity to: %s", capacityAttributes)
                 .changeWithModelUpdates(self -> {
                     Job<ServiceJobExt> serviceJob = engine.getReferenceView().getEntity();
+
                     if (serviceJob.getStatus().getState() != JobState.Accepted) {
                         return Observable.error(JobManagerException.jobTerminating(serviceJob));
                     }
 
-                    Job<ServiceJobExt> updatedJob = JobFunctions.changeServiceJobCapacity(serviceJob, capacity);
+                    Capacity.Builder newCapacityBuilder = serviceJob.getJobDescriptor().getExtensions().getCapacity().toBuilder();
+                    Evaluators.acceptIfTrue(capacityAttributes.getDesired().isPresent(), valueAccepted -> newCapacityBuilder.withDesired(capacityAttributes.getDesired().get()));
+                    Evaluators.acceptIfTrue(capacityAttributes.getMax().isPresent(), valueAccepted -> newCapacityBuilder.withMax(capacityAttributes.getMax().get()));
+                    Evaluators.acceptIfTrue(capacityAttributes.getMin().isPresent(), valueAccepted -> newCapacityBuilder.withMin(capacityAttributes.getMin().get()));
 
+                    Capacity newCapacity = newCapacityBuilder.build();
+
+                    // model validation for capacity
+                    Set<ValidationError> violations = entitySanitizer.validate(newCapacity);
+                    if (!violations.isEmpty()) {
+                        return Observable.error(TitusServiceException.invalidArgument(violations));
+                    }
+
+                    // checking if service job processes allow changes to desired capacity
+                    if (isDesiredCapacityInvalid(newCapacity, serviceJob)) {
+                        return Observable.error(JobManagerException.invalidDesiredCapacity(serviceJob.getId(), newCapacity.getDesired(),
+                                serviceJob.getJobDescriptor().getExtensions().getServiceJobProcesses()));
+                    }
+
+                    if (serviceJob.getJobDescriptor().getExtensions().getCapacity().equals(newCapacity)) {
+                        return Observable.empty();
+                    }
+
+                    // ready to update job capacity
+                    Job<ServiceJobExt> updatedJob = JobFunctions.changeServiceJobCapacity(serviceJob, newCapacity);
                     TitusModelAction modelAction = TitusModelAction.newModelUpdate(self).jobUpdate(jobHolder -> jobHolder.setEntity(updatedJob).addTag(JobManagerConstants.JOB_MANAGER_ATTRIBUTE_CALLMETADATA, callMetadata));
 
                     return jobStore.updateJob(updatedJob).andThen(Observable.just(ModelActionHolder.referenceAndStore(modelAction)));
@@ -101,5 +136,13 @@ public class BasicServiceJobActions {
 
                     return jobStore.updateJob(updatedJob).andThen(Observable.just(ModelActionHolder.referenceAndStore(modelAction)));
                 });
+    }
+
+    private static boolean isDesiredCapacityInvalid(Capacity targetCapacity, Job<ServiceJobExt> serviceJob) {
+        ServiceJobProcesses serviceJobProcesses = serviceJob.getJobDescriptor().getExtensions().getServiceJobProcesses();
+        Capacity currentCapacity = serviceJob.getJobDescriptor().getExtensions().getCapacity();
+        return (serviceJobProcesses.isDisableIncreaseDesired() && targetCapacity.getDesired() > currentCapacity.getDesired()) ||
+                (serviceJobProcesses.isDisableDecreaseDesired() && targetCapacity.getDesired() < currentCapacity.getDesired());
+
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
@@ -63,9 +63,9 @@ public class BasicServiceJobActions {
                     }
 
                     Capacity.Builder newCapacityBuilder = serviceJob.getJobDescriptor().getExtensions().getCapacity().toBuilder();
-                    Evaluators.acceptIfTrue(capacityAttributes.getDesired().isPresent(), valueAccepted -> newCapacityBuilder.withDesired(capacityAttributes.getDesired().get()));
-                    Evaluators.acceptIfTrue(capacityAttributes.getMax().isPresent(), valueAccepted -> newCapacityBuilder.withMax(capacityAttributes.getMax().get()));
-                    Evaluators.acceptIfTrue(capacityAttributes.getMin().isPresent(), valueAccepted -> newCapacityBuilder.withMin(capacityAttributes.getMin().get()));
+                    capacityAttributes.getDesired().ifPresent(newCapacityBuilder::withDesired);
+                    capacityAttributes.getMax().ifPresent(newCapacityBuilder::withMax);
+                    capacityAttributes.getMin().ifPresent(newCapacityBuilder::withMin);
 
                     Capacity newCapacity = newCapacityBuilder.build();
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
@@ -100,6 +100,17 @@ public class JobScalingTest extends BaseIntegrationTest {
 
 
     @Test
+    public void testScaleUpAndDownServiceJobDesiredInvalid() throws Exception {
+        jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
+                .expectAllTasksCreated()
+                .updateJobCapacityDesiredInvalid(6, 2)
+        );
+    }
+
+
+    @Test
     public void testTerminateAndShrink() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testTerminateAndShrink"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
@@ -66,6 +66,20 @@ public class JobScalingTest extends BaseIntegrationTest {
         );
     }
 
+
+    @Test
+    public void testScaleUpAndDownServiceJobWithOptionalAttributes() throws Exception {
+        jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
+                .expectAllTasksCreated()
+                .updateJobCapacityDesired(4)
+                .updateJobCapacityDesired(3)
+                .expectJobToScaleDown()
+        );
+    }
+
+
     @Test
     public void testTerminateAndShrink() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testTerminateAndShrink"), jobScenarioBuilder -> jobScenarioBuilder

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
@@ -68,7 +68,7 @@ public class JobScalingTest extends BaseIntegrationTest {
 
 
     @Test
-    public void testScaleUpAndDownServiceJobWithOptionalAttributes() throws Exception {
+    public void testScaleUpAndDownServiceJobDesired() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
@@ -76,6 +76,26 @@ public class JobScalingTest extends BaseIntegrationTest {
                 .updateJobCapacityDesired(4)
                 .updateJobCapacityDesired(3)
                 .expectJobToScaleDown()
+        );
+    }
+
+    @Test
+    public void testScaleUpAndDownServiceJobMin() throws Exception {
+        jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
+                .expectAllTasksCreated()
+                .updateJobCapacityMin(2)
+        );
+    }
+
+    @Test
+    public void testScaleUpAndDownServiceJobMax() throws Exception {
+        jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
+                .expectAllTasksCreated()
+                .updateJobCapacityMax(4)
         );
     }
 
@@ -93,6 +113,7 @@ public class JobScalingTest extends BaseIntegrationTest {
                 .expectJobUpdateEvent(job -> hasSize(job, 1), "Expected job to scale down to one instance")
         );
     }
+
 
     private JobDescriptor<ServiceJobExt> newJob(String detail) {
         return oneTaskServiceJobDescriptor().toBuilder()

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
@@ -73,8 +73,7 @@ public class JobScalingTest extends BaseIntegrationTest {
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
                 .expectAllTasksCreated()
-                .updateJobCapacityDesired(4)
-                .updateJobCapacityDesired(3)
+                .updateJobCapacityDesired(4, 0, 5)
                 .expectJobToScaleDown()
         );
     }
@@ -85,7 +84,7 @@ public class JobScalingTest extends BaseIntegrationTest {
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
                 .expectAllTasksCreated()
-                .updateJobCapacityMin(2)
+                .updateJobCapacityMin(2, 5, 2)
         );
     }
 
@@ -95,7 +94,7 @@ public class JobScalingTest extends BaseIntegrationTest {
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
                 .expectAllTasksCreated()
-                .updateJobCapacityMax(4)
+                .updateJobCapacityMax(4, 0, 2)
         );
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobScenarioBuilder.java
@@ -241,7 +241,6 @@ public class JobScenarioBuilder {
         return this;
     }
 
-
     public JobScenarioBuilder updateJobCapacityDesired(int desired) {
         logger.info("[{}] Changing job {} capacity desired to {}...", discoverActiveTest(), jobId, desired);
         Stopwatch stopWatch = Stopwatch.createStarted();
@@ -263,6 +262,51 @@ public class JobScenarioBuilder {
         logger.info("[{}] Job {} scaled to new desired size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));
         return this;
     }
+
+    public JobScenarioBuilder updateJobCapacityMin(int min) {
+        logger.info("[{}] Changing job {} capacity min to {}...", discoverActiveTest(), jobId, min);
+        Stopwatch stopWatch = Stopwatch.createStarted();
+
+        TestStreamObserver<Empty> responseObserver = new TestStreamObserver<>();
+
+        client.updateJobCapacityWithOptionalAttributes(
+                JobCapacityUpdateWithOptionalAttributes.newBuilder().setJobId(jobId)
+                    .setJobCapacityWithOptionalAttributes(JobCapacityWithOptionalAttributes.newBuilder().setMin(UInt32Value.newBuilder().setValue(min).build()).build()).build(),
+                responseObserver);
+
+        rethrow(() -> responseObserver.awaitDone(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        expectJobUpdateEvent(job -> {
+            ServiceJobExt ext = (ServiceJobExt) job.getJobDescriptor().getExtensions();
+            return ext.getCapacity().getMin() == min;
+        }, "Job capacity update did not complete in time");
+
+        logger.info("[{}] Job {} scaled to new min size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));
+        return this;
+    }
+
+    public JobScenarioBuilder updateJobCapacityMax(int max) {
+        logger.info("[{}] Changing job {} capacity max to {}...", discoverActiveTest(), jobId, max);
+        Stopwatch stopWatch = Stopwatch.createStarted();
+
+        TestStreamObserver<Empty> responseObserver = new TestStreamObserver<>();
+
+        client.updateJobCapacityWithOptionalAttributes(
+                JobCapacityUpdateWithOptionalAttributes.newBuilder().setJobId(jobId)
+                    .setJobCapacityWithOptionalAttributes(JobCapacityWithOptionalAttributes.newBuilder().setMax(UInt32Value.newBuilder().setValue(max).build()).build()).build(),
+                responseObserver);
+
+        rethrow(() -> responseObserver.awaitDone(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        expectJobUpdateEvent(job -> {
+            ServiceJobExt ext = (ServiceJobExt) job.getJobDescriptor().getExtensions();
+            return ext.getCapacity().getMax() == max;
+        }, "Job capacity update did not complete in time");
+
+        logger.info("[{}] Job {} scaled to new max size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));
+        return this;
+    }
+
 
     public JobScenarioBuilder updateJobStatus(boolean enabled) {
         logger.info("[{}] Changing job {} enable status to {}...", discoverActiveTest(), jobId, enabled);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobScenarioBuilder.java
@@ -241,7 +241,7 @@ public class JobScenarioBuilder {
         return this;
     }
 
-    public JobScenarioBuilder updateJobCapacityDesired(int desired) {
+    public JobScenarioBuilder updateJobCapacityDesired(int desired, int unchangedMin, int unchangedMax) {
         logger.info("[{}] Changing job {} capacity desired to {}...", discoverActiveTest(), jobId, desired);
         Stopwatch stopWatch = Stopwatch.createStarted();
 
@@ -256,14 +256,15 @@ public class JobScenarioBuilder {
 
         expectJobUpdateEvent(job -> {
             ServiceJobExt ext = (ServiceJobExt) job.getJobDescriptor().getExtensions();
-            return ext.getCapacity().getDesired() == desired;
+            Capacity capacity = ext.getCapacity();
+            return capacity.getDesired() == desired && capacity.getMin() == unchangedMin && capacity.getMax() == unchangedMax;
         }, "Job capacity update did not complete in time");
 
         logger.info("[{}] Job {} scaled to new desired size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));
         return this;
     }
 
-    public JobScenarioBuilder updateJobCapacityMin(int min) {
+    public JobScenarioBuilder updateJobCapacityMin(int min, int unchangedMax, int unchangedDesired) {
         logger.info("[{}] Changing job {} capacity min to {}...", discoverActiveTest(), jobId, min);
         Stopwatch stopWatch = Stopwatch.createStarted();
 
@@ -278,14 +279,15 @@ public class JobScenarioBuilder {
 
         expectJobUpdateEvent(job -> {
             ServiceJobExt ext = (ServiceJobExt) job.getJobDescriptor().getExtensions();
-            return ext.getCapacity().getMin() == min;
+            Capacity capacity = ext.getCapacity();
+            return capacity.getMin() == min && capacity.getMax() == unchangedMax && capacity.getDesired() == unchangedDesired;
         }, "Job capacity update did not complete in time");
 
         logger.info("[{}] Job {} scaled to new min size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));
         return this;
     }
 
-    public JobScenarioBuilder updateJobCapacityMax(int max) {
+    public JobScenarioBuilder updateJobCapacityMax(int max, int unchangedMin, int unchangedDesired) {
         logger.info("[{}] Changing job {} capacity max to {}...", discoverActiveTest(), jobId, max);
         Stopwatch stopWatch = Stopwatch.createStarted();
 
@@ -300,7 +302,8 @@ public class JobScenarioBuilder {
 
         expectJobUpdateEvent(job -> {
             ServiceJobExt ext = (ServiceJobExt) job.getJobDescriptor().getExtensions();
-            return ext.getCapacity().getMax() == max;
+            Capacity capacity = ext.getCapacity();
+            return capacity.getMax() == max && capacity.getMin() == unchangedMin && capacity.getDesired() == unchangedDesired;
         }, "Job capacity update did not complete in time");
 
         logger.info("[{}] Job {} scaled to new max size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
@@ -36,6 +36,7 @@ import com.google.common.base.Preconditions;
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
+import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
@@ -57,6 +58,7 @@ import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
 import com.netflix.titus.master.jobmanager.service.integration.scenario.StubbedJobStore.StoreEvent;
 import com.netflix.titus.master.mesos.TitusExecutorDetails;
+import com.netflix.titus.runtime.endpoint.v3.grpc.V3GrpcModelConverters;
 import com.netflix.titus.testkit.rx.ExtTestSubscriber;
 import com.netflix.titus.testkit.rx.TitusRxSubscriber;
 import rx.Subscriber;
@@ -200,10 +202,9 @@ public class JobScenarioBuilder<E extends JobDescriptor.JobDescriptorExt> {
 
     public JobScenarioBuilder<E> changeCapacity(Capacity newCapacity) {
         ExtTestSubscriber<Void> subscriber = new ExtTestSubscriber<>();
-        jobOperations.updateJobCapacity(jobId, newCapacity, callMetadata).subscribe(subscriber);
-
+        CapacityAttributes capacityAttributes = JobModel.newCapacityAttributes(newCapacity).build();
+        jobOperations.updateJobCapacityAttributes(jobId, capacityAttributes, callMetadata).subscribe(subscriber);
         autoAdvanceUntilSuccessful(() -> checkOperationSubscriberAndThrowExceptionIfError(subscriber));
-
         return this;
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
@@ -37,6 +37,7 @@ import com.netflix.titus.api.jobmanager.model.job.sanitizer.JobConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.sanitizer.JobSanitizerBuilder;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
+import com.netflix.titus.common.model.sanitizer.EntitySanitizerBuilder;
 import com.netflix.titus.common.model.sanitizer.VerifierMode;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
@@ -200,7 +201,8 @@ public class JobsScenarioBuilder {
                 ),
                 jobSubmitLimiter,
                 new ManagementSubsystemInitializer(null, null),
-                titusRuntime
+                titusRuntime,
+                EntitySanitizerBuilder.stdBuilder().build()
         );
         v3JobOperations.enterActiveMode();
 

--- a/titus-server-runtime-spring/dependencies.lock
+++ b/titus-server-runtime-spring/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1218,7 +1218,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2411,7 +2411,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3668,7 +3668,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4862,7 +4862,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6108,7 +6108,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -8122,7 +8122,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10136,7 +10136,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12151,7 +12151,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-server-runtime/dependencies.lock
+++ b/titus-server-runtime/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1183,7 +1183,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2341,7 +2341,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3563,7 +3563,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4722,7 +4722,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -5933,7 +5933,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -7958,7 +7958,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -9983,7 +9983,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12009,7 +12009,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -27,6 +27,7 @@ import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
 import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
+import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudgetUpdate;
@@ -93,6 +94,11 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
     @Override
     public void updateJobCapacity(JobCapacityUpdate request, StreamObserver<Empty> responseObserver) {
         streamCompletableResponse(jobServiceGateway.updateJobCapacity(request), responseObserver);
+    }
+
+    @Override
+    public void updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes request, StreamObserver<Empty> responseObserver) {
+        streamCompletableResponse(jobServiceGateway.updateJobCapacityWithOptionalAttributes(request), responseObserver);
     }
 
     @Override

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
+import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Container;
 import com.netflix.titus.api.jobmanager.model.job.ContainerResources;
 import com.netflix.titus.api.jobmanager.model.job.Image;
@@ -70,10 +71,12 @@ import com.netflix.titus.api.jobmanager.model.job.retry.ExponentialBackoffRetryP
 import com.netflix.titus.api.jobmanager.model.job.retry.ImmediateRetryPolicy;
 import com.netflix.titus.api.jobmanager.model.job.retry.RetryPolicy;
 import com.netflix.titus.api.model.EfsMount;
+import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.grpc.protogen.BatchJobSpec;
 import com.netflix.titus.grpc.protogen.Capacity;
 import com.netflix.titus.grpc.protogen.Constraints;
+import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobDescriptor.JobSpecCase;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudget;
@@ -413,6 +416,22 @@ public final class V3GrpcModelConverters {
                 .withMin(capacity.getMin())
                 .withDesired(capacity.getDesired())
                 .withMax(capacity.getMax())
+                .build();
+    }
+
+    public static com.netflix.titus.api.jobmanager.model.job.CapacityAttributes toCoreCapacityAttributes(JobCapacityWithOptionalAttributes capacity) {
+        CapacityAttributes.Builder builder = JobModel.newCapacityAttributes();
+        Evaluators.acceptIfTrue(capacity.hasDesired(), valueAccepted -> builder.withDesired(capacity.getDesired().getValue()));
+        Evaluators.acceptIfTrue(capacity.hasMin(), valueAccepted -> builder.withMin(capacity.getMin().getValue()));
+        Evaluators.acceptIfTrue(capacity.hasMax(), valueAccepted -> builder.withMax(capacity.getMax().getValue()));
+        return builder.build();
+    }
+
+    public static com.netflix.titus.api.jobmanager.model.job.CapacityAttributes toCoreCapacityAttributes(Capacity capacity) {
+        return JobModel.newCapacityAttributes()
+                .withDesired(capacity.getDesired())
+                .withMax(capacity.getMax())
+                .withMin(capacity.getMin())
                 .build();
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementResource.java
@@ -115,7 +115,7 @@ public class JobManagementResource {
 
     @PUT
     @ApiOperation("Update an existing job's capacity. Optional attributes min / max / desired are supported.")
-    @Path("/jobs/{jobId}/capacity-attributes")
+    @Path("/jobs/{jobId}/capacityAttributes")
     public Response setCapacityWithOptionalAttributes(@PathParam("jobId") String jobId,
                                  JobCapacityWithOptionalAttributes capacity) {
         JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes = JobCapacityUpdateWithOptionalAttributes.newBuilder()

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementResource.java
@@ -46,6 +46,8 @@ import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
 import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
+import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
+import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudget;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudgetUpdate;
@@ -109,6 +111,18 @@ public class JobManagementResource {
                 .setCapacity(capacity)
                 .build();
         return Responses.fromCompletable(jobServiceGateway.updateJobCapacity(jobCapacityUpdate));
+    }
+
+    @PUT
+    @ApiOperation("Update an existing job's capacity. Optional attributes min / max / desired are supported.")
+    @Path("/jobs/{jobId}/capacity-attributes")
+    public Response setCapacityWithOptionalAttributes(@PathParam("jobId") String jobId,
+                                 JobCapacityWithOptionalAttributes capacity) {
+        JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes = JobCapacityUpdateWithOptionalAttributes.newBuilder()
+                .setJobId(jobId)
+                .setJobCapacityWithOptionalAttributes(capacity)
+                .build();
+        return Responses.fromCompletable(jobServiceGateway.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes));
     }
 
     @PUT

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/GrpcJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/GrpcJobServiceGateway.java
@@ -26,6 +26,8 @@ import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
 import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
+import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
+import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudgetUpdate;
@@ -97,6 +99,14 @@ public class GrpcJobServiceGateway implements JobServiceGateway {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
             createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobCapacity(jobCapacityUpdate, streamObserver);
+        }, configuration.getRequestTimeoutMs());
+    }
+
+    @Override
+    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes) {
+        return createRequestCompletable(emitter -> {
+            StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
+            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
@@ -23,6 +23,8 @@ import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
 import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
+import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
+import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudgetUpdate;
@@ -56,6 +58,8 @@ public interface JobServiceGateway {
     Observable<String> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata);
 
     Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate);
+
+    Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes);
 
     Completable updateJobProcesses(JobProcessesUpdate jobProcessesUpdate);
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGatewayDelegate.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGatewayDelegate.java
@@ -21,6 +21,8 @@ import com.netflix.titus.grpc.protogen.Job;
 import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
 import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
+import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
+import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudgetUpdate;
@@ -56,6 +58,11 @@ public class JobServiceGatewayDelegate implements JobServiceGateway {
     @Override
     public Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate) {
         return delegate.updateJobCapacity(jobCapacityUpdate);
+    }
+
+    @Override
+    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes) {
+        return delegate.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes);
     }
 
     @Override

--- a/titus-supplementary-component/job-activity-history/dependencies.lock
+++ b/titus-supplementary-component/job-activity-history/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1230,7 +1230,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2435,7 +2435,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3704,7 +3704,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4910,7 +4910,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6168,7 +6168,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -8190,7 +8190,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10212,7 +10212,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12235,7 +12235,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-supplementary-component/task-relocation/dependencies.lock
+++ b/titus-supplementary-component/task-relocation/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1230,7 +1230,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2435,7 +2435,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3704,7 +3704,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4910,7 +4910,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6168,7 +6168,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -8195,7 +8195,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10222,7 +10222,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12250,7 +12250,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-supplementary-component/tasks-publisher/dependencies.lock
+++ b/titus-supplementary-component/tasks-publisher/dependencies.lock
@@ -25,7 +25,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -1235,7 +1235,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -2445,7 +2445,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -3719,7 +3719,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -4930,7 +4930,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.github.fge:jackson-coreutils",
@@ -6193,7 +6193,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -8216,7 +8216,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -10239,7 +10239,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -12263,7 +12263,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-testkit/dependencies.lock
+++ b/titus-testkit/dependencies.lock
@@ -71,7 +71,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2034,7 +2034,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3997,7 +3997,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -6024,7 +6024,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -7988,7 +7988,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -9958,7 +9958,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -11940,7 +11940,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -13922,7 +13922,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -15905,7 +15905,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.9",
+            "locked": "2.9.9.1",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/StubbedJobOperations.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/StubbedJobOperations.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
+import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
@@ -148,8 +149,8 @@ class StubbedJobOperations implements V3JobOperations {
     }
 
     @Override
-    public Observable<Void> updateJobCapacity(String jobId, Capacity capacity, CallMetadata callMetadata) {
-        return updateServiceJob(jobId, job -> changeServiceJobCapacity(job, capacity));
+    public Observable<Void> updateJobCapacityAttributes(String jobId, CapacityAttributes capacityAttributes, CallMetadata callMetadata) {
+        return updateServiceJob(jobId, job -> changeServiceJobCapacity(job, capacityAttributes));
     }
 
     @Override


### PR DESCRIPTION
### Job capacity updates

It enables a partial capacity specification (min / max / desired) to be applied to a service job. It avoids read-modify-write workflow for updating say just 'desired' value. Capacity entity sanitization is applied by applied the updated attributes to the existing capacity. 