### PR TITLE
Attempt #2 on reducing TaskRelocation test flakiness

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/server/AbstractMethodHandler.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/common/reactor/server/AbstractMethodHandler.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.runtime.connector.common.reactor.server;
 
+import java.lang.reflect.InvocationTargetException;
+
 import com.netflix.titus.api.jobmanager.model.CallMetadata;
 import com.netflix.titus.api.jobmanager.service.JobManagerConstants;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
@@ -70,6 +72,9 @@ abstract class AbstractMethodHandler<REQ, RESP> {
         Publisher<RESP> result;
         try {
             result = (Publisher<RESP>) binding.getReactorMethod().invoke(reactorService, args);
+        } catch (InvocationTargetException e) {
+            responseObserver.onError(e.getCause());
+            return;
         } catch (Exception e) {
             responseObserver.onError(e);
             return;

--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/integration/TaskRelocationIntegrationTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/integration/TaskRelocationIntegrationTest.java
@@ -43,7 +43,6 @@ import com.netflix.titus.supplementary.relocation.TestDataFactory;
 import com.netflix.titus.testkit.grpc.TestStreamObserver;
 import com.netflix.titus.testkit.junit.category.IntegrationTest;
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -132,7 +131,7 @@ public class TaskRelocationIntegrationTest {
             client.getCurrentTaskRelocationPlans(TaskRelocationQuery.getDefaultInstance(), events);
             plans = events.getLast();
         } catch (Exception e) {
-            if (e instanceof StatusRuntimeException && e.getMessage().contains("Relocation workflow not ready yet")) {
+            if (e.getMessage().contains("Relocation workflow not ready yet")) {
                 return Optional.empty();
             }
             throw new RuntimeException(e);


### PR DESCRIPTION
Tests are still flaky after #623. E.g.: https://circleci.com/gh/Netflix/titus-control-plane/344

`InvocationTargetException` is coming from the gRPC-reactor stub we create using reflection, this PR surfaces the underlying exception that is triggering it.