### PR TITLE
Add task context for tasks waiting for in use IP allocations

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -44,6 +44,7 @@ public final class TaskAttributes {
     public static final String TASK_ATTRIBUTES_EXECUTOR_URI_OVERRIDE = "task.executorUriOverride";
     public static final String TASK_ATTRIBUTES_TIER = "task.tier";
     public static final String TASK_ATTRIBUTES_IP_ALLOCATION_ID = "task.ipAllocationId";
+    public static final String TASK_ATTRIBUTES_IN_USE_IP_ALLOCATION = "task.ipAllocationAlreadyInUseByTask";
 
     /**
      * Task moved from one job to another.

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import javax.inject.Singleton;
 import com.google.protobuf.Empty;
 import com.netflix.titus.api.FeatureRolloutPlans;
 import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.ContainerResources;
@@ -88,6 +89,9 @@ import com.netflix.titus.master.endpoint.common.CellDecorator;
 import com.netflix.titus.master.endpoint.grpc.GrpcMasterEndpointConfiguration;
 import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
 import com.netflix.titus.master.model.ResourceDimensions;
+import com.netflix.titus.master.scheduler.InUseIpAllocationConstraintFailure;
+import com.netflix.titus.master.scheduler.SchedulingService;
+import com.netflix.titus.master.scheduler.TaskPlacementFailure;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.runtime.endpoint.JobQueryCriteria;
 import com.netflix.titus.runtime.endpoint.authorization.AuthorizationService;
@@ -140,6 +144,7 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
     private final CellDecorator cellDecorator;
     private final AuthorizationService authorizationService;
     private final TitusRuntime titusRuntime;
+    private final SchedulingService schedulingService;
 
     @Inject
     public DefaultJobManagementServiceGrpc(GrpcMasterEndpointConfiguration configuration,
@@ -153,7 +158,8 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                                            CallMetadataResolver callMetadataResolver,
                                            CellInfoResolver cellInfoResolver,
                                            AuthorizationService authorizationService,
-                                           TitusRuntime titusRuntime) {
+                                           TitusRuntime titusRuntime,
+                                           SchedulingService schedulingService) {
         this.configuration = configuration;
         this.agentManagementService = agentManagementService;
         this.capacityGroupService = capacityGroupService;
@@ -166,6 +172,7 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
         this.cellDecorator = new CellDecorator(cellInfoResolver::getCellName);
         this.authorizationService = authorizationService;
         this.titusRuntime = titusRuntime;
+        this.schedulingService = schedulingService;
     }
 
     @Override
@@ -305,7 +312,10 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                     JobManagerCursors::newCoreCursorFrom
             );
 
-            List<Task> grpcTasks = queryResult.getLeft().stream().map(t -> V3GrpcModelConverters.toGrpcTask(t, logStorageInfo)).collect(Collectors.toList());
+            List<Task> grpcTasks = queryResult.getLeft().stream()
+                    .map(t -> V3GrpcModelConverters.toGrpcTask(t, logStorageInfo))
+                    .map(this::addTaskContextToTask)
+                    .collect(Collectors.toList());
 
             TaskQueryResult grpcQueryResult;
             if (taskQuery.getFieldsList().isEmpty()) {
@@ -334,6 +344,7 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                         return Observable.just(V3GrpcModelConverters.toGrpcTask(task, logStorageInfo));
                     })
                     .orElseGet(() -> Observable.error(JobManagerException.taskNotFound(id)))
+                    .map(this::addTaskContextToTask)
                     .subscribe(
                             responseObserver::onNext,
                             e -> safeOnError(logger, e, responseObserver),
@@ -613,6 +624,7 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                     snapshot.add(SNAPSHOT_END_MARKER);
                     return snapshot;
                 }))
+                .map(this::addTaskContextToJobChangeNotification)
                 .doOnError(e -> logger.error("Unexpected error in jobs event stream", e));
 
         Subscription subscription = eventStream.subscribe(
@@ -639,6 +651,7 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                     snapshot.add(SNAPSHOT_END_MARKER);
                     return snapshot;
                 }))
+                .map(this::addTaskContextToJobChangeNotification)
                 .doOnError(e -> {
                     if (!JobManagerException.isExpected(e)) {
                         logger.error("Unexpected error in job {} event stream", jobId, e);
@@ -813,5 +826,44 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                 .orElseThrow(() -> JobManagerException.jobNotFound(jobId));
 
 
+    }
+
+    /**
+     * Adds dynamic Task Context to a task that is being returned in a task lookup.
+     */
+    private Task addTaskContextToTask(Task task) {
+        List<TaskPlacementFailure> taskIpAllocationFailures = schedulingService.getLastTaskPlacementFailures()
+                // Get all in use IP allocation failures
+                .getOrDefault(TaskPlacementFailure.FailureKind.WaitingForInUseIpAllocation, Collections.emptyMap())
+                // Get all in use IP allocation failures for this specific task
+                .getOrDefault(task.getId(), Collections.emptyList());
+        for (TaskPlacementFailure inUseIpAllocationFailure : taskIpAllocationFailures) {
+            // Return the first instance of an in use IP allocation failure.
+            if (inUseIpAllocationFailure instanceof InUseIpAllocationConstraintFailure) {
+                return task.toBuilder()
+                        .putTaskContext(TaskAttributes.TASK_ATTRIBUTES_IN_USE_IP_ALLOCATION, ((InUseIpAllocationConstraintFailure) inUseIpAllocationFailure).getInUseTaskId())
+                        .build();
+            } else {
+                // We expect each in use IP allocation failure to be of type InUseIpAllocationConstraintFailure
+                titusRuntime.getCodeInvariants().inconsistent("Found in use IP allocation placement failure not of type {}, instead {}",
+                        InUseIpAllocationConstraintFailure.class.getSimpleName(),
+                        inUseIpAllocationFailure.getClass().getSimpleName());
+            }
+        }
+        return task;
+    }
+
+    /**
+     * Add dynamic task context if this change refers to a Task Update.
+     */
+    private JobChangeNotification addTaskContextToJobChangeNotification(JobChangeNotification jobChangeNotification) {
+        if (jobChangeNotification.hasTaskUpdate()) {
+            return jobChangeNotification.toBuilder()
+                    .setTaskUpdate(jobChangeNotification.getTaskUpdate().toBuilder()
+                            .setTask(addTaskContextToTask(jobChangeNotification.getTaskUpdate().getTask()))
+                            .build()
+                    ).build();
+        }
+        return jobChangeNotification;
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -659,7 +659,7 @@ public class DefaultSchedulingService implements SchedulingService {
     }
 
     @Override
-    public Map<TaskPlacementFailure.FailureKind, List<TaskPlacementFailure>> getLastTaskPlacementFailures() {
+    public Map<TaskPlacementFailure.FailureKind, Map<String, List<TaskPlacementFailure>>> getLastTaskPlacementFailures() {
         return taskPlacementFailureClassifier.getLastTaskPlacementFailures();
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/InUseIpAllocationConstraintFailure.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/InUseIpAllocationConstraintFailure.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.scheduler;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.netflix.titus.api.model.Tier;
+
+public class InUseIpAllocationConstraintFailure extends TaskPlacementFailure {
+    private final String inUseTaskId;
+
+    public InUseIpAllocationConstraintFailure(String taskId,
+                                              Optional<String> inUseTaskIdOptional,
+                                              int agentCount,
+                                              Tier tier,
+                                              Map<String, Object> rawData) {
+        super(taskId, FailureKind.WaitingForInUseIpAllocation, agentCount, tier, rawData);
+        this.inUseTaskId = inUseTaskIdOptional.orElse("unknown");
+    }
+
+    public String getInUseTaskId() {
+        return inUseTaskId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        InUseIpAllocationConstraintFailure that = (InUseIpAllocationConstraintFailure) o;
+        return inUseTaskId.equals(that.inUseTaskId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), inUseTaskId);
+    }
+
+    @Override
+    public String toString() {
+        return "InUseIpAllocationConstraintFailure{" +
+                "inUseTaskId='" + inUseTaskId + '\'' +
+                '}';
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public interface SchedulingService {
     Observable<SchedulingResultEvent> observeSchedulingResults(String taskId);
 
     /**
-     * Returns the last known task placement failures grouped by a failure kind.
+     * Returns the last known task placement failures grouped by a failure kind and task id.
      */
-    Map<FailureKind, List<TaskPlacementFailure>> getLastTaskPlacementFailures();
+    Map<FailureKind, Map<String, List<TaskPlacementFailure>>> getLastTaskPlacementFailures();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,11 @@ public class TaskPlacementFailure {
          * Task not launched due to job hard constraint. It has lower priority than the previous failure kinds.
          */
         JobHardConstraint,
+
+        /**
+         * Task not launched due to assigned IP allocation in use by another running task.
+         */
+        WaitingForInUseIpAllocation,
 
         Unrecognized,
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScalerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScalerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,7 +178,7 @@ public class ClusterAgentAutoScalerTest {
         List<Task> tasks = createTasks(10, "jobId");
         when(v3JobOperations.getTasks()).thenReturn(tasks);
 
-        Map<TaskPlacementFailure.FailureKind, List<TaskPlacementFailure>> taskPlacementFailures = createTaskPlacementFailures(ImmutableMap.of(
+        Map<TaskPlacementFailure.FailureKind, Map<String, List<TaskPlacementFailure>>> taskPlacementFailures = createTaskPlacementFailures(ImmutableMap.of(
                 TaskPlacementFailure.FailureKind.AllAgentsFull, 10
         ), Tier.Flex);
         when(schedulingService.getLastTaskPlacementFailures()).thenReturn(taskPlacementFailures);
@@ -248,7 +248,7 @@ public class ClusterAgentAutoScalerTest {
         List<Task> tasks = createTasks(10, "jobId");
         when(v3JobOperations.getTasks()).thenReturn(tasks);
 
-        Map<TaskPlacementFailure.FailureKind, List<TaskPlacementFailure>> taskPlacementFailures = createTaskPlacementFailures(ImmutableMap.of(
+        Map<TaskPlacementFailure.FailureKind, Map<String, List<TaskPlacementFailure>>> taskPlacementFailures = createTaskPlacementFailures(ImmutableMap.of(
                 TaskPlacementFailure.FailureKind.AllAgentsFull, 10
         ), Tier.Flex);
         when(schedulingService.getLastTaskPlacementFailures()).thenReturn(taskPlacementFailures);
@@ -523,15 +523,15 @@ public class ClusterAgentAutoScalerTest {
         return agents;
     }
 
-    private Map<TaskPlacementFailure.FailureKind, List<TaskPlacementFailure>> createTaskPlacementFailures(Map<TaskPlacementFailure.FailureKind, Integer> count,
+    private Map<TaskPlacementFailure.FailureKind, Map<String, List<TaskPlacementFailure>>> createTaskPlacementFailures(Map<TaskPlacementFailure.FailureKind, Integer> count,
                                                                                                           Tier tier) {
-        Map<TaskPlacementFailure.FailureKind, List<TaskPlacementFailure>> failureKinds = new HashMap<>();
+        Map<TaskPlacementFailure.FailureKind, Map<String, List<TaskPlacementFailure>>> failureKinds = new HashMap<>();
         for (Map.Entry<TaskPlacementFailure.FailureKind, Integer> entry : count.entrySet()) {
             TaskPlacementFailure.FailureKind failureKind = entry.getKey();
-            List<TaskPlacementFailure> failures = failureKinds.computeIfAbsent(failureKind, k -> new ArrayList<>());
             for (int i = 0; i < entry.getValue(); i++) {
-                TaskPlacementFailure failure = new TaskPlacementFailure("task" + i, failureKind, -1, tier, Collections.emptyMap());
-                failures.add(failure);
+                Map<String, List<TaskPlacementFailure>> failuresByTaskId = failureKinds.computeIfAbsent(failureKind, k -> new HashMap<>());
+                String taskId = "task" + i;
+                failuresByTaskId.computeIfAbsent(taskId, k -> new ArrayList<>()).add(new TaskPlacementFailure(taskId, failureKind, -1, tier, Collections.emptyMap()));
             }
         }
         return failureKinds;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedSchedulingService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedSchedulingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ class StubbedSchedulingService implements SchedulingService {
     }
 
     @Override
-    public Map<TaskPlacementFailure.FailureKind, List<TaskPlacementFailure>> getLastTaskPlacementFailures() {
+    public Map<TaskPlacementFailure.FailureKind, Map<String, List<TaskPlacementFailure>>> getLastTaskPlacementFailures() {
         return Collections.emptyMap();
     }
 }


### PR DESCRIPTION
This PR adds a task context field to tasks that are not placed during scheduling because their assigned IP allocation is already in use by another task. This PR consists of the following changes:

1. Adds a new task placement failure type indicating that the task is waiting for an in use IP allocation.
2. When tasks are returned their task context is updated to reflect if the last placement failed because of an in use IP allocation.
3. Group task placement failures by task id to allow point queries when looking up failed allocations for specific tasks.