### PR TITLE
Support automatically adding runtime predictions to Jobs

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -55,9 +55,43 @@ public final class JobAttributes {
     public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IMAGE = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.image";
 
     /**
+     * Set to true when job runtime prediction fails open
+     */
+    public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.runtimePrediction";
+
+    /**
      * Predicted runtime for a particular job in seconds, used in opportunistic CPU scheduling
      */
     public static final String JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC = PREDICTION_ATTRIBUTE_PREFIX + "predictedRuntimeSec";
+
+    /**
+     * Confidence of the predicted runtime for a particular job
+     */
+    public static final String JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE = PREDICTION_ATTRIBUTE_PREFIX + "confidence";
+
+    /**
+     * Metadata (identifier) about what model generated predictions for a particular job
+     */
+    public static final String JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID = PREDICTION_ATTRIBUTE_PREFIX + "modelId";
+
+    /**
+     * Metadata (version) of the service that generated predictions for a particular job
+     */
+    public static final String JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION = PREDICTION_ATTRIBUTE_PREFIX + "version";
+
+    /**
+     * All available runtime predictions with their associated confidence, as returned from the predictions service for
+     * a particular job.
+     * <p>
+     * These are informational, if any particular prediction is selected for a job, it will be reflected by
+     * {@link JobAttributes#JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC} and {@link JobAttributes#JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE}.
+     */
+    public static final String JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE = PREDICTION_ATTRIBUTE_PREFIX + "available";
+
+    /**
+     * Allow jobs to completely opt-out of having their runtime automatically predicted during admission
+     */
+    public static final String JOB_PARAMETER_SKIP_RUNTIME_PREDICTION = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "runtimePrediction.skip";
 
     /**
      * (Experimental) allow jobs to request being placed into a particular cell (affinity)

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/EmptyJobRuntimePredictionClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/EmptyJobRuntimePredictionClient.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.prediction;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import reactor.core.publisher.Mono;
+
+public class EmptyJobRuntimePredictionClient implements JobRuntimePredictionClient {
+    @Override
+    public Mono<JobRuntimePredictions> getRuntimePredictions(JobDescriptor jobDescriptor) {
+        return Mono.empty();
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePrediction.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePrediction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.prediction;
+
+public class JobRuntimePrediction implements Comparable<JobRuntimePrediction> {
+    private final double confidence;
+    private final double runtimeInSeconds;
+
+    public JobRuntimePrediction(double confidence, double runtime) {
+        this.confidence = confidence;
+        this.runtimeInSeconds = runtime;
+    }
+
+    /**
+     * Statistical confidence associated with the runtimeInSeconds prediction, e.g.: 95% confidence will be 0.95
+     */
+    public double getConfidence() {
+        return confidence;
+    }
+
+    /**
+     * Predicted job runtime, in seconds
+     */
+    public double getRuntimeInSeconds() {
+        return runtimeInSeconds;
+    }
+
+    /**
+     * Predictions are ordered according to their quality (lower to higher):
+     *
+     * <ul>
+     * <li>Higher confidence means higher quality</li>
+     * <li>For the same confidence (a tie), a higher runtimeInSeconds prediction is safer and has higher quality</li>
+     * </ul>
+     */
+    @Override
+    public int compareTo(JobRuntimePrediction other) {
+        int confidenceComparison = Double.compare(this.confidence, other.confidence);
+        if (confidenceComparison != 0) {
+            return confidenceComparison;
+        }
+        return Double.compare(this.runtimeInSeconds, other.runtimeInSeconds);
+    }
+
+    @Override
+    public String toString() {
+        return "JobRuntimePrediction{" +
+                "confidence=" + confidence +
+                ", runtimeInSeconds=" + runtimeInSeconds +
+                '}';
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePredictionClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePredictionClient.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.prediction;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import reactor.core.publisher.Mono;
+
+/**
+ * Client for the service providing runtime predictions for Titus (batch) jobs.
+ */
+public interface JobRuntimePredictionClient {
+    /**
+     * @param jobDescriptor to run predictions on
+     * @return a sorted collection of predictions, from lower to higher quality
+     */
+    Mono<JobRuntimePredictions> getRuntimePredictions(JobDescriptor jobDescriptor);
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePredictions.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePredictions.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.prediction;
+
+import java.util.Collection;
+import java.util.SortedSet;
+
+public class JobRuntimePredictions {
+    private final String version;
+    private final String modelId;
+    private final SortedSet<JobRuntimePrediction> predictions;
+    private final String simpleStringRepresentation;
+
+    public JobRuntimePredictions(String version, String modelId, SortedSet<JobRuntimePrediction> predictions) {
+        this.version = version;
+        this.modelId = modelId;
+        this.predictions = predictions;
+        this.simpleStringRepresentation = buildSimpleString(predictions);
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    public SortedSet<JobRuntimePrediction> getPredictions() {
+        return predictions;
+    }
+
+    /**
+     * One line representation of all predictions in seconds, and their confidence percentile, e.g.:
+     * <tt>0.1=10.0;0.2=15.1;0.9=40.5</tt>
+     */
+    public String toSimpleString() {
+        return simpleStringRepresentation;
+    }
+
+    @Override
+    public String toString() {
+        return "JobRuntimePredictions{" +
+                "version='" + version + '\'' +
+                ", modelId='" + modelId + '\'' +
+                ", predictions=" + predictions +
+                '}';
+    }
+
+    private static String buildSimpleString(Collection<JobRuntimePrediction> predictions) {
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        for (JobRuntimePrediction prediction : predictions) {
+            if (first) {
+                first = false;
+            } else {
+                builder.append(';');
+            }
+            builder.append(prediction.getConfidence()).append('=').append(prediction.getRuntimeInSeconds());
+        }
+        return builder.toString();
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionSanitizer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePrediction;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePredictionClient;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePredictions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_PARAMETER_SKIP_RUNTIME_PREDICTION;
+import static com.netflix.titus.api.jobmanager.model.job.JobFunctions.appendJobDescriptorAttributes;
+
+/**
+ * Decorates {@link JobDescriptor job descriptors} with a prediction of their expected runtime. All information about
+ * predictions will be available as Job attributes.
+ */
+@Singleton
+public class JobRuntimePredictionSanitizer implements AdmissionSanitizer<JobDescriptor> {
+    private static final Logger logger = LoggerFactory.getLogger(JobRuntimePredictionSanitizer.class);
+
+    private final JobRuntimePredictionClient predictionsClient;
+    private final JobRuntimePredictionSelector selector;
+
+    @Inject
+    public JobRuntimePredictionSanitizer(JobRuntimePredictionClient predictionsClient, JobRuntimePredictionSelector selector) {
+        this.predictionsClient = predictionsClient;
+        this.selector = selector;
+    }
+
+    @Override
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
+        if (!JobFunctions.isBatchJob(entity)) {
+            return Mono.empty();
+        }
+        if (isSkippedForJob(entity)) {
+            return Mono.just(JobRuntimePredictionSanitizer::skipSanitization);
+        }
+
+        return predictionsClient.getRuntimePredictions(entity)
+                .map(this::addPredictionToJob)
+                .doOnError(throwable ->
+                        logger.error("Error calling the job runtime prediction service, skipping prediction for {}: {}",
+                                entity.getApplicationName(), throwable.getMessage())
+                )
+                .onErrorReturn(JobRuntimePredictionSanitizer::skipSanitization);
+    }
+
+    private UnaryOperator<JobDescriptor> addPredictionToJob(JobRuntimePredictions predictions) {
+        Optional<JobRuntimePrediction> predictionOpt;
+        Map<String, String> attributes;
+        if (isValid(predictions)) {
+            Pair<Optional<JobRuntimePrediction>, Map<String, String>> predictionWithAttributes = selector.apply(predictions);
+            predictionOpt = predictionWithAttributes.getLeft();
+            attributes = predictionWithAttributes.getRight();
+        } else {
+            predictionOpt = Optional.empty();
+            attributes = Collections.emptyMap();
+        }
+
+        return jobDescriptor -> {
+            Map<String, String> metadata = new HashMap<>(((JobDescriptor<?>) jobDescriptor).getAttributes());
+            metadata.putAll(attributes);
+            metadata.put(JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID, predictions.getModelId());
+            metadata.put(JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION, predictions.getVersion());
+            metadata.put(JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE, predictions.toSimpleString());
+            JobDescriptor<?> withPredictionMetadata = jobDescriptor.toBuilder().withAttributes(metadata).build();
+
+            //noinspection unchecked
+            return predictionOpt.map(prediction -> appendJobDescriptorAttributes(withPredictionMetadata, CollectionsExt.asMap(
+                    JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC, Double.toString(prediction.getRuntimeInSeconds()),
+                    JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE, Double.toString(prediction.getConfidence())
+            ))).orElseGet(() -> skipSanitization(withPredictionMetadata));
+        };
+    }
+
+    private static boolean isValid(JobRuntimePredictions predictions) {
+        if (CollectionsExt.isNullOrEmpty(predictions.getPredictions())) {
+            return false;
+        }
+        // higher quality predictions are always expected to be longer, and no zeroes allowed
+        double lastSeen = 0.0;
+        for (JobRuntimePrediction prediction : predictions.getPredictions()) {
+            double current = prediction.getRuntimeInSeconds();
+            if (current <= 0.0 || current < lastSeen) {
+                return false;
+            }
+            lastSeen = current;
+        }
+        return true;
+    }
+
+    private static boolean isSkippedForJob(JobDescriptor<?> entity) {
+        return Boolean.parseBoolean(
+                entity.getAttributes().getOrDefault(JOB_PARAMETER_SKIP_RUNTIME_PREDICTION, "false").trim()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JobDescriptor skipSanitization(JobDescriptor jobDescriptor) {
+        return JobFunctions.appendJobDescriptorAttribute(jobDescriptor,
+                JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION, true
+        );
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionSelector.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionSelector.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePrediction;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePredictions;
+
+/**
+ * Strategy for selecting a particular job runtime prediction to use, given a collection sorted from lower to higher
+ * quality. In addition to returning one of the predictions to be used, implementations may return job attributes to
+ * be appended to a {@link JobDescriptor} as metadata about the selection.
+ */
+public interface JobRuntimePredictionSelector extends
+        Function<JobRuntimePredictions, Pair<Optional<JobRuntimePrediction>, Map<String, String>>> {
+
+    /**
+     * Always select the highest quality prediction.
+     */
+    static JobRuntimePredictionSelector best() {
+        return best(Collections.emptyMap());
+    }
+
+    /**
+     * Always select the highest quality prediction, with additional metadata.
+     */
+    static JobRuntimePredictionSelector best(Map<String, String> selectionMetadata) {
+        return predictions -> CollectionsExt.isNullOrEmpty(predictions.getPredictions()) ?
+                Pair.of(Optional.empty(), selectionMetadata) :
+                Pair.of(Optional.of(predictions.getPredictions().last()), selectionMetadata);
+    }
+}

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePredictionsTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/connector/prediction/JobRuntimePredictionsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.prediction;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JobRuntimePredictionsTest {
+
+    @Test
+    public void testOneLineRepresentation() {
+        SortedSet<JobRuntimePrediction> predictions = new TreeSet<>();
+        predictions.add(new JobRuntimePrediction(0.95, 26.2));
+        predictions.add(new JobRuntimePrediction(0.1, 10.0));
+        predictions.add(new JobRuntimePrediction(0.2, 15.0));
+        JobRuntimePredictions jobRuntimePredictions = new JobRuntimePredictions("1", "some-id", predictions);
+        assertThat(jobRuntimePredictions.toSimpleString()).isEqualTo("0.1=10.0;0.2=15.0;0.95=26.2");
+    }
+
+}

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionSanitizerTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionSanitizerTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import java.util.Arrays;
+import java.util.TreeSet;
+import java.util.UUID;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.api.service.TitusServiceException;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePrediction;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePredictionClient;
+import com.netflix.titus.runtime.connector.prediction.JobRuntimePredictions;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION;
+import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_PARAMETER_SKIP_RUNTIME_PREDICTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JobRuntimePredictionSanitizerTest {
+
+    private JobDescriptor<BatchJobExt> jobDescriptor;
+    private String modelId;
+    private JobRuntimePredictionClient client;
+
+    @Before
+    public void setup() {
+        jobDescriptor = JobDescriptorGenerator.oneTaskBatchJobDescriptor();
+        modelId = UUID.randomUUID().toString();
+        client = mock(JobRuntimePredictionClient.class);
+
+        JobRuntimePredictions predictions = new JobRuntimePredictions("v1", modelId,
+                new TreeSet<>(Arrays.asList(
+                        new JobRuntimePrediction(0.05, 5.5),
+                        new JobRuntimePrediction(0.25, 6.0),
+                        new JobRuntimePrediction(0.90, 20.1)
+                )));
+        when(client.getRuntimePredictions(jobDescriptor)).thenReturn(Mono.just(predictions));
+    }
+
+    @Test
+    public void predictionsAreAddedToJobs() {
+        AdmissionSanitizer<JobDescriptor> sanitizer = new JobRuntimePredictionSanitizer(client,
+                JobRuntimePredictionSelector.best());
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
+                .assertNext(result -> assertThat(((JobDescriptor<?>) result).getAttributes())
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC, "20.1")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE, "0.9")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID, modelId)
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION, "v1")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE, "0.05=5.5;0.25=6.0;0.9=20.1")
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    public void errorsCauseSanitizationToBeSkipped() {
+        JobRuntimePredictionClient errorClient = mock(JobRuntimePredictionClient.class);
+        when(errorClient.getRuntimePredictions(any())).thenReturn(Mono.error(TitusServiceException.internal("bad request")));
+
+        AdmissionSanitizer<JobDescriptor> sanitizer = new JobRuntimePredictionSanitizer(errorClient,
+                JobRuntimePredictionSelector.best());
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
+                .assertNext(result -> assertThat(((JobDescriptor<?>) result).getAttributes())
+                        .containsEntry(JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION, "true")
+                        .doesNotContainKeys(
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE,
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC,
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID,
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION
+                        )
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    public void emptyPredictionsCauseSanitizationToBeSkipped() {
+        JobRuntimePredictionClient client = mock(JobRuntimePredictionClient.class);
+        JobRuntimePredictions predictions = new JobRuntimePredictions("v1", modelId, new TreeSet<>());
+        when(client.getRuntimePredictions(any())).thenReturn(Mono.just(predictions));
+
+        AdmissionSanitizer<JobDescriptor> sanitizer = new JobRuntimePredictionSanitizer(client,
+                JobRuntimePredictionSelector.best());
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
+                .assertNext(result -> assertThat(((JobDescriptor<?>) result).getAttributes())
+                        .containsEntry(JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION, "true")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID, modelId)
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION, "v1")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE, "")
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    public void zeroedPredictionsCauseSanitizationToBeSkipped() {
+        JobRuntimePredictionClient client = mock(JobRuntimePredictionClient.class);
+        JobRuntimePredictions predictions = new JobRuntimePredictions("v1", modelId,
+                new TreeSet<>(Arrays.asList(
+                        new JobRuntimePrediction(0.05, 0.0),
+                        new JobRuntimePrediction(0.25, 6.0),
+                        new JobRuntimePrediction(0.90, 21.2)
+                )));
+        when(client.getRuntimePredictions(any())).thenReturn(Mono.just(predictions));
+
+        AdmissionSanitizer<JobDescriptor> sanitizer = new JobRuntimePredictionSanitizer(client,
+                JobRuntimePredictionSelector.best());
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
+                .assertNext(result -> assertThat(((JobDescriptor<?>) result).getAttributes())
+                        .containsEntry(JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION, "true")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID, modelId)
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION, "v1")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE, "0.05=0.0;0.25=6.0;0.9=21.2")
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    public void higherQualityPredictionsMustBeLonger() {
+        JobRuntimePredictionClient client = mock(JobRuntimePredictionClient.class);
+        JobRuntimePredictions predictions = new JobRuntimePredictions("v1", modelId,
+                new TreeSet<>(Arrays.asList(
+                        new JobRuntimePrediction(0.05, 5.1),
+                        new JobRuntimePrediction(0.25, 4.0),
+                        new JobRuntimePrediction(0.35, 4.1),
+                        new JobRuntimePrediction(0.90, 4.0)
+                )));
+        when(client.getRuntimePredictions(any())).thenReturn(Mono.just(predictions));
+
+        AdmissionSanitizer<JobDescriptor> sanitizer = new JobRuntimePredictionSanitizer(client,
+                JobRuntimePredictionSelector.best());
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
+                .assertNext(result -> assertThat(((JobDescriptor<?>) result).getAttributes())
+                        .containsEntry(JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION, "true")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID, modelId)
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION, "v1")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_AVAILABLE, "0.05=5.1;0.25=4.0;0.35=4.1;0.9=4.0")
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    public void metadataFromSelectorIsAddedToJobs() {
+        AdmissionSanitizer<JobDescriptor> sanitizer = new JobRuntimePredictionSanitizer(client,
+                JobRuntimePredictionSelector.best(CollectionsExt.asMap(
+                        "selection.extra", "foobar",
+                        // can't override prediction attributes
+                        JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC, "0.82",
+                        JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE, "1.0"
+                )));
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptor))
+                .assertNext(result -> assertThat(((JobDescriptor<?>) result).getAttributes())
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC, "20.1")
+                        .containsEntry(JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE, "0.9")
+                        .containsEntry("selection.extra", "foobar")
+                )
+                .verifyComplete();
+    }
+
+    @Test
+    public void jobsCanOptOut() {
+        JobDescriptor<BatchJobExt> optedOut = jobDescriptor.toBuilder()
+                .withAttributes(CollectionsExt.copyAndAdd(jobDescriptor.getAttributes(),
+                        JOB_PARAMETER_SKIP_RUNTIME_PREDICTION, "true"
+                ))
+                .build();
+        AdmissionSanitizer<JobDescriptor> sanitizer = new JobRuntimePredictionSanitizer(client,
+                JobRuntimePredictionSelector.best());
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(optedOut))
+                .assertNext(result -> assertThat(((JobDescriptor<?>) result).getAttributes())
+                        .containsEntry(JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION, "true")
+                        .doesNotContainKeys(
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_CONFIDENCE,
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC,
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_MODEL_ID,
+                                JOB_ATTRIBUTES_RUNTIME_PREDICTION_VERSION
+                        )
+                )
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
... during admission, from an external predictions service.

The default implementation of the predictions service is a no-op.