### PR TITLE
Retrieve network metadata from pod updates

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -523,11 +523,11 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
             TitusExecutorDetails titusExecutorDetails = new TitusExecutorDetails(
                     Collections.emptyMap(),
                     new TitusExecutorDetails.NetworkConfiguration(
-                            true,
+                            Boolean.valueOf(pod.getMetadata().getAnnotations().getOrDefault("IsRoutableIp", "true")),
                             status.getPodIP(),
-                            "UnknownEniIpAddress",
-                            "unknownEniId",
-                            "unknownResourceId"
+                            pod.getMetadata().getAnnotations().getOrDefault("EniIpAddress", "UnknownEniIpAddress"),
+                            pod.getMetadata().getAnnotations().getOrDefault("EniId", "UnknownEniId"),
+                            pod.getMetadata().getAnnotations().getOrDefault("ResourceId", "UnknownResourceId")
                     )
             );
             publishContainerEvent(podName, StartInitiated, REASON_NORMAL, reason, Optional.of(titusExecutorDetails));


### PR DESCRIPTION
Relevant network metadata is now provided in pod annotations. 