### PR TITLE
Add API validations for IP allocations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ subprojects {
         okHttpVersion = '3.8.0'
         cassandraDriverVersion = '3.3.+'
         commonsCliVersion = '1.3.+'
+        commonsCodecVersion = '1.13'
         caffeineVersion = '2.6.+'
         rxJavaInteropVersion = '0.13.+'
         kubernetesClientVersion = '5.0.0'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,10 @@ import com.netflix.titus.common.util.CollectionsExt;
 /**
  */
 @ClassFieldsNotNull
-@ClassInvariant(expr = "@asserts.notExceedsComputeResources(capacityGroup, container)", mode = VerifierMode.Strict)
+@ClassInvariant.List({
+        @ClassInvariant(expr = "@asserts.notExceedsComputeResources(capacityGroup, container)", mode = VerifierMode.Strict),
+        @ClassInvariant(expr = "@asserts.notExceedsIpAllocations(container, extensions)", mode = VerifierMode.Strict)
+})
 public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
 
     private static final DisruptionBudget DEFAULT_DISRUPTION_BUDGET = DisruptionBudget.newBuilder()

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/SignedIpAddressAllocation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/SignedIpAddressAllocation.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import com.netflix.titus.common.model.sanitizer.ClassFieldsNotNull;
+import com.netflix.titus.common.model.sanitizer.FieldInvariant;
 
 @ClassFieldsNotNull
 public class SignedIpAddressAllocation {
@@ -28,6 +29,10 @@ public class SignedIpAddressAllocation {
     @Valid
     private final IpAddressAllocation ipAddressAllocation;
 
+    @FieldInvariant(
+            value = "@asserts.isBase64(value)",
+            message = "IP Address Signature is NOT base64 encoded"
+    )
     private final byte[] ipAddressAllocationSignature;
 
     public SignedIpAddressAllocation(IpAddressAllocation ipAddressAllocation, byte[] ipAddressAllocationSignature) {
@@ -71,10 +76,19 @@ public class SignedIpAddressAllocation {
                 '}';
     }
 
+    public Builder toBuilder() {
+        return newBuilder(this);
+    }
+
     public static Builder newBuilder() {
         return new Builder();
     }
 
+    public static Builder newBuilder(SignedIpAddressAllocation signedIpAddressAllocation) {
+        return new Builder()
+                .withIpAddressAllocation(signedIpAddressAllocation.getIpAddressAllocation())
+                .withIpAddressAllocationSignature(signedIpAddressAllocation.ipAddressAllocationSignature);
+    }
 
     public static final class Builder {
         private IpAddressAllocation ipAddressAllocation;

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/JobManagerException.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/JobManagerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ public class JobManagerException extends RuntimeException {
         TaskTerminating,
         InvalidContainerResources,
         InvalidDesiredCapacity,
+        InvalidMaxCapacity,
         BelowMinCapacity,
         AboveMaxCapacity,
         SameJobIds,
@@ -90,6 +91,7 @@ public class JobManagerException extends RuntimeException {
             case TaskTerminating:
             case InvalidContainerResources:
             case InvalidDesiredCapacity:
+            case InvalidMaxCapacity:
             case BelowMinCapacity:
             case AboveMaxCapacity:
             case SameJobIds:
@@ -179,6 +181,14 @@ public class JobManagerException extends RuntimeException {
                 ErrorCode.InvalidDesiredCapacity,
                 format("Job %s can not be updated to desired capacity of %s, disableIncreaseDesired %s, disableDecreaseDesired %s",
                         jobId, targetDesired, serviceJobProcesses.isDisableIncreaseDesired(), serviceJobProcesses.isDisableDecreaseDesired())
+        );
+    }
+
+    public static JobManagerException invalidMaxCapacity(String jobId, int targetMax, int ipAllocations) {
+        return new JobManagerException(
+                ErrorCode.InvalidMaxCapacity,
+                format("Job %s can not be updated to max capacity of %d due to only %d IP allocations",
+                        jobId, targetMax, ipAllocations)
         );
     }
 

--- a/titus-common/build.gradle
+++ b/titus-common/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     compile "javax.servlet:javax.servlet-api:${servletVersion}"
     compile "javax.ws.rs:jsr311-api:1.1.1"
+    compile "commons-codec:commons-codec:${commonsCodecVersion}"
 
     // Java Bean validation/EL and SpEL
     compile "javax.el:javax.el-api:${javaxElVersion}"

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobTestUtils.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobTestUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.integration.v3.job;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.rpc.BadRequest;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
+import com.netflix.titus.testkit.grpc.GrpcClientErrorUtils;
+import io.grpc.StatusRuntimeException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class JobTestUtils {
+
+    public static void submitBadJob(JobManagementServiceGrpc.JobManagementServiceBlockingStub client,
+                                     JobDescriptor badJobDescriptor,
+                                     String... expectedFields) {
+        Set<String> expectedFieldSet = new HashSet<>();
+        Collections.addAll(expectedFieldSet, expectedFields);
+
+        try {
+            client.createJob(badJobDescriptor).getId();
+            fail("Expected test to fail");
+        } catch (StatusRuntimeException e) {
+            System.out.println("Received StatusRuntimeException: " + e.getMessage());
+
+            Optional<BadRequest> badRequestOpt = GrpcClientErrorUtils.getDetail(e, BadRequest.class);
+
+            // Print validation messages for visual inspection
+            badRequestOpt.ifPresent(System.out::println);
+
+            Set<String> badFields = badRequestOpt.map(badRequest ->
+                    badRequest.getFieldViolationsList().stream().map(BadRequest.FieldViolation::getField).collect(Collectors.toSet())
+            ).orElse(Collections.emptySet());
+
+            assertThat(badFields).containsAll(expectedFieldSet);
+            assertThat(badFields.size()).isEqualTo(expectedFieldSet.size());
+        }
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/TitusExceptionMapper.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/TitusExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,6 +230,7 @@ public class TitusExceptionMapper implements ExceptionMapper<Throwable> {
                 break;
             case InvalidContainerResources:
             case InvalidDesiredCapacity:
+            case InvalidMaxCapacity:
             case NotServiceJob:
             case NotServiceJobDescriptor:
             case NotBatchJob:

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,6 +175,7 @@ public final class ErrorResponses {
                     return Status.PERMISSION_DENIED;
                 case InvalidContainerResources:
                 case InvalidDesiredCapacity:
+                case InvalidMaxCapacity:
                 case NotServiceJob:
                 case NotServiceJobDescriptor:
                 case NotBatchJob:


### PR DESCRIPTION
This PR adds two validations for IP allocations:

- Check that provided IP allocations signatures are Base64 encoded.
- Check that jobs cannot be created or updated with a max or size greater than their number of IP allocations.