### PR TITLE
Update experimental k8s integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ subprojects {
         commonsCliVersion = '1.3.+'
         caffeineVersion = '2.6.+'
         rxJavaInteropVersion = '0.13.+'
+        kubernetesClientVersion = '5.0.0'
 
         // Test
         junitVersion = '4.10'

--- a/titus-server-master/build.gradle
+++ b/titus-server-master/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     // Misc dependencies
     compile "org.apache.mesos:mesos:${mesosVersion}"
-    compile "io.kubernetes:client-java:4.0.0"
+    compile "io.kubernetes:client-java:${kubernetesClientVersion}"
     compile "com.github.spullara.cli-parser:cli-parser:${cliParserVersion}"
     compile "com.google.inject:guice:${guiceVersion}"
     compile "io.swagger:swagger-jaxrs:${swaggerVersion}"

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/LeaseRescindedEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/LeaseRescindedEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.titus.master.mesos;
 
 public class LeaseRescindedEvent {
@@ -6,8 +22,7 @@ public class LeaseRescindedEvent {
 
     public enum Type {
         All,
-        LeaseId,
-        Hostname
+        LeaseId
     }
 
     private final Type type;
@@ -32,9 +47,5 @@ public class LeaseRescindedEvent {
 
     public static LeaseRescindedEvent leaseIdEvent(String leaseId) {
         return new LeaseRescindedEvent(Type.LeaseId, leaseId);
-    }
-
-    public static LeaseRescindedEvent hostnameEvent(String hostname) {
-        return new LeaseRescindedEvent(Type.Hostname, hostname);
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/VirtualMachineMasterService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/VirtualMachineMasterService.java
@@ -37,6 +37,8 @@ public interface VirtualMachineMasterService {
 
     void setVMLeaseHandler(Action1<List<? extends VirtualMachineLease>> leaseHandler);
 
+    void setRescindLeaseHandler(Action1<List<LeaseRescindedEvent>> rescindLeaseHandler);
+
     Observable<LeaseRescindedEvent> getLeaseRescindedObservable();
 
     Observable<ContainerEvent> getTaskStatusObservable();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/VirtualMachineMasterServiceMesosImpl.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/VirtualMachineMasterServiceMesosImpl.java
@@ -215,6 +215,11 @@ public class VirtualMachineMasterServiceMesosImpl implements VirtualMachineMaste
     }
 
     @Override
+    public void setRescindLeaseHandler(Action1<List<LeaseRescindedEvent>> rescindLeaseHandler) {
+        // do nothing
+    }
+
+    @Override
     public Observable<LeaseRescindedEvent> getLeaseRescindedObservable() {
         return vmLeaseRescindedObserver;
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/WorkerStateMonitor.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/WorkerStateMonitor.java
@@ -90,7 +90,7 @@ public class WorkerStateMonitor {
                                 } else {
                                     taskStatusBuilder
                                             .withReasonCode(reasonCode)
-                                            .withReasonMessage("Mesos task state change event: " + args.getReasonMessage());
+                                            .withReasonMessage(args.getReasonMessage());
                                 }
                                 TaskStatus taskStatus = taskStatusBuilder.build();
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -611,13 +611,14 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         List<V1Pod> podsStuckBeingDeleted = currentPods.stream()
                 .filter(pod -> {
                     String podName = pod.getMetadata().getName();
-                    DateTime deletionTimestamp = pod.getMetadata().getDeletionTimestamp();
-                    return clock.isPast(deletionTimestamp.getMillis() + POD_GC_DELETION_TTL) &&
+                    DateTime deletionTime = pod.getMetadata().getDeletionTimestamp();
+                    return deletionTime != null &&
+                            clock.isPast(deletionTime.getMillis() + POD_GC_DELETION_TTL) &&
                             !currentTaskIds.contains(podName);
                 })
                 .collect(Collectors.toList());
 
-        // GC orphaned pods that stuck being deleted
+        // GC orphaned pods that are stuck being deleted
         logger.debug("Attempting to GC {} orphaned pods not in Titus", podsStuckBeingDeleted.size());
         for (V1Pod pod : podsStuckBeingDeleted) {
             gcPod(pod);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.titus.master.mesos.kubeapiserver;
 
 import java.time.Duration;
@@ -9,8 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -18,16 +35,21 @@ import javax.inject.Singleton;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Injector;
 import com.netflix.fenzo.VirtualMachineLease;
 import com.netflix.fenzo.functions.Action1;
 import com.netflix.fenzo.plugins.VMLeaseObject;
+import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.common.annotation.Experimental;
 import com.netflix.titus.common.framework.scheduler.LocalScheduler;
 import com.netflix.titus.common.framework.scheduler.model.ScheduleDescriptor;
 import com.netflix.titus.common.network.client.ClientMetrics;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.ExecutorsExt;
+import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.time.Clock;
 import com.netflix.titus.master.mesos.ContainerEvent;
 import com.netflix.titus.master.mesos.LeaseRescindedEvent;
@@ -37,13 +59,11 @@ import com.netflix.titus.master.mesos.V3ContainerEvent;
 import com.netflix.titus.master.mesos.VirtualMachineMasterService;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
-import io.kubernetes.client.Configuration;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.models.V1Container;
-import io.kubernetes.client.models.V1DeleteOptions;
 import io.kubernetes.client.models.V1Node;
-import io.kubernetes.client.models.V1NodeAddress;
+import io.kubernetes.client.models.V1NodeCondition;
 import io.kubernetes.client.models.V1NodeList;
 import io.kubernetes.client.models.V1NodeStatus;
 import io.kubernetes.client.models.V1ObjectMeta;
@@ -53,7 +73,9 @@ import io.kubernetes.client.models.V1PodSpec;
 import io.kubernetes.client.models.V1PodStatus;
 import io.kubernetes.client.models.V1ResourceRequirements;
 import io.kubernetes.client.util.Config;
+import io.kubernetes.client.util.Watch;
 import org.apache.mesos.Protos;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -66,79 +88,115 @@ import static com.netflix.titus.api.jobmanager.model.job.TaskState.StartInitiate
 import static com.netflix.titus.api.jobmanager.model.job.TaskState.Started;
 import static com.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_FAILED;
 import static com.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_NORMAL;
+import static com.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_TASK_LOST;
 
 /**
  * Responsible for integrating Kubernetes API Server concepts into Titus's Mesos based approaches.
  */
-@Experimental(detail = "This is a basic integration with the kubernetes api server", deadline = "7/1/2019")
+@Experimental(detail = "This is a basic integration with the kubernetes api server", deadline = "8/1/2019")
 @Singleton
 public class KubeApiServerIntegrator implements VirtualMachineMasterService {
     private static final Logger logger = LoggerFactory.getLogger(KubeApiServerIntegrator.class);
     private static final String ATTRIBUTE_PREFIX = "com.netflix.titus.agent.attribute/";
     private static final String KUBERNETES_NAMESPACE = "default";
     private static final String CLIENT_METRICS_PREFIX = "titusMaster.mesos.kubeApiServerIntegration";
-    private static final int GRACE_PERIOD_SECONDS = 300;
+    private static final long POD_TERMINATION_GRACE_PERIOD_SECONDS = 600L;
+    private static final int DELETE_GRACE_PERIOD_SECONDS = 300;
+    private static final int POD_GC_DELETION_TTL = 60_000;
+    private static final int NODE_GC_TTL_MS = 60_000;
 
     private static final String POST = "POST";
     private static final String GET = "GET";
     private static final String DELETE = "DELETE";
     private static final String STATUS_200 = "200";
+    private static final String NOT_FOUND = "Not found";
     private static final String NODES = "nodes";
     private static final String PODS = "pods";
+
+    private static final String PENDING = "Pending";
+    private static final String RUNNING = "Running";
+    private static final String SUCCEEDED = "Succeeded";
+    private static final String FAILED = "Failed";
+    private static final String READY = "Ready";
+    private static final String STOPPED = "Stopped";
 
     private final TitusRuntime titusRuntime;
     private final MesosConfiguration mesosConfiguration;
     private final LocalScheduler scheduler;
     private final Clock clock;
+    private final Injector injector;
 
-    private final ClientMetrics nodesClientMetrics;
-    private final ClientMetrics podsClientMetrics;
+    private volatile Snapshot<V1Node> lastSnapshot = Snapshot.emptySnapshot();
+
     private final Cache<String, V1Pod> lastPodUpdate = CacheBuilder.newBuilder()
-            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .expireAfterWrite(10, TimeUnit.MINUTES)
             .build();
 
     private com.netflix.fenzo.functions.Action1<List<? extends VirtualMachineLease>> leaseHandler;
-    private Subject<LeaseRescindedEvent, LeaseRescindedEvent> vmLeaseRescindedObserver;
+    private Action1<List<LeaseRescindedEvent>> rescindLeaseHandler;
     private Subject<ContainerEvent, ContainerEvent> vmTaskStatusObserver;
-    private CoreV1Api api;
+    private V3JobOperations v3JobOperations;
+    private ClientMetrics nodesClientMetrics;
+    private ClientMetrics podsClientMetrics;
+    private CoreV1Api normalApi;
+    private ApiClient watchClient;
+    private CoreV1Api watchApi;
 
     @Inject
     public KubeApiServerIntegrator(TitusRuntime titusRuntime,
                                    MesosConfiguration mesosConfiguration,
-                                   LocalScheduler scheduler) {
+                                   LocalScheduler scheduler,
+                                   Injector injector) {
         this.titusRuntime = titusRuntime;
         this.mesosConfiguration = mesosConfiguration;
         this.scheduler = scheduler;
         this.clock = titusRuntime.getClock();
+        this.injector = injector;
 
-        this.vmLeaseRescindedObserver = PublishSubject.create();
         this.vmTaskStatusObserver = PublishSubject.create();
 
         nodesClientMetrics = new ClientMetrics(CLIENT_METRICS_PREFIX, NODES, titusRuntime.getRegistry(), clock);
         podsClientMetrics = new ClientMetrics(CLIENT_METRICS_PREFIX, PODS, titusRuntime.getRegistry(), clock);
+
+        ApiClient normalClient = Config.fromUrl(mesosConfiguration.getKubeApiServerUrl());
+        normalClient.getHttpClient().setReadTimeout(60_000, TimeUnit.MILLISECONDS);
+        normalApi = new CoreV1Api(normalClient);
+
+        watchClient = Config.fromUrl(mesosConfiguration.getKubeApiServerUrl());
+        watchClient.getHttpClient().setReadTimeout(1_800_000, TimeUnit.MILLISECONDS);
+        watchApi = new CoreV1Api(watchClient);
     }
 
     @Override
     public void enterActiveMode() {
-        ApiClient client = Config.fromUrl(mesosConfiguration.getKubeApiServerUrl());
-        Configuration.setDefaultApiClient(client);
-        api = new CoreV1Api(client);
+        v3JobOperations = injector.getInstance(V3JobOperations.class);
 
-        ScheduleDescriptor getNodeSchedulerDescriptor = ScheduleDescriptor.newBuilder()
-                .withName("getNodes")
-                .withDescription("Get node information")
-                .withInterval(Duration.ofSeconds(5))
-                .withTimeout(Duration.ofSeconds(10))
-                .build();
-        scheduler.schedule(getNodeSchedulerDescriptor, e -> pollForNodes(), ExecutorsExt.namedSingleThreadExecutor("kube-api-server-integrator-nodes"));
-
-        ScheduleDescriptor getPodsSchedulerDescriptor = ScheduleDescriptor.newBuilder()
-                .withName("getPods")
+        ScheduleDescriptor getNodeUpdatesSchedulerDescriptor = ScheduleDescriptor.newBuilder()
+                .withName("getNodeUpdates")
                 .withDescription("Get pod information")
+                .withInitialDelay(Duration.ofSeconds(5))
                 .withInterval(Duration.ofSeconds(5))
-                .withTimeout(Duration.ofSeconds(10))
+                .withTimeout(Duration.ofMinutes(5))
                 .build();
-        scheduler.schedule(getPodsSchedulerDescriptor, e -> pollForPods(), ExecutorsExt.namedSingleThreadExecutor("kube-api-server-integrator-pods"));
+        scheduler.schedule(getNodeUpdatesSchedulerDescriptor, e -> getNodeUpdates(), ExecutorsExt.namedSingleThreadExecutor("kube-api-server-integrator-get-node-updates"));
+
+        ScheduleDescriptor getPodUpdatesSchedulerDescriptor = ScheduleDescriptor.newBuilder()
+                .withName("getPodUpdates")
+                .withDescription("Get pod information")
+                .withInitialDelay(Duration.ofSeconds(5))
+                .withInterval(Duration.ofSeconds(5))
+                .withTimeout(Duration.ofHours(1))
+                .build();
+        scheduler.schedule(getPodUpdatesSchedulerDescriptor, e -> getPodUpdates(), ExecutorsExt.namedSingleThreadExecutor("kube-api-server-integrator-get-pod-updates"));
+
+        ScheduleDescriptor reconcileSchedulerDescriptor = ScheduleDescriptor.newBuilder()
+                .withName("reconcileNodesAndPods")
+                .withDescription("Reconcile nodes and pods")
+                .withInitialDelay(Duration.ofSeconds(10))
+                .withInterval(Duration.ofSeconds(30))
+                .withTimeout(Duration.ofMinutes(5))
+                .build();
+        scheduler.schedule(reconcileSchedulerDescriptor, e -> reconcileNodesAndPods(), ExecutorsExt.namedSingleThreadExecutor("kube-api-server-integrator-gc"));
     }
 
     @Override
@@ -148,7 +206,7 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
             try {
                 V1Pod v1Pod = taskInfoToPod(request);
                 logger.debug("pod: {}", v1Pod);
-                api.createNamespacedPod(KUBERNETES_NAMESPACE, v1Pod, false, null, null);
+                normalApi.createNamespacedPod(KUBERNETES_NAMESPACE, v1Pod, false, null, null);
                 podsClientMetrics.incrementOnSuccess(POST, PODS, STATUS_200);
             } catch (ApiException e) {
                 logger.error("Unable to create pod with error:", e);
@@ -180,7 +238,7 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         V1PodSpec spec = new V1PodSpec()
                 .nodeName(nodeName)
                 .containers(Collections.singletonList(container))
-                .terminationGracePeriodSeconds(600L);
+                .terminationGracePeriodSeconds(POD_TERMINATION_GRACE_PERIOD_SECONDS);
 
         return new V1Pod()
                 .metadata(metadata)
@@ -225,23 +283,20 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
 
     @Override
     public void rejectLease(VirtualMachineLease lease) {
-        // do nothing since there isn't a real lease
+        // do nothing
     }
 
     @Override
     public void killTask(String taskId) {
         long startTimeMs = clock.wallTime();
         try {
-            api.deleteNamespacedPod(taskId, KUBERNETES_NAMESPACE, new V1DeleteOptions(), null, null, GRACE_PERIOD_SECONDS, null, null);
+            normalApi.deleteNamespacedPod(taskId, KUBERNETES_NAMESPACE, null, null, null, DELETE_GRACE_PERIOD_SECONDS, null, null);
             podsClientMetrics.incrementOnSuccess(DELETE, PODS, STATUS_200);
         } catch (JsonSyntaxException e) {
             // this is probably successful. the generated client has the wrong response type
             podsClientMetrics.incrementOnSuccess(DELETE, PODS, STATUS_200);
         } catch (ApiException e) {
-            if (e.getMessage().equalsIgnoreCase("Not found")) {
-                // pod is no longer in api server
-                publishContainerEvent(taskId, Finished, REASON_NORMAL, "", Optional.empty());
-            } else {
+            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
                 logger.error("Failed to kill task: {} with error: ", taskId, e);
                 podsClientMetrics.incrementOnError(DELETE, PODS, e);
             }
@@ -259,8 +314,13 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
     }
 
     @Override
+    public void setRescindLeaseHandler(Action1<List<LeaseRescindedEvent>> rescindLeaseHandler) {
+        this.rescindLeaseHandler = rescindLeaseHandler;
+    }
+
+    @Override
     public Observable<LeaseRescindedEvent> getLeaseRescindedObservable() {
-        return vmLeaseRescindedObserver.asObservable();
+        return PublishSubject.create();
     }
 
     @Override
@@ -268,11 +328,57 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         return vmTaskStatusObserver.asObservable();
     }
 
-    private void pollForNodes() {
+    private void getNodeUpdates() {
+        try {
+            long startTimeMs = clock.wallTime();
+            V1NodeList list = null;
+            try {
+                list = normalApi.listNode(null, null, null, null, null, null, null, null, null);
+                nodesClientMetrics.incrementOnSuccess(GET, NODES, STATUS_200);
+            } catch (Exception e) {
+                logger.error("Failed to list nodes with error:", e);
+                nodesClientMetrics.incrementOnError(GET, NODES, e);
+            } finally {
+                nodesClientMetrics.registerLatency(GET, startTimeMs);
+            }
+            if (list != null) {
+                Snapshot<V1Node> snapshot = Snapshot.newSnapshot(list.getItems(), clock.wallTime());
+                SnapshotComparison<V1Node> comparison = snapshot.compare(lastSnapshot, n -> n.getMetadata().getName(), (first, second) -> true);
+                //TODO check for changes to node conditions once the conditions are implemented
+
+                List<String> leaseIdsToRemove = comparison.getRemoved().stream()
+                        .map(n -> n.getMetadata().getName())
+                        .collect(Collectors.toList());
+                if (!leaseIdsToRemove.isEmpty() && rescindLeaseHandler != null) {
+                    List<LeaseRescindedEvent> leaseRescindedEvents = leaseIdsToRemove.stream()
+                            .map(LeaseRescindedEvent::leaseIdEvent)
+                            .collect(Collectors.toList());
+                    rescindLeaseHandler.call(leaseRescindedEvents);
+                }
+
+                // send all leases as fenzo will currently dedup them
+                List<VirtualMachineLease> leasesToAdd = snapshot.getItems().stream()
+                        .map(this::nodeToLease)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                if (!leasesToAdd.isEmpty() && leaseHandler != null) {
+                    leaseHandler.call(leasesToAdd);
+                }
+
+                lastSnapshot = snapshot;
+            }
+        } catch (Exception e) {
+            logger.error("Error with get nodes updates: ", e);
+        }
+        logger.debug("Finished get node updates");
+    }
+
+    private Optional<List<V1Node>> listNodes() {
         long startTimeMs = clock.wallTime();
         V1NodeList list = null;
         try {
-            list = api.listNode(null, null, null, null, null, null, null, null, null);
+            list = normalApi.listNode(null, null, null, null, null, null, null, null, null);
             nodesClientMetrics.incrementOnSuccess(GET, NODES, STATUS_200);
         } catch (Exception e) {
             logger.error("Failed to list nodes with error:", e);
@@ -280,37 +386,33 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         } finally {
             nodesClientMetrics.registerLatency(GET, startTimeMs);
         }
-        if (list != null && !list.getItems().isEmpty()) {
-            final List<VMLeaseObject> leaseObjects = list.getItems().stream()
-                    .map(this::nodeToOffer)
-                    .filter(Objects::nonNull)
-                    .map(VMLeaseObject::new)
-                    .collect(Collectors.toList());
-            if (!leaseObjects.isEmpty()) {
-                vmLeaseRescindedObserver.onNext(LeaseRescindedEvent.allEvent());
-                leaseHandler.call(leaseObjects);
-            }
+        if (list != null) {
+            return Optional.of(new ArrayList<>(list.getItems()));
         }
+        return Optional.empty();
+    }
+
+    private VirtualMachineLease nodeToLease(V1Node node) {
+        Protos.Offer offer = nodeToOffer(node);
+        if (offer == null) {
+            return null;
+        }
+        return new VMLeaseObject(offer);
     }
 
     private Protos.Offer nodeToOffer(V1Node node) {
         try {
-            String offerId = UUID.randomUUID().toString();
             V1ObjectMeta metadata = node.getMetadata();
             V1NodeStatus status = node.getStatus();
+            String nodeName = metadata.getName();
             boolean hasTrueReadyCondition = status.getConditions().stream()
-                    .anyMatch(c -> c.getType().equalsIgnoreCase("Ready") && c.getStatus().equalsIgnoreCase("True"));
+                    .anyMatch(c -> c.getType().equalsIgnoreCase(READY) && Boolean.valueOf(c.getStatus()));
             if (hasTrueReadyCondition) {
-                String hostname = status.getAddresses().stream().filter(a -> a.getType().equals("InternalIP"))
-                        .findFirst()
-                        .map(V1NodeAddress::getAddress)
-                        .orElse("");
-
                 return Protos.Offer.newBuilder()
-                        .setId(Protos.OfferID.newBuilder().setValue(offerId).build())
-                        .setHostname(hostname)
+                        .setId(Protos.OfferID.newBuilder().setValue(nodeName).build())
+                        .setHostname(nodeName)
                         .setFrameworkId(Protos.FrameworkID.newBuilder().setValue("TitusFramework").build())
-                        .setSlaveId(Protos.SlaveID.newBuilder().setValue(metadata.getName()).build())
+                        .setSlaveId(Protos.SlaveID.newBuilder().setValue(nodeName).build())
                         .addAllResources(nodeToResources(node))
                         .addAllAttributes(nodeToAttributes(node))
                         .build();
@@ -357,11 +459,34 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
                 .build();
     }
 
-    private void pollForPods() {
+    private void getPodUpdates() {
+        try {
+            logger.debug("Creating list namespaced pod watch");
+            Watch<V1Pod> watch = Watch.createWatch(watchClient, watchApi.listNamespacedPodCall(
+                    KUBERNETES_NAMESPACE, null, null, null, null,
+                    null, null, null, null, true, null, null),
+                    new TypeToken<Watch.Response<V1Pod>>() {
+                    }.getType());
+            for (Watch.Response<V1Pod> item : watch) {
+                logger.debug("Received pod update with type: {}, object: {}", item.type, item.object);
+                V1Pod pod = item.object;
+                try {
+                    podUpdated(pod);
+                } catch (Exception e) {
+                    logger.error("Unable to handle pod update: {} with error:", pod, e);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error with pod watch: ", e);
+        }
+        logger.debug("Finished list namespaced pod watch");
+    }
+
+    private Optional<List<V1Pod>> listPods() {
         long startTimeMs = clock.wallTime();
         V1PodList list = null;
         try {
-            list = api.listNamespacedPod(KUBERNETES_NAMESPACE, null, null, null, null, null, null, null, null, null);
+            list = normalApi.listNamespacedPod(KUBERNETES_NAMESPACE, null, null, null, null, null, null, null, null, null);
             podsClientMetrics.incrementOnSuccess(GET, PODS, STATUS_200);
         } catch (Exception e) {
             logger.error("Failed to list pods with error: ", e);
@@ -369,29 +494,30 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         } finally {
             podsClientMetrics.registerLatency(GET, startTimeMs);
         }
-        if (list != null && !list.getItems().isEmpty()) {
-            for (V1Pod pod : list.getItems()) {
-                String taskId = pod.getMetadata().getName();
-                V1Pod lastPod = lastPodUpdate.getIfPresent(taskId);
-                if (!Objects.equals(pod, lastPod)) {
-                    try {
-                        podUpdated(pod);
-                    } catch (Exception ignored) {
-                    }
-                    lastPodUpdate.put(taskId, pod);
-                }
-            }
+        if (list != null) {
+            return Optional.of(new ArrayList<>(list.getItems()));
         }
+        return Optional.empty();
     }
 
     private void podUpdated(V1Pod pod) {
-        String taskId = pod.getMetadata().getName();
+        String podName = pod.getMetadata().getName();
+        V1Pod previousPod = lastPodUpdate.getIfPresent(podName);
+
         V1PodStatus status = pod.getStatus();
         String phase = status.getPhase();
+        String reason = status.getReason();
 
-        if (phase.equalsIgnoreCase("Pending")) {
-            publishContainerEvent(taskId, Launched, REASON_NORMAL, status.getReason(), Optional.empty());
-        } else if (phase.equalsIgnoreCase("Running")) {
+        if (previousPod != null && previousPod.getStatus().getPhase().equalsIgnoreCase(phase)) {
+            // ignore updates when the phases are the same
+            return;
+        }
+
+        lastPodUpdate.put(podName, pod);
+
+        if (phase.equalsIgnoreCase(PENDING)) {
+            publishContainerEvent(podName, Launched, REASON_NORMAL, reason, Optional.empty());
+        } else if (phase.equalsIgnoreCase(RUNNING) && pod.getMetadata().getDeletionTimestamp() == null) {
             TitusExecutorDetails titusExecutorDetails = new TitusExecutorDetails(
                     Collections.emptyMap(),
                     new TitusExecutorDetails.NetworkConfiguration(
@@ -402,12 +528,12 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
                             "unknownResourceId"
                     )
             );
-            publishContainerEvent(taskId, StartInitiated, REASON_NORMAL, status.getReason(), Optional.of(titusExecutorDetails));
-            publishContainerEvent(taskId, Started, REASON_NORMAL, status.getReason(), Optional.empty());
-        } else if (phase.equalsIgnoreCase("Succeeded")) {
-            publishContainerEvent(taskId, Finished, REASON_NORMAL, status.getReason(), Optional.empty());
-        } else if (phase.equalsIgnoreCase("Failed")) {
-            publishContainerEvent(taskId, Started, REASON_FAILED, status.getReason(), Optional.empty());
+            publishContainerEvent(podName, StartInitiated, REASON_NORMAL, reason, Optional.of(titusExecutorDetails));
+            publishContainerEvent(podName, Started, REASON_NORMAL, reason, Optional.empty());
+        } else if (phase.equalsIgnoreCase(SUCCEEDED)) {
+            publishContainerEvent(podName, Finished, REASON_NORMAL, reason, Optional.empty());
+        } else if (phase.equalsIgnoreCase(FAILED)) {
+            publishContainerEvent(podName, Finished, REASON_FAILED, reason, Optional.empty());
         }
     }
 
@@ -423,5 +549,161 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         );
         logger.debug("Publishing task status: {}", event);
         vmTaskStatusObserver.onNext(event);
+    }
+
+    private void reconcileNodesAndPods() {
+        Optional<List<V1Node>> nodesOpt = listNodes();
+        if (!nodesOpt.isPresent()) {
+            return;
+        }
+        List<V1Node> currentNodes = nodesOpt.get();
+        List<V1Node> nodesToGc = currentNodes.stream()
+                .filter(this::isNodeReadyForGc)
+                .collect(Collectors.toList());
+
+        // GC nodes that have timed out due to not publishing a heartbeat
+        logger.debug("Attempting to GC {} nodes", nodesToGc.size());
+        for (V1Node node : nodesToGc) {
+            gcNode(node);
+        }
+        logger.debug("Finished node GC");
+
+        Map<String, Task> currentTasks = v3JobOperations.getTasks().stream().collect(Collectors.toMap(Task::getId, Function.identity()));
+        Optional<List<V1Pod>> podsOpt = listPods();
+        if (!podsOpt.isPresent()) {
+            return;
+        }
+        List<V1Pod> currentPods = podsOpt.get();
+        List<V1Pod> terminalPodsToGc = currentPods.stream()
+                .filter(p -> {
+                    Task task = currentTasks.get(p.getMetadata().getName());
+                    if (task != null) {
+                        return TaskState.isTerminalState(task.getStatus().getState());
+                    }
+                    return isPodNotRunning(p);
+                })
+                .collect(Collectors.toList());
+
+        // GC pods that have been persisted in Titus and are in a terminal state
+        logger.debug("Attempting to GC {} terminal pods", terminalPodsToGc.size());
+        for (V1Pod pod : terminalPodsToGc) {
+            gcPod(pod);
+        }
+        logger.debug("Finished terminal pod GC");
+
+        Set<String> currentNodesNames = currentNodes.stream().map(n -> n.getMetadata().getName()).collect(Collectors.toSet());
+        List<V1Pod> orphanedPodsToGc = currentPods.stream()
+                .filter(p -> {
+                    String nodeName = p.getSpec().getNodeName();
+                    return StringExt.isNotEmpty(nodeName) && !currentNodesNames.contains(nodeName);
+                })
+                .collect(Collectors.toList());
+
+        // GC orphaned pods on nodes that are no longer available
+        logger.debug("Attempting to GC {} orphaned pods without valid nodes", orphanedPodsToGc.size());
+        for (V1Pod pod : orphanedPodsToGc) {
+            gcPod(pod);
+        }
+        logger.debug("Finished orphaned pod GC without valid nodes");
+
+        Set<String> currentPodNames = currentPods.stream().map(p -> p.getMetadata().getName()).collect(Collectors.toSet());
+        Set<String> currentTaskIds = currentTasks.keySet();
+        List<V1Pod> podsStuckBeingDeleted = currentPods.stream()
+                .filter(pod -> {
+                    String podName = pod.getMetadata().getName();
+                    DateTime deletionTimestamp = pod.getMetadata().getDeletionTimestamp();
+                    return clock.isPast(deletionTimestamp.getMillis() + POD_GC_DELETION_TTL) &&
+                            !currentTaskIds.contains(podName);
+                })
+                .collect(Collectors.toList());
+
+        // GC orphaned pods that stuck being deleted
+        logger.debug("Attempting to GC {} orphaned pods not in Titus", podsStuckBeingDeleted.size());
+        for (V1Pod pod : podsStuckBeingDeleted) {
+            gcPod(pod);
+        }
+        logger.debug("Finished orphaned pod GC not in Titus");
+
+
+        List<Task> tasksNotInApiServer = currentTasks.values().stream()
+                .filter(t -> TaskState.isRunning(t.getStatus().getState()) && !currentPodNames.contains(t.getId()))
+                .collect(Collectors.toList());
+
+        // Transition orphaned tasks to Finished that don't exist in Kubernetes
+        logger.debug("Attempting to transition {} orphaned tasks", tasksNotInApiServer.size());
+        for (Task task : tasksNotInApiServer) {
+            publishContainerEvent(task.getId(), Finished, REASON_TASK_LOST, "Inconsistency between control plane and machine", Optional.empty());
+        }
+        logger.debug("Finished orphaned tasks transitions");
+    }
+
+    private void gcNode(V1Node node) {
+        String nodeName = node.getMetadata().getName();
+        long startTimeMs = clock.wallTime();
+        try {
+            normalApi.deleteNode(nodeName, null, null, null, 0, null, "Background");
+            nodesClientMetrics.incrementOnSuccess(DELETE, NODES, STATUS_200);
+        } catch (JsonSyntaxException e) {
+            // this is probably successful. the generated client has the wrong response type
+            nodesClientMetrics.incrementOnSuccess(DELETE, NODES, STATUS_200);
+        } catch (ApiException e) {
+            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+                logger.error("Failed to delete node: {} with error: ", nodeName, e);
+                nodesClientMetrics.incrementOnError(DELETE, NODES, e);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to delete node: {} with error: ", nodeName, e);
+            nodesClientMetrics.incrementOnError(DELETE, NODES, e);
+        } finally {
+            nodesClientMetrics.registerLatency(DELETE, startTimeMs);
+        }
+    }
+
+    private boolean isNodeReadyForGc(V1Node node) {
+        Optional<V1NodeCondition> stoppedConditionOpt = node.getStatus().getConditions().stream()
+                .filter(c -> c.getType().equalsIgnoreCase(STOPPED) && Boolean.valueOf(c.getStatus()))
+                .findAny();
+        if (stoppedConditionOpt.isPresent()) {
+            return true;
+        }
+
+        Optional<V1NodeCondition> readyConditionOpt = node.getStatus().getConditions().stream()
+                .filter(c -> c.getType().equalsIgnoreCase(READY))
+                .findAny();
+        if (!readyConditionOpt.isPresent()) {
+            return false;
+        }
+        V1NodeCondition readyCondition = readyConditionOpt.get();
+        Boolean status = Boolean.valueOf(readyCondition.getStatus());
+        DateTime lastHeartbeatTime = readyCondition.getLastHeartbeatTime();
+        return !status &&
+                lastHeartbeatTime != null &&
+                clock.isPast(lastHeartbeatTime.getMillis() + NODE_GC_TTL_MS);
+    }
+
+    private boolean isPodNotRunning(V1Pod pod) {
+        return !pod.getStatus().getPhase().equalsIgnoreCase(RUNNING);
+    }
+
+    private void gcPod(V1Pod pod) {
+        String podName = pod.getMetadata().getName();
+        long startTimeMs = clock.wallTime();
+        try {
+            normalApi.deleteNamespacedPod(podName, KUBERNETES_NAMESPACE, null, null, null, 0, null, "Background");
+            podsClientMetrics.incrementOnSuccess(DELETE, PODS, STATUS_200);
+        } catch (JsonSyntaxException e) {
+            // this is probably successful. the generated client has the wrong response type
+            podsClientMetrics.incrementOnSuccess(DELETE, PODS, STATUS_200);
+        } catch (ApiException e) {
+            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+                logger.error("Failed to delete pod: {} with error: ", podName, e);
+                podsClientMetrics.incrementOnError(DELETE, PODS, e);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to delete pod: {} with error: ", podName, e);
+            podsClientMetrics.incrementOnError(DELETE, PODS, e);
+        } finally {
+            podsClientMetrics.registerLatency(DELETE, startTimeMs);
+        }
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/Snapshot.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/Snapshot.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+/**
+ * Utility class that makes creating a snapshot of data at a certain point in time easier.
+ */
+public class Snapshot<T> {
+
+    private static final Snapshot EMPTY_SNAPSHOT = new Snapshot<>(Collections.emptyList(), 0);
+
+    private final List<T> items;
+    private final long timestamp;
+
+    private Snapshot(Collection<T> collection, long timestamp) {
+        items = new ArrayList<>(collection);
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Create new snapshot
+     */
+    public static <T> Snapshot<T> newSnapshot(Collection<T> collection, long timestamp) {
+        return new Snapshot<>(collection, timestamp);
+    }
+
+    /**
+     * Get empty snapshot. Note that the empty snapshot has of timestamp of 0.
+     */
+    public static <T> Snapshot<T> emptySnapshot() {
+        return EMPTY_SNAPSHOT;
+    }
+
+    /**
+     * Get the items in this snapshot.
+     */
+    public List<T> getItems() {
+        return Collections.unmodifiableList(items);
+    }
+
+    /**
+     * Get the timestamp of this snapshot.
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Compare this snapshot with another snapshot. Note that the passed in snapshot is considered to be the first snapshot
+     * when doing the comparison.
+     */
+    public SnapshotComparison<T> compare(Snapshot<T> snapshot, Function<T, String> identityFn, BiPredicate<T, T> equalFn) {
+        return SnapshotComparison.compare(snapshot, this, identityFn, equalFn);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/SnapshotComparison.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/SnapshotComparison.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.netflix.titus.common.util.CollectionsExt;
+
+public class SnapshotComparison<T> {
+    private final List<T> added;
+    private final List<T> removed;
+    private final List<T> modified;
+    private final List<T> unmodified;
+
+    private SnapshotComparison(List<T> added, List<T> removed, List<T> modified, List<T> unmodified) {
+        this.added = added;
+        this.removed = removed;
+        this.modified = modified;
+        this.unmodified = unmodified;
+    }
+
+    public static <T> SnapshotComparison<T> compare(Snapshot<T> first, Snapshot<T> second, Function<T, String> identityFn, BiPredicate<T, T> equalFn) {
+        List<T> firstSnapshotItems = first.getItems();
+        List<T> secondSnapshotItems = second.getItems();
+        Map<String, T> firstItemsMap = firstSnapshotItems.stream().collect(Collectors.toMap(identityFn, Function.identity()));
+        Map<String, T> secondItemsMap = secondSnapshotItems.stream().collect(Collectors.toMap(identityFn, Function.identity()));
+
+        Set<String> firstSnapshotIds = firstItemsMap.keySet();
+        Set<String> secondSnapshotIds = secondItemsMap.keySet();
+        Set<String> addedIds = CollectionsExt.copyAndRemove(secondSnapshotIds, firstSnapshotIds);
+        Set<String> removedIds = CollectionsExt.copyAndRemove(firstSnapshotIds, secondSnapshotIds);
+        Set<String> sameIds = new HashSet<>(firstSnapshotIds);
+        sameIds.retainAll(secondSnapshotIds);
+
+        List<T> addedItems = addedIds.stream()
+                .map(secondItemsMap::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        List<T> removedItems = removedIds.stream().
+                map(firstItemsMap::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        List<T> modifiedItems = new ArrayList<>();
+        List<T> unmodifiedItems = new ArrayList<>();
+
+        for (String id : sameIds) {
+            T firstItem = firstItemsMap.get(id);
+            T secondItem = firstItemsMap.get(id);
+            if (equalFn.test(firstItem, secondItem)) {
+                unmodifiedItems.add(secondItem);
+            } else {
+                modifiedItems.add(secondItem);
+            }
+        }
+        return new SnapshotComparison<>(addedItems, removedItems, modifiedItems, unmodifiedItems);
+    }
+
+    public List<T> getAdded() {
+        return added;
+    }
+
+    public List<T> getRemoved() {
+        return removed;
+    }
+
+    public List<T> getModified() {
+        return modified;
+    }
+
+    public List<T> getUnmodified() {
+        return unmodified;
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -79,6 +79,7 @@ import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.config.MasterConfiguration;
 import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.mesos.LeaseRescindedEvent;
+import com.netflix.titus.master.mesos.MesosConfiguration;
 import com.netflix.titus.master.mesos.TaskInfoFactory;
 import com.netflix.titus.master.mesos.VirtualMachineMasterService;
 import com.netflix.titus.master.model.job.TitusQueuableTask;
@@ -120,6 +121,7 @@ public class DefaultSchedulingService implements SchedulingService {
     private final V3JobOperations v3JobOperations;
     private final VMOperations vmOps;
     private final Optional<FitInjection> fitInjection;
+    private final MesosConfiguration mesosConfiguration;
     private TaskScheduler taskScheduler;
     private final TaskSchedulingService schedulingService;
     private TaskQueue taskQueue;
@@ -195,14 +197,15 @@ public class DefaultSchedulingService implements SchedulingService {
                                     TaskMigrator taskMigrator,
                                     TitusRuntime titusRuntime,
                                     AgentResourceCache agentResourceCache,
-                                    Config config) {
+                                    Config config,
+                                    MesosConfiguration mesosConfiguration) {
         this(v3JobOperations, agentManagementService, v3TaskInfoFactory, vmOps,
                 virtualMachineService, masterConfiguration, schedulerConfiguration,
                 systemHardConstraint, taskCache,
                 Schedulers.computation(),
                 tierSlaUpdater, registry,
                 preferentialNamedConsumableResourceEvaluator, agentManagementFitnessCalculator,
-                taskMigrator, titusRuntime, agentResourceCache, config
+                taskMigrator, titusRuntime, agentResourceCache, config, mesosConfiguration
         );
     }
 
@@ -223,7 +226,8 @@ public class DefaultSchedulingService implements SchedulingService {
                                     TaskMigrator taskMigrator,
                                     TitusRuntime titusRuntime,
                                     AgentResourceCache agentResourceCache,
-                                    Config config) {
+                                    Config config,
+                                    MesosConfiguration mesosConfiguration) {
         this.v3JobOperations = v3JobOperations;
         this.agentManagementService = agentManagementService;
         this.vmOps = vmOps;
@@ -237,6 +241,7 @@ public class DefaultSchedulingService implements SchedulingService {
         this.titusRuntime = titusRuntime;
         this.agentResourceCache = agentResourceCache;
         this.systemHardConstraint = systemHardConstraint;
+        this.mesosConfiguration = mesosConfiguration;
         agentResourceCacheUpdater = new AgentResourceCacheUpdater(titusRuntime, agentResourceCache, v3JobOperations);
 
         FitFramework fit = titusRuntime.getFitFramework();
@@ -264,6 +269,18 @@ public class DefaultSchedulingService implements SchedulingService {
         taskQueue = TaskQueues.createTieredQueue(2);
         schedulingService = setupTaskSchedulingService(taskScheduler);
         virtualMachineService.setVMLeaseHandler(schedulingService::addLeases);
+        virtualMachineService.setRescindLeaseHandler(leaseRescindedEvents -> {
+            for (LeaseRescindedEvent event : leaseRescindedEvents) {
+                switch (event.getType()) {
+                    case All:
+                        taskScheduler.expireAllLeases();
+                        break;
+                    case LeaseId:
+                        taskScheduler.expireLease(event.getValue());
+                        break;
+                }
+            }
+        });
         this.taskCache = taskCache;
 
         this.taskPlacementRecorder = new TaskPlacementRecorder(config, masterConfiguration, schedulingService, v3JobOperations, v3TaskInfoFactory, titusRuntime);
@@ -354,7 +371,9 @@ public class DefaultSchedulingService implements SchedulingService {
     private TaskScheduler setupTaskScheduler(Observable<LeaseRescindedEvent> vmLeaseRescindedObservable,
                                              TaskScheduler.Builder schedulerBuilder) {
         int minMinIdle = 4;
-        final TaskScheduler scheduler = schedulerBuilder.withMaxOffersToReject(Math.max(1, minMinIdle)).build();
+        final TaskScheduler scheduler = schedulerBuilder.withMaxOffersToReject(Math.max(1, minMinIdle))
+                .withSingleOfferPerVM(mesosConfiguration.isKubeApiServerIntegrationEnabled())
+                .build();
         vmLeaseRescindedObservable
                 .doOnNext(event -> {
                     switch (event.getType()) {
@@ -363,9 +382,6 @@ public class DefaultSchedulingService implements SchedulingService {
                             break;
                         case LeaseId:
                             scheduler.expireLease(event.getValue());
-                            break;
-                        case Hostname:
-                            scheduler.expireAllLeases(event.getValue());
                             break;
                     }
                 })

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementAttributes.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementAttributes.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.titus.master.service.management;
 
 /**

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementFunctions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/CapacityManagementFunctions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.titus.master.service.management;
 
 import java.util.Map;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
@@ -28,10 +28,10 @@ import com.netflix.fenzo.functions.Action1;
 import com.netflix.titus.api.json.ObjectMappers;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.tuple.Pair;
-import com.netflix.titus.master.mesos.LeaseRescindedEvent;
-import com.netflix.titus.master.mesos.VirtualMachineMasterService;
 import com.netflix.titus.master.mesos.ContainerEvent;
+import com.netflix.titus.master.mesos.LeaseRescindedEvent;
 import com.netflix.titus.master.mesos.TitusExecutorDetails;
+import com.netflix.titus.master.mesos.VirtualMachineMasterService;
 import org.apache.mesos.Protos;
 import rx.Observable;
 import rx.subjects.PublishSubject;
@@ -162,6 +162,11 @@ class StubbedVirtualMachineMasterService implements VirtualMachineMasterService 
 
     @Override
     public void setVMLeaseHandler(Action1<List<? extends VirtualMachineLease>> leaseHandler) {
+        throw new IllegalStateException("method not supported");
+    }
+
+    @Override
+    public void setRescindLeaseHandler(Action1<List<LeaseRescindedEvent>> rescindLeaseHandler) {
         throw new IllegalStateException("method not supported");
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/SnapshotTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/SnapshotTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SnapshotTest {
+
+    @Test
+    public void compareTest() {
+        // compare overlapping integer sequence and verify results
+        Snapshot<Integer> firstSnapshot = Snapshot.newSnapshot(Arrays.asList(1, 2, 3, 4), 0);
+        Snapshot<Integer> secondSnapshot = Snapshot.newSnapshot(Arrays.asList(3, 4, 5, 6), 0);
+        SnapshotComparison<Integer> result = secondSnapshot.compare(firstSnapshot, Object::toString, (first, second) -> first.equals(second) && first == 4);
+
+        assertThat(result.getRemoved()).containsOnly(1, 2);
+        assertThat(result.getAdded()).containsOnly(5, 6);
+        assertThat(result.getModified()).containsOnly(3);
+        assertThat(result.getUnmodified()).containsOnly(4);
+    }
+}


### PR DESCRIPTION
### Description of the Change
Update the experimental k8s integration to create snapshots of nodes and compare them to manage fenzo leases.

A simulated kubernetes api-server will be added in a future PR in order to be able to perform integration tests against this integration.

