### PR TITLE
flag for temporarily disabling MoveTask validation

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/FeatureActivationConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/FeatureActivationConfiguration.java
@@ -34,13 +34,6 @@ public interface FeatureActivationConfiguration {
     @DefaultValue("true")
     boolean isMergingTaskMigrationPlanInGatewayEnabled();
 
-
-    /**
-     * Feature flag disabling movetask api
-     */
-    @DefaultValue("true")
-    boolean isMoveTaskApiEnabled();
-
     /**
      * Toggle validation of compatibility between Jobs when moving tasks across them. It is useful during emergencies to
      * force tasks to be moved, but it adds risk of causing inconsistencies in Jobs with incompatible tasks. Use with

--- a/titus-api/src/main/java/com/netflix/titus/api/FeatureActivationConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/FeatureActivationConfiguration.java
@@ -40,4 +40,12 @@ public interface FeatureActivationConfiguration {
      */
     @DefaultValue("true")
     boolean isMoveTaskApiEnabled();
+
+    /**
+     * Toggle validation of compatibility between Jobs when moving tasks across them. It is useful during emergencies to
+     * force tasks to be moved, but it adds risk of causing inconsistencies in Jobs with incompatible tasks. Use with
+     * care.
+     */
+    @DefaultValue("true")
+    boolean isMoveTaskValidationEnabled();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -448,9 +448,6 @@ public class DefaultV3JobOperations implements V3JobOperations {
 
     @Override
     public Observable<Void> moveServiceTask(String sourceJobId, String targetJobId, String taskId, CallMetadata callMetadata) {
-        if (!featureActivationConfiguration.isMoveTaskApiEnabled()) {
-            throw JobManagerException.notEnabled("Move task");
-        }
         return Observable.defer(() -> {
             Pair<ReconciliationEngine<JobManagerReconcilerEvent>, EntityHolder> fromEngineTaskPair =
                     reconciliationFramework.findEngineByChildId(taskId).orElseThrow(() -> JobManagerException.taskNotFound(taskId));

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -479,7 +479,7 @@ public class DefaultV3JobOperations implements V3JobOperations {
             }
 
             JobCompatibility compatibility = JobCompatibility.of(jobFrom, jobTo);
-            if (!compatibility.isCompatible()) {
+            if (featureActivationConfiguration.isMoveTaskValidationEnabled() && !compatibility.isCompatible()) {
                 Optional<String> diffReport = ProtobufExt.diffReport(
                         V3GrpcModelConverters.toGrpcJobDescriptor(compatibility.getNormalizedDescriptorFrom()),
                         V3GrpcModelConverters.toGrpcJobDescriptor(compatibility.getNormalizedDescriptorTo())

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
@@ -106,6 +106,7 @@ public class JobsScenarioBuilder {
         when(configuration.getTaskRetryerResetTimeMs()).thenReturn(TimeUnit.MINUTES.toMillis(5));
         when(configuration.getTaskKillAttempts()).thenReturn(2L);
         when(featureActivationConfiguration.isMoveTaskApiEnabled()).thenReturn(true);
+        when(featureActivationConfiguration.isMoveTaskValidationEnabled()).thenReturn(true);
 
         jobStore.events().subscribe(storeEvents);
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
@@ -105,7 +105,6 @@ public class JobsScenarioBuilder {
         when(configuration.getTaskInKillInitiatedStateTimeoutMs()).thenReturn(KILL_INITIATED_TIMEOUT_MS);
         when(configuration.getTaskRetryerResetTimeMs()).thenReturn(TimeUnit.MINUTES.toMillis(5));
         when(configuration.getTaskKillAttempts()).thenReturn(2L);
-        when(featureActivationConfiguration.isMoveTaskApiEnabled()).thenReturn(true);
         when(featureActivationConfiguration.isMoveTaskValidationEnabled()).thenReturn(true);
 
         jobStore.events().subscribe(storeEvents);


### PR DESCRIPTION
To be used in emergencies, when tasks need to be moved, and operators are sure their jobs are compatible, even when there are some differences in their job descriptors.