### PR TITLE
Run admission control after basic entity validations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,9 @@ subprojects {
         testLogging {
             events "failed"
             exceptionFormat "full"
+            showExceptions true
+            showStackTraces true
+            showCauses true
         }
     }
 
@@ -177,6 +180,9 @@ subprojects {
         testLogging {
             events "failed"
             exceptionFormat "full"
+            showExceptions true
+            showStackTraces true
+            showCauses true
         }
     }
 
@@ -193,6 +199,9 @@ subprojects {
         testLogging {
             events "failed"
             exceptionFormat "full"
+            showExceptions true
+            showStackTraces true
+            showCauses true
         }
     }
 
@@ -201,7 +210,7 @@ subprojects {
         dependsOn 'integrationTest'
         dependsOn 'integrationNotParallelizableTest'
         tasks.findByName('integrationTest').mustRunAfter 'test'
-        tasks.findByName('integrationNotParallelizableTest').mustRunAfter 'integrationTest'
+        tasks.findByName('integrationNotParallelizableTest').mustRunAfter 'test'
     }
 }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
@@ -24,7 +24,6 @@ import com.netflix.titus.grpc.protogen.JobAttributesDeleteRequest;
 import com.netflix.titus.grpc.protogen.JobAttributesUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
-import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
 import com.netflix.titus.grpc.protogen.JobDisruptionBudgetUpdate;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
@@ -88,8 +88,7 @@ public class SanitizingJobServiceGateway extends JobServiceGatewayDelegate {
                             }
                         })
                 )
-                .flatMap(jd -> delegate.createJob(V3GrpcModelConverters.toGrpcJobDescriptor(sanitizedCoreJobDescriptor),
-                        callMetadata));
+                .flatMap(jd -> delegate.createJob(V3GrpcModelConverters.toGrpcJobDescriptor(jd), callMetadata));
     }
 
     @Override

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
@@ -17,11 +17,12 @@
 package com.netflix.titus.runtime.jobmanager.gateway;
 
 import java.util.Set;
-import javax.inject.Named;
+import java.util.stream.Collectors;
 
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
 import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
@@ -29,42 +30,66 @@ import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
+import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
+import com.netflix.titus.runtime.endpoint.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.v3.grpc.V3GrpcModelConverters;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
-import static com.netflix.titus.api.jobmanager.model.job.sanitizer.JobSanitizerBuilder.JOB_STRICT_SANITIZER;
+import static com.netflix.titus.common.util.rx.ReactorExt.toObservable;
 
 public class SanitizingJobServiceGateway extends JobServiceGatewayDelegate {
 
     private final JobServiceGateway delegate;
     private final EntitySanitizer entitySanitizer;
+    private final AdmissionValidator<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> admissionValidator;
+    private final AdmissionSanitizer<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> admissionSanitizer;
 
     public SanitizingJobServiceGateway(JobServiceGateway delegate,
-                                       @Named(JOB_STRICT_SANITIZER) EntitySanitizer entitySanitizer) {
+                                       EntitySanitizer entitySanitizer,
+                                       AdmissionValidator<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> validator,
+                                       AdmissionSanitizer<com.netflix.titus.api.jobmanager.model.job.JobDescriptor> sanitizer) {
         super(delegate);
         this.delegate = delegate;
         this.entitySanitizer = entitySanitizer;
+        this.admissionValidator = validator;
+        this.admissionSanitizer = sanitizer;
     }
 
     @Override
     public Observable<String> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata) {
         com.netflix.titus.api.jobmanager.model.job.JobDescriptor coreJobDescriptor;
         try {
-            coreJobDescriptor = V3GrpcModelConverters.toCoreJobDescriptor(jobDescriptor);
+            coreJobDescriptor = JobFunctions.filterOutSanitizationAttributes(V3GrpcModelConverters.toCoreJobDescriptor(jobDescriptor));
         } catch (Exception e) {
             return Observable.error(TitusServiceException.invalidArgument(e));
         }
-        com.netflix.titus.api.jobmanager.model.job.JobDescriptor sanitizedCoreJobDescriptor = entitySanitizer.sanitize(coreJobDescriptor).orElse(coreJobDescriptor);
 
+        // basic entity validations based on class/field constraints
+        com.netflix.titus.api.jobmanager.model.job.JobDescriptor sanitizedCoreJobDescriptor = entitySanitizer.sanitize(coreJobDescriptor).orElse(coreJobDescriptor);
         Set<ValidationError> violations = entitySanitizer.validate(sanitizedCoreJobDescriptor);
         if (!violations.isEmpty()) {
             return Observable.error(TitusServiceException.invalidArgument(violations));
         }
 
-        JobDescriptor effectiveJobDescriptor = V3GrpcModelConverters.toGrpcJobDescriptor(sanitizedCoreJobDescriptor);
-
-        return delegate.createJob(effectiveJobDescriptor, callMetadata);
+        // validations that need external data
+        return toObservable(admissionSanitizer.sanitizeAndApply(sanitizedCoreJobDescriptor)
+                .switchIfEmpty(Mono.just(sanitizedCoreJobDescriptor)))
+                .onErrorResumeNext(throwable -> Observable.error(TitusServiceException.invalidArgument(throwable)))
+                .flatMap(jd -> toObservable(admissionValidator.validate(jd))
+                        .flatMap(errors -> {
+                            // Only emit an error on HARD validation errors
+                            errors = errors.stream().filter(ValidationError::isHard).collect(Collectors.toSet());
+                            if (!errors.isEmpty()) {
+                                return Observable.error(TitusServiceException.invalidJob(errors));
+                            } else {
+                                return Observable.just(jd);
+                            }
+                        })
+                )
+                .flatMap(jd -> delegate.createJob(V3GrpcModelConverters.toGrpcJobDescriptor(sanitizedCoreJobDescriptor),
+                        callMetadata));
     }
 
     @Override


### PR DESCRIPTION
That way we avoid expensive validation/sanitization calls for obvious invalid payloads.