### PR TITLE
Record success and error latencies for WebClients in a consistent way

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/network/client/LatencyRecorder.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/network/client/LatencyRecorder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.network.client;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.base.Preconditions;
+import com.netflix.titus.common.network.client.internal.WebClientMetric;
+import com.netflix.titus.common.util.time.Clock;
+import org.springframework.http.HttpMethod;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+
+// TODO: same operator for Flux when needed
+class LatencyRecorder<T> extends MonoOperator<T, T> {
+    private final Clock clock;
+    private final WebClientMetric metrics;
+    private final HttpMethod method;
+    private final Optional<String> path;
+
+    LatencyRecorder(Clock clock, Mono<T> source, WebClientMetric metrics, HttpMethod method) {
+        super(source);
+        this.clock = clock;
+        this.metrics = metrics;
+        this.method = method;
+        this.path = Optional.empty();
+    }
+
+    LatencyRecorder(Clock clock, Mono<T> source, WebClientMetric metrics, HttpMethod method, String path) {
+        super(source);
+        this.clock = clock;
+        this.metrics = metrics;
+        this.method = method;
+        this.path = Optional.of(path);
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        AtomicLong startTimeMsHolder = new AtomicLong();
+        source.subscribe(
+                actual::onNext,
+                error -> {
+                    long startTimeMs = startTimeMsHolder.get();
+                    Preconditions.checkState(startTimeMs > 0, "onError() called before onSubscribe()");
+                    Duration elapsed = Duration.ofMillis(clock.wallTime() - startTimeMs);
+                    if (path.isPresent()) {
+                        metrics.registerOnErrorLatency(method, path.get(), elapsed);
+                    } else {
+                        metrics.registerOnErrorLatency(method, elapsed);
+                    }
+                    actual.onError(error);
+                },
+                () -> {
+                    long startTimeMs = startTimeMsHolder.get();
+                    Preconditions.checkState(startTimeMs > 0, "onComplete() called before onSubscribe()");
+                    Duration elapsed = Duration.ofMillis(clock.wallTime() - startTimeMs);
+                    if (path.isPresent()) {
+                        metrics.registerOnSuccessLatency(method, path.get(), elapsed);
+                    } else {
+                        metrics.registerOnSuccessLatency(method, elapsed);
+                    }
+                    actual.onComplete();
+                },
+                subscription -> {
+                    startTimeMsHolder.set(clock.wallTime());
+                    actual.onSubscribe(subscription);
+                }
+        );
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/network/client/WebClientExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/network/client/WebClientExt.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.network.client;
+
+import java.util.function.Function;
+
+import com.netflix.titus.common.network.client.internal.WebClientMetric;
+import com.netflix.titus.common.util.time.Clock;
+import org.reactivestreams.Publisher;
+import org.springframework.http.HttpMethod;
+import reactor.core.publisher.Mono;
+
+public final class WebClientExt {
+
+    /**
+     * A {@link Mono} operator that records latency of completion (success or error), use with
+     * {@link Mono#compose(Function)}.
+     */
+    public static <T> Function<Mono<T>, Publisher<T>> latencyMonoOperator(Clock clock, WebClientMetric metrics, HttpMethod method) {
+        return source -> new LatencyRecorder<>(clock, source, metrics, method);
+    }
+
+    /**
+     * A {@link Mono} operator that records latency of completion (success or error), use with
+     * {@link Mono#compose(Function)}.
+     */
+    public static <T> Function<Mono<T>, Publisher<T>> latencyMonoOperator(Clock clock, WebClientMetric metrics, HttpMethod method, String path) {
+        return source -> new LatencyRecorder<>(clock, source, metrics, method, path);
+    }
+
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/network/client/internal/WebClientMetric.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/network/client/internal/WebClientMetric.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.common.network.client.internal;
 
+import java.time.Duration;
+
 import com.netflix.spectator.api.Registry;
 import com.netflix.titus.common.network.client.ClientMetrics;
 import com.netflix.titus.common.util.time.Clock;
@@ -32,8 +34,20 @@ public class WebClientMetric {
         delegate = new ClientMetrics(WEB_CLIENT_METRICS, endpointName, registry, clock);
     }
 
-    public void registerLatency(HttpMethod method, long startTimeMs) {
-        delegate.registerLatency(method.name(), startTimeMs);
+    public void registerOnSuccessLatency(HttpMethod method, Duration elapsed) {
+        delegate.registerOnSuccessLatency(method.name(), elapsed);
+    }
+
+    public void registerOnSuccessLatency(HttpMethod method, String path, Duration elapsed) {
+        delegate.registerOnSuccessLatency(method.name(), path, elapsed);
+    }
+
+    public void registerOnErrorLatency(HttpMethod method, Duration elapsed) {
+        delegate.registerOnErrorLatency(method.name(), elapsed);
+    }
+
+    public void registerOnErrorLatency(HttpMethod method, String path, Duration elapsed) {
+        delegate.registerOnErrorLatency(method.name(), path, elapsed);
     }
 
     public void incrementOnSuccess(HttpClientResponse response, Connection connection) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -152,9 +152,10 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
                 podsClientMetrics.incrementOnSuccess(POST, PODS, STATUS_200);
             } catch (ApiException e) {
                 logger.error("Unable to create pod with error:", e);
+                podsClientMetrics.registerOnErrorLatency(POST, Duration.ofMillis(clock.wallTime() - startTimeMs));
                 podsClientMetrics.incrementOnError(POST, PODS, e);
             } finally {
-                podsClientMetrics.registerLatency(POST, startTimeMs);
+                podsClientMetrics.registerOnSuccessLatency(POST, Duration.ofMillis(clock.wallTime() - startTimeMs));
             }
         }
     }
@@ -248,8 +249,9 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         } catch (Exception e) {
             logger.error("Failed to kill task: {} with error: ", taskId, e);
             podsClientMetrics.incrementOnError(DELETE, PODS, e);
+            podsClientMetrics.registerOnErrorLatency(DELETE, Duration.ofMillis(clock.wallTime() - startTimeMs));
         } finally {
-            podsClientMetrics.registerLatency(DELETE, startTimeMs);
+            podsClientMetrics.registerOnSuccessLatency(DELETE, Duration.ofMillis(clock.wallTime() - startTimeMs));
         }
     }
 
