### PR TITLE
Update Signed IP Allocation to use updated fields

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/SignedIpAddressAllocation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/SignedIpAddressAllocation.java
@@ -31,21 +31,70 @@ public class SignedIpAddressAllocation {
 
     @FieldInvariant(
             value = "@asserts.isBase64(value)",
-            message = "IP Address Signature is NOT base64 encoded"
+            message = "Must be base64 encoded"
     )
-    private final byte[] ipAddressAllocationSignature;
+    private final byte[] authoritativePublicKey;
 
-    public SignedIpAddressAllocation(IpAddressAllocation ipAddressAllocation, byte[] ipAddressAllocationSignature) {
+    @FieldInvariant(
+            value = "@asserts.isBase64(value)",
+            message = "Must be base64 encoded"
+    )
+    private final byte[] hostPublicKey;
+
+    @FieldInvariant(
+            value = "@asserts.isBase64(value)",
+            message = "Must be base64 encoded"
+    )
+    private final byte[] hostPublicKeySignature;
+
+    @FieldInvariant(
+            value = "@asserts.isBase64(value)",
+            message = "Must be base64 encoded"
+    )
+    private final byte[] message;
+
+    @FieldInvariant(
+            value = "@asserts.isBase64(value)",
+            message = "Must be base64 encoded"
+    )
+    private final byte[] messageSignature;
+
+    public SignedIpAddressAllocation(IpAddressAllocation ipAddressAllocation,
+                                     byte[] authoritativePublicKey,
+                                     byte[] hostPublicKey,
+                                     byte[] hostPublicKeySignature,
+                                     byte[] message,
+                                     byte[] messageSignature) {
         this.ipAddressAllocation = ipAddressAllocation;
-        this.ipAddressAllocationSignature = ipAddressAllocationSignature;
+        this.authoritativePublicKey = authoritativePublicKey;
+        this.hostPublicKey = hostPublicKey;
+        this.hostPublicKeySignature = hostPublicKeySignature;
+        this.message = message;
+        this.messageSignature = messageSignature;
     }
 
     public IpAddressAllocation getIpAddressAllocation() {
         return ipAddressAllocation;
     }
 
-    public byte[] getIpAddressAllocationSignature() {
-        return ipAddressAllocationSignature;
+    public byte[] getAuthoritativePublicKey() {
+        return authoritativePublicKey;
+    }
+
+    public byte[] getHostPublicKey() {
+        return hostPublicKey;
+    }
+
+    public byte[] getHostPublicKeySignature() {
+        return hostPublicKeySignature;
+    }
+
+    public byte[] getMessage() {
+        return message;
+    }
+
+    public byte[] getMessageSignature() {
+        return messageSignature;
     }
 
     @Override
@@ -57,14 +106,22 @@ public class SignedIpAddressAllocation {
             return false;
         }
         SignedIpAddressAllocation that = (SignedIpAddressAllocation) o;
-        return Objects.equals(ipAddressAllocation, that.ipAddressAllocation) &&
-                Arrays.equals(ipAddressAllocationSignature, that.ipAddressAllocationSignature);
+        return ipAddressAllocation.equals(that.ipAddressAllocation) &&
+                Arrays.equals(authoritativePublicKey, that.authoritativePublicKey) &&
+                Arrays.equals(hostPublicKey, that.hostPublicKey) &&
+                Arrays.equals(hostPublicKeySignature, that.hostPublicKeySignature) &&
+                Arrays.equals(message, that.message) &&
+                Arrays.equals(messageSignature, that.messageSignature);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hash(ipAddressAllocation);
-        result = 31 * result + Arrays.hashCode(ipAddressAllocationSignature);
+        result = 31 * result + Arrays.hashCode(authoritativePublicKey);
+        result = 31 * result + Arrays.hashCode(hostPublicKey);
+        result = 31 * result + Arrays.hashCode(hostPublicKeySignature);
+        result = 31 * result + Arrays.hashCode(message);
+        result = 31 * result + Arrays.hashCode(messageSignature);
         return result;
     }
 
@@ -72,7 +129,11 @@ public class SignedIpAddressAllocation {
     public String toString() {
         return "SignedIpAddressAllocation{" +
                 "ipAddressAllocation=" + ipAddressAllocation +
-                ", ipAddressAllocationSignature=" + Arrays.toString(ipAddressAllocationSignature) +
+                ", authoritativePublicKey=" + Arrays.toString(authoritativePublicKey) +
+                ", hostPublicKey=" + Arrays.toString(hostPublicKey) +
+                ", hostPublicKeySignature=" + Arrays.toString(hostPublicKeySignature) +
+                ", message=" + Arrays.toString(message) +
+                ", messageSignature=" + Arrays.toString(messageSignature) +
                 '}';
     }
 
@@ -84,15 +145,24 @@ public class SignedIpAddressAllocation {
         return new Builder();
     }
 
-    public static Builder newBuilder(SignedIpAddressAllocation signedIpAddressAllocation) {
-        return new Builder()
-                .withIpAddressAllocation(signedIpAddressAllocation.getIpAddressAllocation())
-                .withIpAddressAllocationSignature(signedIpAddressAllocation.ipAddressAllocationSignature);
+    public static Builder newBuilder(SignedIpAddressAllocation copy) {
+        Builder builder = new Builder();
+        builder.ipAddressAllocation = copy.getIpAddressAllocation();
+        builder.authoritativePublicKey = copy.getAuthoritativePublicKey();
+        builder.hostPublicKey = copy.getHostPublicKey();
+        builder.hostPublicKeySignature = copy.getHostPublicKeySignature();
+        builder.message = copy.getMessage();
+        builder.messageSignature = copy.getMessageSignature();
+        return builder;
     }
 
     public static final class Builder {
         private IpAddressAllocation ipAddressAllocation;
-        private byte[] ipAddressAllocationSignature;
+        private byte[] authoritativePublicKey;
+        private byte[] hostPublicKey;
+        private byte[] hostPublicKeySignature;
+        private byte[] message;
+        private byte[] messageSignature;
 
         private Builder() {
         }
@@ -102,19 +172,39 @@ public class SignedIpAddressAllocation {
             return this;
         }
 
-        public Builder withIpAddressAllocationSignature(byte[] val) {
-            ipAddressAllocationSignature = val;
+        public Builder withAuthoritativePublicKey(byte[] val) {
+            authoritativePublicKey = val;
             return this;
         }
 
-        public Builder but() {
-            return newBuilder()
-                    .withIpAddressAllocation(ipAddressAllocation)
-                    .withIpAddressAllocationSignature(ipAddressAllocationSignature);
+        public Builder withHostPublicKey(byte[] val) {
+            hostPublicKey = val;
+            return this;
+        }
+
+        public Builder withHostPublicKeySignature(byte[] val) {
+            hostPublicKeySignature = val;
+            return this;
+        }
+
+        public Builder withMessage(byte[] val) {
+            message = val;
+            return this;
+        }
+
+        public Builder withMessageSignature(byte[] val) {
+            messageSignature = val;
+            return this;
         }
 
         public SignedIpAddressAllocation build() {
-            return new SignedIpAddressAllocation(ipAddressAllocation, ipAddressAllocationSignature);
+            return new SignedIpAddressAllocation(
+                    ipAddressAllocation,
+                    authoritativePublicKey,
+                    hostPublicKey,
+                    hostPublicKeySignature,
+                    message,
+                    messageSignature);
         }
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/SignedIpAddressAllocationMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/SignedIpAddressAllocationMixin.java
@@ -23,6 +23,10 @@ import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressAllocation;
 public abstract class SignedIpAddressAllocationMixin {
     @JsonCreator
     public SignedIpAddressAllocationMixin(@JsonProperty("ipAddressAllocation") IpAddressAllocation ipAddressAllocation,
-                                          @JsonProperty("ipAddressAllocationSignature") byte[] ipAddressAllocationSignature) {
+                                          @JsonProperty("authoritativePublicKey") byte[] authoritativePublicKey,
+                                          @JsonProperty("hostPublicKey") byte[] hostPublicKey,
+                                          @JsonProperty("hostPublicKeySignature") byte[] hostPublicKeySignature,
+                                          @JsonProperty("message") byte[] message,
+                                          @JsonProperty("messageSignature") byte[] messageSignature) {
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobIpAllocationsTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobIpAllocationsTest.java
@@ -251,12 +251,12 @@ public class JobIpAllocationsTest extends BaseIntegrationTest {
         JobDescriptor<ServiceJobExt> invalidJobDescriptor = ONE_TASK_SERVICE_JOB
                 .but(j -> j.getContainer()
                         .but(c -> c.getContainerResources().toBuilder().withSignedIpAddressAllocations(Collections.singletonList(
-                                c.getContainerResources().getSignedIpAddressAllocations().get(0).toBuilder().withIpAddressAllocationSignature(invalidSignatureBytes).build()
+                                c.getContainerResources().getSignedIpAddressAllocations().get(0).toBuilder().withHostPublicKeySignature(invalidSignatureBytes).build()
                         )))
                 );
         submitBadJob(client,
                 toGrpcJobDescriptor(invalidJobDescriptor),
-                "container.containerResources.ipSignedAddressAllocations[0].ipAddressAllocationSignature");
+                "container.containerResources.ipSignedAddressAllocations[0].hostPublicKeySignature");
     }
 
     /**

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/V3GrpcModelConverters.java
@@ -208,7 +208,11 @@ public final class V3GrpcModelConverters {
     public static SignedIpAddressAllocation toCoreSignedIpAddressAllocation(SignedAddressAllocation grpcSignedIpAddressAllocation) {
         return SignedIpAddressAllocation.newBuilder()
                 .withIpAddressAllocation(toCoreIpAddressAllocation(grpcSignedIpAddressAllocation.getAddressAllocation()))
-                .withIpAddressAllocationSignature(grpcSignedIpAddressAllocation.getSignedAddressAllocation().toByteArray())
+                .withAuthoritativePublicKey(grpcSignedIpAddressAllocation.getAuthoritativePublicKey().toByteArray())
+                .withHostPublicKey(grpcSignedIpAddressAllocation.getHostPublicKey().toByteArray())
+                .withHostPublicKeySignature(grpcSignedIpAddressAllocation.getHostPublicKeySignature().toByteArray())
+                .withMessage(grpcSignedIpAddressAllocation.getMessage().toByteArray())
+                .withMessageSignature(grpcSignedIpAddressAllocation.getMessageSignature().toByteArray())
                 .build();
     }
 
@@ -629,7 +633,11 @@ public final class V3GrpcModelConverters {
     public static SignedAddressAllocation toGrpcSignedAddressAllocation(SignedIpAddressAllocation coreSignedIpAddressAllocation) {
         return SignedAddressAllocation.newBuilder()
                 .setAddressAllocation(toGrpcAddressAllocation(coreSignedIpAddressAllocation.getIpAddressAllocation()))
-                .setSignedAddressAllocation(ByteString.copyFrom(coreSignedIpAddressAllocation.getIpAddressAllocationSignature()))
+                .setAuthoritativePublicKey(ByteString.copyFrom(coreSignedIpAddressAllocation.getAuthoritativePublicKey()))
+                .setHostPublicKey(ByteString.copyFrom(coreSignedIpAddressAllocation.getHostPublicKey()))
+                .setHostPublicKeySignature(ByteString.copyFrom(coreSignedIpAddressAllocation.getHostPublicKeySignature()))
+                .setMessage(ByteString.copyFrom(coreSignedIpAddressAllocation.getMessage()))
+                .setMessageSignature(ByteString.copyFrom(coreSignedIpAddressAllocation.getMessageSignature()))
                 .build();
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobIpAllocationGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobIpAllocationGenerator.java
@@ -61,13 +61,17 @@ public final class JobIpAllocationGenerator {
         List<SignedIpAddressAllocation> signedIpAddressAllocationList = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             signedIpAddressAllocationList.add(SignedIpAddressAllocation.newBuilder()
-                    .withIpAddressAllocationSignature(new byte[0])
                     .withIpAddressAllocation(IpAddressAllocation.newBuilder()
                             .withUuid(UUID.randomUUID().toString())
                             .withIpAddress(ipAddressList.get(i))
                             .withIpAddressLocation(ipAddressLocationList.get(i))
                             .build()
                     )
+                    .withAuthoritativePublicKey(new byte[0])
+                    .withHostPublicKey(new byte[0])
+                    .withHostPublicKeySignature(new byte[0])
+                    .withMessage(new byte[0])
+                    .withMessageSignature(new byte[0])
                     .build());
         }
         return DataGenerator.items(signedIpAddressAllocationList);


### PR DESCRIPTION
This PR updates the core model to use the updated signature scheme required by the VPC service. The old signature byte array is replaced with 5 new byte arrays to manage the signature scheme.