### PR TITLE
Pass task IP allocation to agent and es publisher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.1-rc65'
+        titusApiDefinitionsVersion = '0.0.1-rc66'
 
         awsSdkVersion = '1.11.+'
         javaxElVersion = '3.+'

--- a/titus-ext/aws/dependencies.lock
+++ b/titus-ext/aws/dependencies.lock
@@ -7,7 +7,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -34,7 +34,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -1286,7 +1286,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -1313,7 +1313,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -2565,7 +2565,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -2592,7 +2592,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -3908,7 +3908,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -3935,7 +3935,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -5188,7 +5188,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -5215,7 +5215,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -6486,7 +6486,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -6513,7 +6513,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -8591,7 +8591,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -8618,7 +8618,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -10696,7 +10696,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -10723,7 +10723,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
@@ -12802,7 +12802,7 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
@@ -12829,7 +12829,7 @@
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.605",
+            "locked": "1.11.606",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {

--- a/titus-grpc-api/dependencies.lock
+++ b/titus-grpc-api/dependencies.lock
@@ -375,8 +375,8 @@
     },
     "protobuf": {
         "com.netflix.titus:titus-api-definitions": {
-            "locked": "0.0.1-rc65",
-            "requested": "0.0.1-rc65"
+            "locked": "0.0.1-rc66",
+            "requested": "0.0.1-rc66"
         }
     },
     "protobufToolsLocator_grpc": {

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskDocument.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskDocument.java
@@ -48,6 +48,7 @@ import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AG
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_REGION;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_IP_ALLOCATION_ID;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_NETWORK_INTERFACE_ID;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_NETWORK_INTERFACE_INDEX;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TIER;
@@ -99,6 +100,7 @@ public class TaskDocument {
     private double disk;
     private int gpu;
     private int shm;
+    private String ipAddressAllocationId;
     private Map<String, String> env;
     private int retries;
     private boolean restartOnSuccess;
@@ -193,6 +195,10 @@ public class TaskDocument {
 
     public int getShm() {
         return shm;
+    }
+
+    public String getIpAddressAllocationId() {
+        return ipAddressAllocationId;
     }
 
     public int getGpu() {
@@ -472,6 +478,11 @@ public class TaskDocument {
         final String instanceId = taskContext.get(TASK_ATTRIBUTES_AGENT_ID);
         if (instanceId != null) {
             taskDocument.hostInstanceId = instanceId;
+        }
+
+        final String ipAddressAllocationId = taskContext.get(TASK_ATTRIBUTES_IP_ALLOCATION_ID);
+        if (ipAddressAllocationId != null) {
+            taskDocument.ipAddressAllocationId = ipAddressAllocationId;
         }
 
         extractNetworkConfigurationData(taskContext, taskDocument);


### PR DESCRIPTION
Companion PR: https://github.com/Netflix/titus-api-definitions/pull/105

This PR sets IP allocation ID info in the ES task document and Agent proto, if available.