### PR TITLE
support factional job runtime predictions

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -507,12 +507,19 @@ public final class JobFunctions {
                 .flatMap(StringExt::parseInt);
     }
 
+    /**
+     * Jobs can include a fractional runtime duration prediction in seconds, which are parsed with millisecond resolution.
+     *
+     * @return a duration (if present) with millisecond resolution
+     * @see JobAttributes#JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC
+     */
     public static Optional<Duration> getJobRuntimePrediction(Job job) {
         if (!isBatchJob(job)) {
             return Optional.empty();
         }
         return Optional.ofNullable(((Job<?>) job).getJobDescriptor().getAttributes().get(JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC))
-                .flatMap(StringExt::parseLong)
-                .map(Duration::ofSeconds);
+                .flatMap(StringExt::parseDouble)
+                .map(seconds -> ((long) (seconds * 1000))) // seconds -> milliseconds
+                .map(Duration::ofMillis);
     }
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/StringExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/StringExt.java
@@ -495,4 +495,12 @@ public final class StringExt {
             return Optional.empty();
         }
     }
+
+    public static Optional<Double> parseDouble(String s) {
+        try {
+            return Optional.of(Double.parseDouble(s));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
@@ -47,7 +47,7 @@ import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTask
 @Category(IntegrationTest.class)
 public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
     private static final JobDescriptor<BatchJobExt> BATCH_JOB_WITH_RUNTIME_PREDICTION = JobFunctions.appendJobDescriptorAttribute(
-            oneTaskBatchJobDescriptor(), JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC, "12" /* seconds */
+            oneTaskBatchJobDescriptor(), JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC, "12.6" /* seconds */
     );
 
     private final TitusStackResource titusStackResource = new TitusStackResource(twoPartitionsPerTierCell(2));


### PR DESCRIPTION
predictions are in seconds, but can be fractional and will be parsed with a resolution up to milliseconds.