### PR TITLE
Simplify the scheduling service APIs

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobReconciliationFrameworkFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobReconciliationFrameworkFactory.java
@@ -312,7 +312,6 @@ public class JobReconciliationFrameworkFactory {
 
         try {
             Pair<Tier, String> tierAssignment = JobManagerUtil.getTierAssignment(job, capacityGroupService);
-            String host = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_HOST);
             schedulingService.addRunningTask(new V3QueueableTask(
                     tierAssignment.getLeft(),
                     tierAssignment.getRight(),
@@ -325,7 +324,7 @@ public class JobReconciliationFrameworkFactory {
                     constraintEvaluatorTransformer,
                     systemSoftConstraint,
                     systemHardConstraint
-            ), host);
+            ));
         } catch (Exception e) {
             logger.error("Failed to initialize running task in Fenzo: {} with error:", task.getId(), e);
             return TaskFenzoCheck.FenzoAddError;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulingService.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.netflix.fenzo.TaskRequest;
-import com.netflix.fenzo.queues.QueuableTask;
+import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.scheduler.TaskPlacementFailure.FailureKind;
 import rx.Observable;
 
@@ -35,12 +35,12 @@ public interface SchedulingService<T extends TaskRequest> {
     /**
      * Adds a running task to the scheduler. This method is used to restore the scheduler state after system failover.
      */
-    void addRunningTask(QueuableTask task, String hostname);
+    void addRunningTask(V3QueueableTask queueableTask);
 
     /**
      * Adds a new, not scheduled yet, task to the scheduler.
      */
-    void addTask(QueuableTask queuableTask);
+    void addTask(V3QueueableTask queueableTask);
 
     /**
      * Removes a task from the scheduler.

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedSchedulingService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedSchedulingService.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 import com.google.common.base.Preconditions;
 import com.netflix.fenzo.TaskRequest;
-import com.netflix.fenzo.queues.QueuableTask;
+import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.scheduler.SchedulingResultEvent;
 import com.netflix.titus.master.scheduler.SchedulingService;
 import com.netflix.titus.master.scheduler.TaskPlacementFailure;
@@ -32,14 +32,14 @@ import rx.Observable;
 
 class StubbedSchedulingService implements SchedulingService<TaskRequest> {
 
-    private final Map<String, QueuableTask> queuableTasks = new HashMap<>();
+    private final Map<String, V3QueueableTask> queuableTasks = new HashMap<>();
 
-    public HashMap<String, QueuableTask> getQueuableTasks() {
+    public HashMap<String, V3QueueableTask> getQueuableTasks() {
         return new HashMap<>(queuableTasks);
     }
 
     @Override
-    public void addTask(QueuableTask queuableTask) {
+    public void addTask(V3QueueableTask queuableTask) {
         queuableTasks.put(queuableTask.getId(), queuableTask);
     }
 
@@ -50,7 +50,7 @@ class StubbedSchedulingService implements SchedulingService<TaskRequest> {
     }
 
     @Override
-    public void addRunningTask(QueuableTask task, String hostname) {
+    public void addRunningTask(V3QueueableTask task) {
         queuableTasks.put(task.getId(), task);
     }
 


### PR DESCRIPTION
### Description of the Change
Simplify the scheduling service APIs to not use hostname and determine hostname as an internal implementation detail.