### PR TITLE
blockingStub is maybe having concurrency issues

### DIFF
--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/integration/TaskRelocationIntegrationTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/integration/TaskRelocationIntegrationTest.java
@@ -149,11 +149,9 @@ public class TaskRelocationIntegrationTest {
             client.getTaskRelocationResult(RelocationTaskId.newBuilder().setId(taskId).build(), events);
             return Optional.of(events.getLast().getTaskRelocationPlan());
         } catch (Exception e) {
-            if (e instanceof StatusRuntimeException) {
-                StatusRuntimeException se = (StatusRuntimeException) e;
-                if (se.getStatus().getCode() == Status.Code.NOT_FOUND) {
-                    return Optional.empty();
-                }
+            Status status = Status.fromThrowable(e);
+            if (status.getCode() == Status.Code.NOT_FOUND) {
+                return Optional.empty();
             }
             throw new RuntimeException(e);
         }
@@ -165,11 +163,9 @@ public class TaskRelocationIntegrationTest {
             client.getTaskRelocationResult(RelocationTaskId.newBuilder().setId(taskId).build(), events);
             return Optional.of(last(events.getLast().getRelocationAttemptsList()));
         } catch (Exception e) {
-            if (e instanceof StatusRuntimeException) {
-                StatusRuntimeException se = (StatusRuntimeException) e;
-                if (se.getStatus().getCode() == Status.Code.NOT_FOUND) {
-                    return Optional.empty();
-                }
+            Status status = Status.fromThrowable(e);
+            if (status.getCode() == Status.Code.NOT_FOUND) {
+                return Optional.empty();
             }
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
it looks like it occasionally throws `InvocationTargetException` when running with parallel gradle tasks on CircleCI.

This is a somewhat desperate attempt to solve flakiness in tests, e.g.: https://circleci.com/gh/Netflix/titus-control-plane/339. It seems the `InvocationTargetException` comes from deep layers of gRPC code, but unfortunately the `BlockingStubs` are destroying the exception stacktraces at https://github.com/grpc/grpc-java/blob/v1.10.1/stub/src/main/java/io/grpc/stub/ClientCalls.java#L221

If anything, this change will hopefully allow us to find the underlying issue more easily.