### PR TITLE
Use Single Machine ID

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -20,7 +20,6 @@ public final class TaskAttributes {
     /*
      * Agent attributes.
      */
-    public static final String TASK_ATTRIBUTES_AGENT_ID = "agent.id";
     public static final String TASK_ATTRIBUTES_AGENT_REGION = "agent.region";
     public static final String TASK_ATTRIBUTES_AGENT_ZONE = "agent.zone";
     public static final String TASK_ATTRIBUTES_AGENT_ASG = "agent.asg";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterOperationFunctions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterOperationFunctions.java
@@ -69,7 +69,7 @@ public class ClusterOperationFunctions {
     public static Map<String, Long> getNumberOfTasksOnAgents(Collection<Task> tasks) {
         return tasks.stream()
                 .collect(Collectors.groupingBy(
-                        task -> task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID, "Unknown"),
+                        task -> task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, "Unknown"),
                         Collectors.counting())
                 );
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterRemovableAgentRemover.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterRemovableAgentRemover.java
@@ -283,7 +283,7 @@ public class ClusterRemovableAgentRemover {
     private Map<String, Long> getNumberOfTasksOnAgents() {
         return v3JobOperations.getTasks().stream()
                 .collect(Collectors.groupingBy(
-                        task -> task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID, "Unknown"),
+                        task -> task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, "Unknown"),
                         Collectors.counting())
                 );
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterRemovableInstanceGroupAgentRemover.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterRemovableInstanceGroupAgentRemover.java
@@ -265,7 +265,7 @@ public class ClusterRemovableInstanceGroupAgentRemover {
     private Map<String, Long> getNumberOfTasksOnAgents() {
         return v3JobOperations.getTasks().stream()
                 .collect(Collectors.groupingBy(
-                        task -> task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID, "Unknown"),
+                        task -> task.getTaskContext().getOrDefault(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, "Unknown"),
                         Collectors.counting())
                 );
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -155,7 +155,7 @@ public final class JobManagerUtil {
 
             Map<String, String> taskContext = new HashMap<>(opportunisticResourcesContext);
             Map<String, Protos.Attribute> attributes = CollectionsExt.nonNull(lease.getAttributeMap());
-            String hostIp = addAttributeToContext(attributes, "hostIp").orElse(lease.hostname());
+            String hostIp = findAttribute(attributes, "hostIp").orElse(lease.hostname());
             taskContext.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST, hostIp);
 
             executorUriOverrideOpt.ifPresent(v -> taskContext.put(TASK_ATTRIBUTES_EXECUTOR_URI_OVERRIDE, v));
@@ -165,10 +165,10 @@ public final class JobManagerUtil {
                 attributesMap.forEach((k, v) -> taskContext.put("agent." + k, v));
 
                 // TODO Some agent attribute names are configurable, some not. We need to clean this up.
-                addAttributeToContext(attributes, zoneAttributeName).ifPresent(value ->
+                findAttribute(attributes, zoneAttributeName).ifPresent(value ->
                         taskContext.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE, value)
                 );
-                addAttributeToContext(attributes, "id").ifPresent(value ->
+                findAttribute(attributes, "id").ifPresent(value ->
                         taskContext.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, value)
                 );
             }
@@ -223,7 +223,7 @@ public final class JobManagerUtil {
         return Optional.empty();
     }
 
-    private static Optional<String> addAttributeToContext(Map<String, Protos.Attribute> attributes, String name) {
+    private static Optional<String> findAttribute(Map<String, Protos.Attribute> attributes, String name) {
         Protos.Attribute attribute = attributes.get(name);
         return (attribute != null) ? Optional.of(attribute.getText().getValue()) : Optional.empty();
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/task/BasicTaskActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/task/BasicTaskActions.java
@@ -24,9 +24,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.netflix.fenzo.queues.QAttributes;
 import com.netflix.titus.api.jobmanager.TaskAttributes;
-import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.Task;
@@ -37,6 +35,7 @@ import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations.Trigger;
 import com.netflix.titus.api.jobmanager.store.JobStore;
 import com.netflix.titus.api.model.Tier;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.common.framework.reconciler.EntityHolder;
 import com.netflix.titus.common.framework.reconciler.ModelActionHolder;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
@@ -45,7 +44,6 @@ import com.netflix.titus.common.util.DateTimeExt;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.jobmanager.service.JobManagerConfiguration;
 import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
-import com.netflix.titus.master.jobmanager.service.common.V3QAttributes;
 import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.jobmanager.service.common.action.JobEntityHolders;
 import com.netflix.titus.master.jobmanager.service.common.action.TaskRetryers;
@@ -114,11 +112,7 @@ public class BasicTaskActions {
                     return titusStore.updateTask(referenceTask)
                             .andThen(Observable.fromCallable(() -> {
                                 if (referenceTask.getStatus().getState() == TaskState.Finished) {
-                                    Pair<Tier, String> tierAssignment = JobManagerUtil.getTierAssignment((Job) engine.getReferenceView().getEntity(), capacityGroupService);
-                                    QAttributes qAttributes = new V3QAttributes(tierAssignment.getLeft().ordinal(), tierAssignment.getRight());
-                                    // host name should be null if it doesn't exist for fenzo to not try to unassign it
-                                    String hostName = referenceTask.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST);
-                                    schedulingService.removeTask(referenceTask.getId(), qAttributes, hostName);
+                                    schedulingService.removeTask(referenceTask.getId());
                                 }
                                 TitusModelAction modelUpdateAction = TitusModelAction.newModelUpdate(self)
                                         .taskUpdate(storeRoot -> {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/ContainerFailureBasedAgentQualityTracker.java
@@ -222,7 +222,7 @@ public class ContainerFailureBasedAgentQualityTracker implements AgentQualityTra
     }
 
     private PlacementHistory tryGetOrCreatePlacementHistory(Task task) {
-        String hostname = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST);
+        String hostname = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID);
         if (hostname == null) {
             invariants.inconsistent("Task without host name assigned: taskId=%s", task.getId());
             return null;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -560,10 +560,9 @@ public class DefaultSchedulingService implements SchedulingService {
             Pair<Tier, String> tierAssignment = JobManagerUtil.getTierAssignment(job, capacityGroupService);
             QAttributes qAttributes = new V3QAttributes(tierAssignment.getLeft().ordinal(), tierAssignment.getRight());
             // host name should be null if it doesn't exist for fenzo to not try to unassign it
-            String hostname = kubeIntegrationEnabled ?
-                    task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID)
-                    :
-                    task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST);
+            String hostname = kubeIntegrationEnabled
+                    ? task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID)
+                    : task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST);
 
             logger.info("Removing task from Fenzo: taskId={}, qAttributes={}, hostname={}", taskId, qAttributes, hostname);
             schedulingService.removeTask(taskId, qAttributes, hostname);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -58,12 +58,14 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 import com.netflix.titus.api.agent.service.AgentManagementFunctions;
 import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.DisruptionBudgetFunctions;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.framework.fit.FitFramework;
 import com.netflix.titus.common.framework.fit.FitInjection;
 import com.netflix.titus.common.runtime.TitusRuntime;
@@ -73,6 +75,8 @@ import com.netflix.titus.common.util.rx.ObservableExt;
 import com.netflix.titus.common.util.spectator.SpectatorExt;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.config.MasterConfiguration;
+import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
+import com.netflix.titus.master.jobmanager.service.common.V3QAttributes;
 import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.mesos.LeaseRescindedEvent;
 import com.netflix.titus.master.mesos.MesosConfiguration;
@@ -87,6 +91,7 @@ import com.netflix.titus.master.scheduler.resourcecache.AgentResourceCache;
 import com.netflix.titus.master.scheduler.resourcecache.AgentResourceCacheUpdater;
 import com.netflix.titus.master.scheduler.resourcecache.OpportunisticCpuCache;
 import com.netflix.titus.master.scheduler.resourcecache.TaskCache;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.master.taskmigration.TaskMigrator;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
@@ -118,7 +123,6 @@ public class DefaultSchedulingService implements SchedulingService {
     private final V3JobOperations v3JobOperations;
     private final VMOperations vmOps;
     private final Optional<FitInjection> fitInjection;
-    private final MesosConfiguration mesosConfiguration;
     private TaskScheduler taskScheduler;
     private final TaskSchedulingService schedulingService;
     private TaskQueue taskQueue;
@@ -169,10 +173,12 @@ public class DefaultSchedulingService implements SchedulingService {
     private final Registry registry;
     private final TaskMigrator taskMigrator;
     private final AgentManagementService agentManagementService;
+    private final ApplicationSlaManagementService capacityGroupService;
     private Subscription vmStateUpdateSubscription;
 
     private final AtomicReference<Map<String, List<TaskAssignmentResult>>> lastSchedulingResult = new AtomicReference<>();
     private final BehaviorSubject<Map<String, List<TaskAssignmentResult>>> schedulingResultSubject = BehaviorSubject.create();
+    private final boolean kubeIntegrationEnabled;
 
     @Inject
     public DefaultSchedulingService(V3JobOperations v3JobOperations,
@@ -193,12 +199,13 @@ public class DefaultSchedulingService implements SchedulingService {
                                     TitusRuntime titusRuntime,
                                     AgentResourceCache agentResourceCache,
                                     Config config,
-                                    MesosConfiguration mesosConfiguration) {
+                                    MesosConfiguration mesosConfiguration,
+                                    ApplicationSlaManagementService capacityGroupService) {
         this(v3JobOperations, agentManagementService, v3TaskInfoFactory, vmOps, virtualMachineService,
                 masterConfiguration, schedulerConfiguration, systemHardConstraint, taskCache, opportunisticCpuCache,
                 Schedulers.computation(), tierSlaUpdater, registry, preferentialNamedConsumableResourceEvaluator,
                 agentManagementFitnessCalculator, taskMigrator, titusRuntime, agentResourceCache, config,
-                mesosConfiguration);
+                mesosConfiguration, capacityGroupService);
     }
 
     public DefaultSchedulingService(V3JobOperations v3JobOperations,
@@ -220,7 +227,8 @@ public class DefaultSchedulingService implements SchedulingService {
                                     TitusRuntime titusRuntime,
                                     AgentResourceCache agentResourceCache,
                                     Config config,
-                                    MesosConfiguration mesosConfiguration) {
+                                    MesosConfiguration mesosConfiguration,
+                                    ApplicationSlaManagementService capacityGroupService) {
         this.v3JobOperations = v3JobOperations;
         this.agentManagementService = agentManagementService;
         this.vmOps = vmOps;
@@ -234,8 +242,9 @@ public class DefaultSchedulingService implements SchedulingService {
         this.titusRuntime = titusRuntime;
         this.agentResourceCache = agentResourceCache;
         this.systemHardConstraint = systemHardConstraint;
-        this.mesosConfiguration = mesosConfiguration;
+        this.capacityGroupService = capacityGroupService;
         agentResourceCacheUpdater = new AgentResourceCacheUpdater(titusRuntime, agentResourceCache, v3JobOperations);
+        kubeIntegrationEnabled = mesosConfiguration.isKubeApiServerIntegrationEnabled();
 
         FitFramework fit = titusRuntime.getFitFramework();
         if (fit.isActive()) {
@@ -364,7 +373,7 @@ public class DefaultSchedulingService implements SchedulingService {
                                              TaskScheduler.Builder schedulerBuilder) {
         int minMinIdle = 4;
         final TaskScheduler scheduler = schedulerBuilder.withMaxOffersToReject(Math.max(1, minMinIdle))
-                .withSingleOfferPerVM(mesosConfiguration.isKubeApiServerIntegrationEnabled())
+                .withSingleOfferPerVM(kubeIntegrationEnabled)
                 .build();
         vmLeaseRescindedObservable
                 .doOnNext(event -> {
@@ -542,9 +551,25 @@ public class DefaultSchedulingService implements SchedulingService {
     }
 
     @Override
-    public void removeTask(String taskId, QAttributes qAttributes, String hostname) {
-        logger.info("Removing task from Fenzo: taskId={}, qAttributes={}, hostname={}", taskId, qAttributes, hostname);
-        schedulingService.removeTask(taskId, qAttributes, hostname);
+    public void removeTask(String taskId) {
+        Optional<Pair<Job<?>, Task>> taskById = v3JobOperations.findTaskById(taskId);
+        if (taskById.isPresent()) {
+            Pair<Job<?>, Task> jobTaskPair = taskById.get();
+            Job job = jobTaskPair.getLeft();
+            Task task = jobTaskPair.getRight();
+            Pair<Tier, String> tierAssignment = JobManagerUtil.getTierAssignment(job, capacityGroupService);
+            QAttributes qAttributes = new V3QAttributes(tierAssignment.getLeft().ordinal(), tierAssignment.getRight());
+            // host name should be null if it doesn't exist for fenzo to not try to unassign it
+            String hostname = kubeIntegrationEnabled ?
+                    task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID)
+                    :
+                    task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST);
+
+            logger.info("Removing task from Fenzo: taskId={}, qAttributes={}, hostname={}", taskId, qAttributes, hostname);
+            schedulingService.removeTask(taskId, qAttributes, hostname);
+        } else {
+            logger.warn("Unable to remove taskId: {} from fenzo because it does not exist in job management", taskId);
+        }
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulingService.java
@@ -26,6 +26,7 @@ import com.netflix.titus.master.scheduler.TaskPlacementFailure.FailureKind;
 import rx.Observable;
 
 /**
+ *
  */
 public interface SchedulingService {
 
@@ -43,11 +44,8 @@ public interface SchedulingService {
 
     /**
      * Removes a task from the scheduler.
-     * <p>
-     * FIXME To remove a task, it should be enough to pass the task id. The other arguments represent an internal state of the scheduling component itself.
      */
-    @Deprecated
-    void removeTask(String taskid, QAttributes qAttributes, String hostname);
+    void removeTask(String taskid);
 
     /**
      * Returns the last known scheduling result for a task.

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementRecorder.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementRecorder.java
@@ -226,7 +226,7 @@ class TaskPlacementRecorder {
         if (!fenzoTask.isCpuOpportunistic() || count <= 0) {
             return Collections.emptyMap();
         }
-        Optional<OpportunisticCpuAvailability> availability = opportunisticCpuCache.findAvailableOpportunisticCpus(assignmentResult.getVMId());
+        Optional<OpportunisticCpuAvailability> availability = opportunisticCpuCache.findAvailableOpportunisticCpus(assignmentResult.getHostname());
         if (!availability.isPresent()) {
             titusRuntime.getCodeInvariants().inconsistent("Task %s was scheduled on opportunistic CPUs that are not available",
                     fenzoTask.getId());

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/OpportunisticCpuConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/OpportunisticCpuConstraint.java
@@ -108,12 +108,12 @@ public class OpportunisticCpuConstraint implements SystemConstraint {
             return Failure.NO_RUNTIME_PREDICTION.toResult();
         }
 
-        String agentId = targetVM.getVMId();
-        if (StringExt.isEmpty(agentId)) {
+        String machineId = targetVM.getHostname();
+        if (StringExt.isEmpty(machineId)) {
             return Failure.NO_MACHINE_ID.toResult();
         }
 
-        Optional<OpportunisticCpuAvailability> availabilityOpt = opportunisticCpuCache.findAvailableOpportunisticCpus(agentId);
+        Optional<OpportunisticCpuAvailability> availabilityOpt = opportunisticCpuCache.findAvailableOpportunisticCpus(machineId);
         if (!availabilityOpt.isPresent()) {
             return Failure.NO_OPPORTUNISTIC_CPUS.toResult();
         }
@@ -124,7 +124,7 @@ public class OpportunisticCpuConstraint implements SystemConstraint {
             return Failure.AVAILABILITY_NOT_LONG_ENOUGH.toResult();
         }
 
-        if (availabilityOpt.get().getCount() - taskCache.getOpportunisticCpusAllocated(agentId) < request.getOpportunisticCpus()) {
+        if (availabilityOpt.get().getCount() - taskCache.getOpportunisticCpusAllocated(machineId) < request.getOpportunisticCpus()) {
             return Failure.NOT_ENOUGH_OPPORTUNISTIC_CPUS.toResult();
         }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/TaskCacheEventListener.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/TaskCacheEventListener.java
@@ -61,20 +61,15 @@ public class TaskCacheEventListener implements SchedulingEventListener {
 
         int opportunisticCpus = request.getOpportunisticCpus();
         if (request.isCpuOpportunistic() && opportunisticCpus > 0) {
-            String agentId = taskAssignmentResult.getVMId();
-            if (agentId == null) {
-                String hostname = taskAssignmentResult.getHostname();
-                codeInvariants().inconsistent("No machine ID for hostname %s", hostname);
-                agentId = hostname;
-            }
-            Optional<String> allocationId = opportunisticCpuCache.findAvailableOpportunisticCpus(agentId)
+            String machineId = taskAssignmentResult.getHostname();
+            Optional<String> allocationId = opportunisticCpuCache.findAvailableOpportunisticCpus(machineId)
                     .map(OpportunisticCpuAvailability::getAllocationId);
             if (!allocationId.isPresent()) {
-                codeInvariants().inconsistent("Task assigned to opportunistic CPUs on machine %s that can not be found", agentId);
+                codeInvariants().inconsistent("Task assigned to opportunistic CPUs on machine %s that can not be found", machineId);
             }
             taskCache.addOpportunisticCpuAllocation(new OpportunisticCpuAllocation(
                     taskAssignmentResult.getTaskId(),
-                    agentId,
+                    machineId,
                     allocationId.orElse(UNKNOWN_ALLOCATION_ID),
                     opportunisticCpus
             ));

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/resourcecache/AgentResourceCacheUpdater.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/resourcecache/AgentResourceCacheUpdater.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Subscription;
 
-import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID;
 
 public class AgentResourceCacheUpdater {
     private static final Logger logger = LoggerFactory.getLogger(AgentResourceCacheUpdater.class);
@@ -80,7 +80,7 @@ public class AgentResourceCacheUpdater {
     private void createOrUpdateAgentResourceCacheForV3Task(TaskUpdateEvent event) {
         Job<?> job = event.getCurrentJob();
         Task task = event.getCurrentTask();
-        String hostname = task.getTaskContext().get(TASK_ATTRIBUTES_AGENT_HOST);
+        String hostname = task.getTaskContext().get(TASK_ATTRIBUTES_AGENT_INSTANCE_ID);
         if (task.getStatus().getState() == TaskState.Started) {
             agentResourceCache.createOrUpdate(hostname, instanceOpt -> {
                 AgentResourceCacheInstance instance = AgentResourceCacheFunctions.createInstance(hostname, job, task, titusRuntime.getClock().wallTime());

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/resourcecache/TaskCache.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/resourcecache/TaskCache.java
@@ -177,7 +177,7 @@ public class TaskCache {
     }
 
     private static Optional<String> getAgentId(Task task) {
-        return Optional.ofNullable(task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID));
+        return Optional.ofNullable(task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID));
     }
 
     private static Optional<String> getOpportunisticCpuAllocationId(Task task) {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScalerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScalerTest.java
@@ -499,7 +499,7 @@ public class ClusterAgentAutoScalerTest {
         List<Task> tasks = createTasks(17, "jobId");
         for (int i = 0; i < tasks.size(); i++) {
             Task task = tasks.get(i);
-            when(task.getTaskContext()).thenReturn(singletonMap(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID, "instanceGroup1" + i));
+            when(task.getTaskContext()).thenReturn(singletonMap(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, "instanceGroup1" + i));
         }
 
         when(v3JobOperations.getTasks()).thenReturn(tasks);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterRemovableAgentRemoverTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterRemovableAgentRemoverTest.java
@@ -153,7 +153,7 @@ public class ClusterRemovableAgentRemoverTest {
 
     private Task createTask(String agentId) {
         Task task = mock(Task.class);
-        when(task.getTaskContext()).thenReturn(singletonMap(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID, agentId));
+        when(task.getTaskContext()).thenReturn(singletonMap(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, agentId));
         return task;
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterRemovableInstanceGroupAgentRemoverTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/clusteroperations/ClusterRemovableInstanceGroupAgentRemoverTest.java
@@ -147,7 +147,7 @@ public class ClusterRemovableInstanceGroupAgentRemoverTest {
 
     private Task createTask(String agentId) {
         Task task = mock(Task.class);
-        when(task.getTaskContext()).thenReturn(singletonMap(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID, agentId));
+        when(task.getTaskContext()).thenReturn(singletonMap(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, agentId));
         return task;
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedSchedulingService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedSchedulingService.java
@@ -44,9 +44,9 @@ class StubbedSchedulingService implements SchedulingService {
     }
 
     @Override
-    public void removeTask(String taskid, QAttributes qAttributes, String hostname) {
-        Preconditions.checkArgument(queuableTasks.containsKey(taskid));
-        queuableTasks.remove(taskid);
+    public void removeTask(String taskId) {
+        Preconditions.checkArgument(queuableTasks.containsKey(taskId));
+        queuableTasks.remove(taskId);
     }
 
     @Override

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
@@ -74,7 +74,7 @@ class StubbedVirtualMachineMasterService implements VirtualMachineMasterService 
 
             @Override
             public String hostname() {
-                return "1.2.3.4";
+                return "i-12345";
             }
 
             @Override

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/util/RelocationUtil.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/util/RelocationUtil.java
@@ -79,7 +79,7 @@ public final class RelocationUtil {
     }
 
     public static boolean isOnInstance(AgentInstance instance, Task task) {
-        String taskAgentId = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID);
+        String taskAgentId = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID);
         return taskAgentId != null && taskAgentId.equals(instance.getId());
     }
 

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskDocument.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskDocument.java
@@ -43,7 +43,7 @@ import com.netflix.titus.common.util.StringExt;
 
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_ASG;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST;
-import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_ID;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_ITYPE;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_REGION;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE;
@@ -475,7 +475,7 @@ public class TaskDocument {
             taskDocument.instanceType = instanceType;
         }
 
-        final String instanceId = taskContext.get(TASK_ATTRIBUTES_AGENT_ID);
+        final String instanceId = taskContext.get(TASK_ATTRIBUTES_AGENT_INSTANCE_ID);
         if (instanceId != null) {
             taskDocument.hostInstanceId = instanceId;
         }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
@@ -193,7 +193,6 @@ public class JobComponentStub {
                                 .withTimestamp(clock.wallTime())
                                 .build()
                         )
-                        .addToTaskContext("agent.id", agentInstance.getId())
                         .addToTaskContext(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, agentInstance.getId())
                         .addToTaskContext(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST, agentInstance.getIpAddress())
                         .build());

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
@@ -193,7 +193,7 @@ public class JobComponentStub {
                                 .withTimestamp(clock.wallTime())
                                 .build()
                         )
-                        .addToTaskContext(TaskAttributes.TASK_ATTRIBUTES_AGENT_ID, agentInstance.getId())
+                        .addToTaskContext("agent.id", agentInstance.getId())
                         .addToTaskContext(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, agentInstance.getId())
                         .addToTaskContext(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST, agentInstance.getIpAddress())
                         .build());


### PR DESCRIPTION
### Description of the Change
* Use a single machine id throughout the control plane
* Update the `SchedulingService.removeTask` API to hide the internal implementation details
* Start using `TASK_ATTRIBUTES_AGENT_INSTANCE_ID` consistently and remove `TASK_ATTRIBUTES_AGENT_ID` so it is not accidentally used