### PR TITLE
track GPU utilization as a consumption metric

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/SimpleCapacityGuaranteeStrategy.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/internal/SimpleCapacityGuaranteeStrategy.java
@@ -79,6 +79,10 @@ public class SimpleCapacityGuaranteeStrategy implements CapacityGuaranteeStrateg
         return new CapacityAllocations(instanceAllocations, resourceShortage);
     }
 
+    /**
+     * This implementation assumes that capacityRequirements never specify a gpu dimension, since instances with GPUs
+     * are not autoscaled, and are removed from the evaluation.
+     */
     private Optional<ResourceDimension> allocate(Tier tier,
                                                  CapacityRequirements capacityRequirements,
                                                  Map<AgentInstanceGroup, Integer> instanceAllocations) {
@@ -105,6 +109,7 @@ public class SimpleCapacityGuaranteeStrategy implements CapacityGuaranteeStrateg
             int instancesAvailable = instanceGroup.getMax() - instancesUsed;
 
             if (instancesAvailable > 0) {
+                // IMPORTANT: gpu are not considered, so GPUs can never be in capacity requirements (reserved)
                 int instanceRequired = (int) ResourceDimensions.divideAndRoundUp(left, instanceResources);
                 if (instanceRequired <= instancesAvailable) {
                     instanceAllocations.put(instanceGroup, instancesUsed + instanceRequired);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/model/ResourceDimensionsTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/model/ResourceDimensionsTest.java
@@ -31,32 +31,32 @@ public class ResourceDimensionsTest {
 
     @Test
     public void testResourceDimensionAddition() throws Exception {
-        ResourceDimension small = ResourceDimensionSample.Small.build();
-        ResourceDimension expected = ResourceDimensionSample.SmallX2.build();
+        ResourceDimension small = ResourceDimensionSample.SmallWithGpu.build();
+        ResourceDimension expected = ResourceDimensionSample.SmallWithGpuX2.build();
 
         assertThat(ResourceDimensions.add(small, small)).isEqualTo(expected);
     }
 
     @Test
     public void testResourceDimensionSubtraction() throws Exception {
-        ResourceDimension large = ResourceDimensionSample.SmallX2.build();
-        ResourceDimension small = ResourceDimensionSample.Small.build();
+        ResourceDimension large = ResourceDimensionSample.SmallWithGpuX2.build();
+        ResourceDimension small = ResourceDimensionSample.SmallWithGpu.build();
 
         assertThat(ResourceDimensions.subtractPositive(large, small)).isEqualTo(small);
     }
 
     @Test
     public void testResourceDimensionMultiplication() throws Exception {
-        ResourceDimension small = ResourceDimensionSample.Small.build();
-        ResourceDimension expected = ResourceDimensionSample.SmallX2.build();
+        ResourceDimension small = ResourceDimensionSample.SmallWithGpu.build();
+        ResourceDimension expected = ResourceDimensionSample.SmallWithGpuX2.build();
 
         assertThat(ResourceDimensions.multiply(small, 2)).isEqualTo(expected);
     }
 
     @Test
     public void testResourceDimensionDivide() throws Exception {
-        ResourceDimension large = ResourceDimensionSample.SmallX2.build();
-        ResourceDimension small = ResourceDimensionSample.Small.build();
+        ResourceDimension large = ResourceDimensionSample.SmallWithGpuX2.build();
+        ResourceDimension small = ResourceDimensionSample.SmallWithGpu.build();
 
         Pair<Long, ResourceDimension> result = ResourceDimensions.divide(large, small);
         assertThat(result.getLeft()).isEqualTo(2);
@@ -65,9 +65,9 @@ public class ResourceDimensionsTest {
 
     @Test
     public void testResourceDimensionDivideAndRoundUp() throws Exception {
-        ResourceDimension large = ResourceDimensionSample.SmallX2.build();
-        ResourceDimension largePlus = ResourceDimensionSample.SmallX2.builder().withCpus(large.getCpu() + 1).build();
-        ResourceDimension small = ResourceDimensionSample.Small.build();
+        ResourceDimension large = ResourceDimensionSample.SmallWithGpuX2.build();
+        ResourceDimension largePlus = ResourceDimensionSample.SmallWithGpuX2.builder().withCpus(large.getCpu() + 1).build();
+        ResourceDimension small = ResourceDimensionSample.SmallWithGpu.build();
 
         assertThat(ResourceDimensions.divideAndRoundUp(large, small)).isEqualTo(2);
         assertThat(ResourceDimensions.divideAndRoundUp(largePlus, small)).isEqualTo(3);
@@ -75,16 +75,16 @@ public class ResourceDimensionsTest {
 
     @Test
     public void testAligningUpToHigherCPU() throws Exception {
-        ResourceDimension small2X = ResourceDimensionSample.SmallX2.build();
-        ResourceDimension original = ResourceDimensionSample.Small.builder().withCpus(small2X.getCpu()).build();
+        ResourceDimension small2X = ResourceDimensionSample.SmallWithGpuX2.build();
+        ResourceDimension original = ResourceDimensionSample.SmallWithGpu.builder().withCpus(small2X.getCpu()).build();
 
         assertThat(ResourceDimensions.alignUp(original, small2X)).isEqualTo(small2X);
     }
 
     @Test
     public void testAligningUpToHigherMemory() throws Exception {
-        ResourceDimension small2X = ResourceDimensionSample.SmallX2.build();
-        ResourceDimension original = ResourceDimensionSample.Small.builder().withMemoryMB(small2X.getMemoryMB()).build();
+        ResourceDimension small2X = ResourceDimensionSample.SmallWithGpuX2.build();
+        ResourceDimension original = ResourceDimensionSample.SmallWithGpu.builder().withMemoryMB(small2X.getMemoryMB()).build();
 
         assertThat(ResourceDimensions.alignUp(original, small2X)).isEqualTo(small2X);
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/service/management/internal/ResourceConsumptionLogTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/service/management/internal/ResourceConsumptionLogTest.java
@@ -49,7 +49,7 @@ public class ResourceConsumptionLogTest {
         );
         String result = ResourceConsumptionLog.doLog(event);
 
-        String expected = "Resource consumption change: group=myCapacityGroup [below limit] actual=[cpu=1.0, memoryMB=1, diskMB=10, networkMbs=10], max=[cpu=2.0, memoryMB=2, diskMB=20, networkMbs=20], limit=[cpu=3.0, memoryMB=3, diskMB=30, networkMbs=30], attrs={attrKey=attrValue}";
+        String expected = "Resource consumption change: group=myCapacityGroup [below limit] actual=[cpu=1.0, memoryMB=1, diskMB=10, networkMbs=10, gpu=0], max=[cpu=2.0, memoryMB=2, diskMB=20, networkMbs=20, gpu=0], limit=[cpu=3.0, memoryMB=3, diskMB=30, networkMbs=30, gpu=0], attrs={attrKey=attrValue}";
         assertThat(result).isEqualTo(expected);
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/data/core/ResourceDimensionSample.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/data/core/ResourceDimensionSample.java
@@ -29,7 +29,6 @@ public enum ResourceDimensionSample {
                     .withMemoryMB(1024)
                     .withDiskMB(100)
                     .withNetworkMbs(100);
-
         }
     },
     SmallX2() {
@@ -40,7 +39,18 @@ public enum ResourceDimensionSample {
                     .withMemoryMB(2048)
                     .withDiskMB(200)
                     .withNetworkMbs(200);
-
+        }
+    },
+    SmallWithGpu() {
+        @Override
+        public Builder builder() {
+            return Small.builder().withGpu(1);
+        }
+    },
+    SmallWithGpuX2() {
+        @Override
+        public Builder builder() {
+            return SmallX2.builder().withGpu(2);
         }
     };
 


### PR DESCRIPTION
Note that currently capacity groups **can not** specify gpus to be reserved, since the current implementation ignores machines with GPU available when computing minimum required capacity.