### PR TITLE
Fix circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,9 @@ jobs:
             sudo apt update
             sudo apt install -qy ca-certificates git
       - checkout
-      - run: sudo chmod -R 777 /root/.gradle/caches
-      - run: sudo chmod -R 777 /root/.gradle/wrapper
       - restore_cache:
           keys:
-            - v1-gradle-cache
+            - v2-gradle-cache
       - run: ./gradlew testAll --parallel --no-daemon --max-workers 2 --stacktrace
       - run:
           name: Save test results
@@ -35,6 +33,6 @@ jobs:
           paths:
             - ~/.gradle/caches
             - ~/.gradle/wrapper
-          key: v1-gradle-cache
+          key: v2-gradle-cache
           when: always
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2.1
 executors:
   java:
     docker:
-      - image: azul/zulu-openjdk:8
+      - image: circleci/openjdk:8-stretch-node-browsers-legacy
+  #azul/zulu-openjdk:8
 jobs:
   build:
     executor: java
@@ -12,12 +13,12 @@ jobs:
           environment:
             DEBIAN_FRONTEND: noninteractive
           command: |
-            apt update
-            apt install -qy ca-certificates git
+            sudo apt update
+            sudo apt install -qy ca-certificates git
       - checkout
-      - restore_cache:
-          keys:
-            - v1-gradle-cache
+#      - restore_cache:
+#          keys:
+#            - v1-gradle-cache
       - run: ./gradlew testAll --parallel --no-daemon --max-workers 2 --stacktrace
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
             sudo apt update
             sudo apt install -qy ca-certificates git
       - checkout
-#      - restore_cache:
-#          keys:
-#            - v2-gradle-cache
+      - restore_cache:
+          keys:
+            - v2-gradle-cache
       - run: ./gradlew testAll --parallel --no-daemon --max-workers 2 --stacktrace
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
             sudo apt update
             sudo apt install -qy ca-certificates git
       - checkout
-      - restore_cache:
-          keys:
-            - v2-gradle-cache
+#      - restore_cache:
+#          keys:
+#            - v2-gradle-cache
       - run: ./gradlew testAll --parallel --no-daemon --max-workers 2 --stacktrace
       - run:
           name: Save test results
@@ -34,5 +34,5 @@ jobs:
             - ~/.gradle/caches
             - ~/.gradle/wrapper
           key: v2-gradle-cache
-          when: always
+          when: on_success
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ executors:
   java:
     docker:
       - image: circleci/openjdk:8-stretch-node-browsers-legacy
-  #azul/zulu-openjdk:8
 jobs:
   build:
     executor: java
@@ -16,9 +15,9 @@ jobs:
             sudo apt update
             sudo apt install -qy ca-certificates git
       - checkout
-#      - restore_cache:
-#          keys:
-#            - v1-gradle-cache
+      - restore_cache:
+          keys:
+            - v1-gradle-cache
       - run: ./gradlew testAll --parallel --no-daemon --max-workers 2 --stacktrace
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
             sudo apt update
             sudo apt install -qy ca-certificates git
       - checkout
+      - run: sudo chmod -R 777 /root/.gradle/caches
+      - run: sudo chmod -R 777 /root/.gradle/wrapper
       - restore_cache:
           keys:
             - v1-gradle-cache


### PR DESCRIPTION
Embedded postgres does not like being run as root, default user for the previous docker image was root, using circleci's jdk8 image. Since the previous cache was in the root directory using a new index for this cache. 