@@ -277,8 +279,9 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         } catch (Exception e) {
             logger.error("Failed to list nodes with error:", e);
             nodesClientMetrics.incrementOnError(GET, NODES, e);
+            nodesClientMetrics.registerOnErrorLatency(GET, Duration.ofMillis(clock.wallTime() - startTimeMs));
         } finally {
-            nodesClientMetrics.registerLatency(GET, startTimeMs);
+            nodesClientMetrics.registerOnSuccessLatency(GET, Duration.ofMillis(clock.wallTime() - startTimeMs));
         }
         if (list != null && !list.getItems().isEmpty()) {
             final List<VMLeaseObject> leaseObjects = list.getItems().stream()
@@ -366,8 +369,9 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         } catch (Exception e) {
             logger.error("Failed to list pods with error: ", e);
             podsClientMetrics.incrementOnError(GET, PODS, e);
+            podsClientMetrics.registerOnErrorLatency(GET, Duration.ofMillis(clock.wallTime() - startTimeMs));
         } finally {
-            podsClientMetrics.registerLatency(GET, startTimeMs);
+            podsClientMetrics.registerOnSuccessLatency(GET, Duration.ofMillis(clock.wallTime() - startTimeMs));
         }
         if (list != null && !list.getItems().isEmpty()) {
             for (V1Pod pod : list.getItems()) {


### PR DESCRIPTION
Some of the async code was incorrectly computing a start timestamp from when the async method gets called, instead of when the async computation begins (when requests are sent).

This adds a new reusable operator for async clients using `Mono` that automatically records latency metrics.