### PR TITLE
don't scale up agents on some scheduling failures

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/StringExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/StringExt.java
@@ -481,6 +481,9 @@ public final class StringExt {
     }
 
     public static Optional<Integer> parseInt(String s) {
+        if (StringExt.isEmpty(s)) {
+            return Optional.empty();
+        }
         try {
             return Optional.of(Integer.parseInt(s));
         } catch (NumberFormatException e) {
@@ -489,6 +492,9 @@ public final class StringExt {
     }
 
     public static Optional<Long> parseLong(String s) {
+        if (StringExt.isEmpty(s)) {
+            return Optional.empty();
+        }
         try {
             return Optional.of(Long.parseLong(s));
         } catch (NumberFormatException e) {
@@ -497,6 +503,9 @@ public final class StringExt {
     }
 
     public static Optional<Double> parseDouble(String s) {
+        if (StringExt.isEmpty(s)) {
+            return Optional.empty();
+        }
         try {
             return Optional.of(Double.parseDouble(s));
         } catch (NumberFormatException e) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
@@ -60,6 +60,11 @@ public class TaskPlacementFailure {
          */
         WaitingForInUseIpAllocation,
 
+        /**
+         * Task not launched due to failure to assign requested opportunistic resources
+         */
+        OpportunisticResource,
+
         Unrecognized,
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/OpportunisticCpuConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/OpportunisticCpuConstraint.java
@@ -32,7 +32,6 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.scheduler.SchedulerConfiguration;
-import com.netflix.titus.master.scheduler.SchedulerUtils;
 import com.netflix.titus.master.scheduler.opportunistic.OpportunisticCpuAvailability;
 import com.netflix.titus.master.scheduler.resourcecache.OpportunisticCpuCache;
 import com.netflix.titus.master.scheduler.resourcecache.TaskCache;
@@ -43,17 +42,39 @@ public class OpportunisticCpuConstraint implements SystemConstraint {
     public static final String NAME = OpportunisticCpuConstraint.class.getSimpleName();
 
     private static final Result VALID = new Result(true, null);
-    private static final Result NO_RUNTIME_PREDICTION = new Result(false, "Task requested opportunistic CPUs without a runtime prediction");
-    private static final Result NO_MACHINE_ID = new Result(false, "No machine id attribute filled by Fenzo");
-    private static final Result NO_OPPORTUNISTIC_CPUS = new Result(false, "The machine does not have opportunistic CPUs available");
-    private static final Result AVAILABILITY_NOT_LONG_ENOUGH = new Result(false, "CPU availability on the machine will not last for long enough");
-    private static final Result NOT_ENOUGH_OPPORTUNISTIC_CPUS = new Result(false, "The machine does not have enough opportunistic CPUs available");
+
+    private enum Failure {
+        NO_RUNTIME_PREDICTION("Task requested opportunistic CPUs without a runtime prediction"),
+        NO_MACHINE_ID("No machine id attribute filled by Fenzo"),
+        NO_OPPORTUNISTIC_CPUS("The machine does not have opportunistic CPUs available"),
+        AVAILABILITY_NOT_LONG_ENOUGH("CPU availability on the machine will not last for long enough"),
+        NOT_ENOUGH_OPPORTUNISTIC_CPUS("The machine does not have enough opportunistic CPUs available");
+
+        private Result result;
+
+        Failure(String reason) {
+            this.result = new Result(false, reason);
+        }
+
+        public Result toResult() {
+            return result;
+        }
+    }
 
     private final SchedulerConfiguration configuration;
     private final FeatureActivationConfiguration featureConfiguration;
     private final TaskCache taskCache;
     private final OpportunisticCpuCache opportunisticCpuCache;
     private final TitusRuntime titusRuntime;
+
+    public static boolean isOpportunisticCpuConstraintReason(String reason) {
+        for (Failure failure : Failure.values()) {
+            if (failure.toResult().getFailureReason().equals(reason)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     @Inject
     public OpportunisticCpuConstraint(SchedulerConfiguration configuration,
@@ -84,27 +105,27 @@ public class OpportunisticCpuConstraint implements SystemConstraint {
 
         Optional<Duration> runtimePrediction = request.getRuntimePrediction();
         if (!runtimePrediction.isPresent()) {
-            return NO_RUNTIME_PREDICTION;
+            return Failure.NO_RUNTIME_PREDICTION.toResult();
         }
 
         String agentId = targetVM.getVMId();
         if (StringExt.isEmpty(agentId)) {
-            return NO_MACHINE_ID;
+            return Failure.NO_MACHINE_ID.toResult();
         }
 
         Optional<OpportunisticCpuAvailability> availabilityOpt = opportunisticCpuCache.findAvailableOpportunisticCpus(agentId);
         if (!availabilityOpt.isPresent()) {
-            return NO_OPPORTUNISTIC_CPUS;
+            return Failure.NO_OPPORTUNISTIC_CPUS.toResult();
         }
 
         Duration taskRuntime = runtimePrediction.get();
         Instant now = Instant.ofEpochMilli(titusRuntime.getClock().wallTime());
         if (now.plus(taskRuntime).isAfter(availabilityOpt.get().getExpiresAt())) {
-            return AVAILABILITY_NOT_LONG_ENOUGH;
+            return Failure.AVAILABILITY_NOT_LONG_ENOUGH.toResult();
         }
 
         if (availabilityOpt.get().getCount() - taskCache.getOpportunisticCpusAllocated(agentId) < request.getOpportunisticCpus()) {
-            return NOT_ENOUGH_OPPORTUNISTIC_CPUS;
+            return Failure.NOT_ENOUGH_OPPORTUNISTIC_CPUS.toResult();
         }
 
         return VALID;


### PR DESCRIPTION
Some scheduling failures are not related to lack of available agent capacity, so don't try to scale up agent instances based on those failures.