### PR TITLE
Add scheduler REST/GRPC endpoints to TitusFederation server

### DIFF
--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/AggregatingSchedulerServiceGrpc.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/AggregatingSchedulerServiceGrpc.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.endpoint.grpc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.federation.service.AggregatingSchedulerService;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulingResultEvent;
+import com.netflix.titus.grpc.protogen.SchedulingResultRequest;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.attachCancellingCallback;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.safeOnError;
+
+@Singleton
+public class AggregatingSchedulerServiceGrpc extends SchedulerServiceGrpc.SchedulerServiceImplBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(AggregatingSchedulerServiceGrpc.class);
+
+    private final AggregatingSchedulerService schedulerService;
+
+    @Inject
+    public AggregatingSchedulerServiceGrpc(AggregatingSchedulerService schedulerService) {
+        this.schedulerService = schedulerService;
+    }
+
+    @Override
+    public void getSchedulingResult(SchedulingResultRequest request, StreamObserver<SchedulingResultEvent> responseObserver) {
+        Disposable subscription = schedulerService.findLastSchedulingResult(request.getTaskId()).subscribe(
+                responseObserver::onNext,
+                e -> safeOnError(logger, e, responseObserver),
+                responseObserver::onCompleted
+        );
+        attachCancellingCallback(responseObserver, subscription);
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/FederationGrpcModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/FederationGrpcModule.java
@@ -21,6 +21,7 @@ import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultAutoScalingServiceGrpc;
 import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultHealthServiceGrpc;
 import com.netflix.titus.runtime.endpoint.v3.grpc.DefaultJobManagementServiceGrpc;
@@ -32,6 +33,7 @@ public class FederationGrpcModule extends AbstractModule {
     protected void configure() {
         bind(TitusFederationGrpcServer.class).asEagerSingleton();
         bind(HealthGrpc.HealthImplBase.class).to(DefaultHealthServiceGrpc.class);
+        bind(SchedulerServiceGrpc.SchedulerServiceImplBase.class).to(AggregatingSchedulerServiceGrpc.class);
         bind(JobManagementServiceGrpc.JobManagementServiceImplBase.class).to(DefaultJobManagementServiceGrpc.class);
         bind(AutoScalingServiceGrpc.AutoScalingServiceImplBase.class).to(DefaultAutoScalingServiceGrpc.class);
         bind(LoadBalancerServiceGrpc.LoadBalancerServiceImplBase.class).to(DefaultLoadBalancerServiceGrpc.class);

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/TitusFederationGrpcServer.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/grpc/TitusFederationGrpcServer.java
@@ -35,6 +35,8 @@ import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceImplBase;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc.LoadBalancerServiceImplBase;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc.SchedulerServiceImplBase;
 import com.netflix.titus.runtime.endpoint.common.grpc.interceptor.ErrorCatchingServerInterceptor;
 import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
 import io.grpc.Server;
@@ -52,6 +54,7 @@ public class TitusFederationGrpcServer {
     private static final Logger LOG = LoggerFactory.getLogger(TitusFederationGrpcServer.class);
 
     private final HealthImplBase healthService;
+    private final SchedulerServiceImplBase schedulerService;
     private final JobManagementServiceImplBase jobManagementService;
     private AutoScalingServiceImplBase autoScalingService;
     private LoadBalancerServiceImplBase loadBalancerService;
@@ -64,11 +67,13 @@ public class TitusFederationGrpcServer {
     @Inject
     public TitusFederationGrpcServer(
             HealthImplBase healthService,
+            SchedulerServiceImplBase schedulerService,
             JobManagementServiceImplBase jobManagementService,
             AutoScalingServiceImplBase autoScalingService,
             LoadBalancerServiceImplBase loadBalancerService,
             EndpointConfiguration config) {
         this.healthService = healthService;
+        this.schedulerService = schedulerService;
         this.jobManagementService = jobManagementService;
         this.autoScalingService = autoScalingService;
         this.loadBalancerService = loadBalancerService;
@@ -87,6 +92,10 @@ public class TitusFederationGrpcServer {
                     .addService(ServerInterceptors.intercept(
                             healthService,
                             createInterceptors(HealthGrpc.getServiceDescriptor())
+                    ))
+                    .addService(ServerInterceptors.intercept(
+                            schedulerService,
+                            createInterceptors(SchedulerServiceGrpc.getServiceDescriptor())
                     ))
                     .addService(ServerInterceptors.intercept(
                             jobManagementService,

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/FederationSchedulerResource.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/FederationSchedulerResource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.endpoint.rest;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.netflix.titus.federation.service.AggregatingSchedulerService;
+import com.netflix.titus.grpc.protogen.SchedulingResultEvent;
+import com.netflix.titus.runtime.endpoint.common.rest.Responses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+/**
+ * Supports subset of operations provided by {@link com.netflix.titus.grpc.protogen.SchedulerServiceGrpc}, applicable
+ * at the federation level.
+ */
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(tags = "Scheduler")
+@Path("/v3/scheduler")
+@Singleton
+public class FederationSchedulerResource {
+
+    private final AggregatingSchedulerService schedulerService;
+
+    @Inject
+    public FederationSchedulerResource(AggregatingSchedulerService schedulerService) {
+        this.schedulerService = schedulerService;
+    }
+
+    @GET
+    @ApiOperation("Find scheduling result for a task")
+    @Path("/results/{id}")
+    public SchedulingResultEvent findLastSchedulingResult(@PathParam("id") String taskId) {
+        return Responses.fromMono(schedulerService.findLastSchedulingResult(taskId));
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/JerseyModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/JerseyModule.java
@@ -71,6 +71,7 @@ public final class JerseyModule extends JerseyServletModule {
 
             // resources
             config.getClasses().add(HealthResource.class);
+            config.getClasses().add(FederationSchedulerResource.class);
             config.getClasses().add(JobManagementResource.class);
             config.getClasses().add(AutoScalingResource.class);
             config.getClasses().add(LoadBalancerResource.class);

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingSchedulerService.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingSchedulerService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service;
+
+import com.netflix.titus.grpc.protogen.SchedulingResultEvent;
+import reactor.core.publisher.Mono;
+
+/**
+ * Supports subset of operations provided by {@link com.netflix.titus.grpc.protogen.SchedulerServiceGrpc}, applicable
+ * at the federation level.
+ */
+public interface AggregatingSchedulerService {
+
+    /**
+     * Returns the last known scheduling result for a task.
+     *
+     * @return {@link Mono#empty()} if the task is not found or the scheduling result otherwise
+     */
+    Mono<SchedulingResultEvent> findLastSchedulingResult(String taskId);
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultAggregatingSchedulerService.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultAggregatingSchedulerService.java
@@ -50,10 +50,10 @@ public class DefaultAggregatingSchedulerService implements AggregatingSchedulerS
 
     @Override
     public Mono<SchedulingResultEvent> findLastSchedulingResult(String taskId) {
-        return findTaskInAllCells(taskId).map(CellResponse::getResult);
+        return findSchedulingResultInAllCells(taskId).map(CellResponse::getResult);
     }
 
-    private Mono<CellResponse<SchedulerServiceGrpc.SchedulerServiceStub, SchedulingResultEvent>> findTaskInAllCells(String taskId) {
+    private Mono<CellResponse<SchedulerServiceGrpc.SchedulerServiceStub, SchedulingResultEvent>> findSchedulingResultInAllCells(String taskId) {
         Observable<CellResponse<SchedulerServiceGrpc.SchedulerServiceStub, SchedulingResultEvent>> action = aggregatingClient.callExpectingErrors(SchedulerServiceGrpc::newStub, findSchedulingResultInCell(taskId))
                 .reduce(ResponseMerger.singleValue())
                 .flatMap(response -> response.getResult()

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultAggregatingSchedulerService.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultAggregatingSchedulerService.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service;
+
+import java.util.function.BiConsumer;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.netflix.titus.common.util.rx.ReactorExt;
+import com.netflix.titus.federation.startup.GrpcConfiguration;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulingResultEvent;
+import com.netflix.titus.grpc.protogen.SchedulingResultRequest;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import io.grpc.stub.StreamObserver;
+import reactor.core.publisher.Mono;
+import rx.Observable;
+
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
+
+@Singleton
+public class DefaultAggregatingSchedulerService implements AggregatingSchedulerService {
+
+    private final GrpcConfiguration grpcConfiguration;
+    private final AggregatingCellClient aggregatingClient;
+    private final CallMetadataResolver callMetadataResolver;
+
+    @Inject
+    public DefaultAggregatingSchedulerService(GrpcConfiguration grpcConfiguration,
+                                              AggregatingCellClient aggregatingClient,
+                                              CallMetadataResolver callMetadataResolver) {
+        this.grpcConfiguration = grpcConfiguration;
+        this.aggregatingClient = aggregatingClient;
+        this.callMetadataResolver = callMetadataResolver;
+    }
+
+    @Override
+    public Mono<SchedulingResultEvent> findLastSchedulingResult(String taskId) {
+        return findTaskInAllCells(taskId).map(CellResponse::getResult);
+    }
+
+    private Mono<CellResponse<SchedulerServiceGrpc.SchedulerServiceStub, SchedulingResultEvent>> findTaskInAllCells(String taskId) {
+        Observable<CellResponse<SchedulerServiceGrpc.SchedulerServiceStub, SchedulingResultEvent>> action = aggregatingClient.callExpectingErrors(SchedulerServiceGrpc::newStub, findSchedulingResultInCell(taskId))
+                .reduce(ResponseMerger.singleValue())
+                .flatMap(response -> response.getResult()
+                        .map(v -> Observable.just(CellResponse.ofValue(response)))
+                        .onErrorGet(Observable::error)
+                );
+        return ReactorExt.toFlux(action).last();
+    }
+
+    private ClientCall<SchedulingResultEvent> findSchedulingResultInCell(String taskId) {
+        SchedulingResultRequest request = SchedulingResultRequest.newBuilder().setTaskId(taskId).build();
+        return (client, streamObserver) -> wrap(client).getSchedulingResult(request, streamObserver);
+    }
+
+    private SchedulerServiceGrpc.SchedulerServiceStub wrap(SchedulerServiceGrpc.SchedulerServiceStub client) {
+        return createWrappedStub(client, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
+    }
+
+    private interface ClientCall<T> extends BiConsumer<SchedulerServiceGrpc.SchedulerServiceStub, StreamObserver<T>> {
+        // generics sanity
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/ServiceModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/ServiceModule.java
@@ -26,6 +26,7 @@ public class ServiceModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(HealthService.class).to(AggregatingHealthService.class);
+        bind(AggregatingSchedulerService.class).to(DefaultAggregatingSchedulerService.class);
         bind(JobServiceGateway.class).to(AggregatingJobServiceGateway.class);
         bind(AutoScalingService.class).to(AggregatingAutoScalingService.class);
         bind(LoadBalancerService.class).to(AggregatingLoadbalancerService.class);

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/EmbeddedTitusOperations.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/EmbeddedTitusOperations.java
@@ -22,6 +22,7 @@ import com.netflix.titus.grpc.protogen.EvictionServiceGrpc;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
 import com.netflix.titus.testkit.embedded.cloud.agent.TaskExecutorHolder;
 import rx.Observable;
@@ -30,6 +31,8 @@ public interface EmbeddedTitusOperations {
     SimulatedCloud getSimulatedCloud();
 
     HealthGrpc.HealthStub getHealthClient();
+
+    SchedulerServiceGrpc.SchedulerServiceBlockingStub getV3BlockingSchedulerClient();
 
     JobManagementServiceGrpc.JobManagementServiceStub getV3GrpcClient();
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedCellTitusOperations.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/EmbeddedCellTitusOperations.java
@@ -24,6 +24,7 @@ import com.netflix.titus.grpc.protogen.EvictionServiceGrpc;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.testkit.embedded.EmbeddedTitusOperations;
 import com.netflix.titus.testkit.embedded.cell.gateway.EmbeddedTitusGateway;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMaster;
@@ -55,6 +56,11 @@ public class EmbeddedCellTitusOperations implements EmbeddedTitusOperations {
     @Override
     public HealthGrpc.HealthStub getHealthClient() {
         return gateway.map(EmbeddedTitusGateway::getHealthClient).orElse(master.getHealthClient());
+    }
+
+    @Override
+    public SchedulerServiceGrpc.SchedulerServiceBlockingStub getV3BlockingSchedulerClient() {
+        return gateway.map(EmbeddedTitusGateway::getV3BlockingSchedulerClient).orElse(master.getV3BlockingSchedulerClient());
     }
 
     @Override

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
@@ -40,6 +40,7 @@ import com.netflix.titus.grpc.protogen.EvictionServiceGrpc;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.master.TitusMaster;
 import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.AdmissionValidator;
@@ -181,6 +182,11 @@ public class EmbeddedTitusGateway {
 
     public HealthGrpc.HealthStub getHealthClient() {
         HealthGrpc.HealthStub client = HealthGrpc.newStub(getOrCreateGrpcChannel());
+        return attachCallHeaders(client);
+    }
+
+    public SchedulerServiceGrpc.SchedulerServiceBlockingStub getV3BlockingSchedulerClient() {
+        SchedulerServiceGrpc.SchedulerServiceBlockingStub client = SchedulerServiceGrpc.newBlockingStub(getOrCreateGrpcChannel());
         return attachCallHeaders(client);
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
@@ -74,6 +74,7 @@ import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceBlockingStub;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceStub;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.grpc.protogen.SupervisorServiceGrpc;
 import com.netflix.titus.grpc.protogen.SupervisorServiceGrpc.SupervisorServiceBlockingStub;
 import com.netflix.titus.master.TitusMaster;
@@ -331,6 +332,11 @@ public class EmbeddedTitusMaster {
 
     public SupervisorServiceBlockingStub getSupervisorBlockingGrpcClient() {
         SupervisorServiceBlockingStub client = SupervisorServiceGrpc.newBlockingStub(getOrCreateGrpcChannel());
+        return TestKitGrpcClientErrorUtils.attachCallHeaders(client);
+    }
+
+    public SchedulerServiceGrpc.SchedulerServiceBlockingStub getV3BlockingSchedulerClient() {
+        SchedulerServiceGrpc.SchedulerServiceBlockingStub client = SchedulerServiceGrpc.newBlockingStub(getOrCreateGrpcChannel());
         return TestKitGrpcClientErrorUtils.attachCallHeaders(client);
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedFederationTitusOperations.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedFederationTitusOperations.java
@@ -25,6 +25,7 @@ import com.netflix.titus.grpc.protogen.EvictionServiceGrpc;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.testkit.embedded.EmbeddedTitusOperations;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
 import com.netflix.titus.testkit.embedded.cloud.agent.TaskExecutorHolder;
@@ -49,6 +50,11 @@ class EmbeddedFederationTitusOperations implements EmbeddedTitusOperations {
     @Override
     public HealthGrpc.HealthStub getHealthClient() {
         return federation.getHealthGrpcClient();
+    }
+
+    @Override
+    public SchedulerServiceGrpc.SchedulerServiceBlockingStub getV3BlockingSchedulerClient() {
+        return federation.getV3BlockingSchedulerClient();
     }
 
     @Override

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedTitusFederation.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedTitusFederation.java
@@ -36,6 +36,7 @@ import com.netflix.titus.grpc.protogen.EvictionServiceGrpc;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
+import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.master.TitusMaster;
 import com.netflix.titus.runtime.endpoint.common.rest.EmbeddedJettyModule;
 import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
@@ -153,6 +154,11 @@ public class EmbeddedTitusFederation {
 
     public HealthGrpc.HealthStub getHealthGrpcClient() {
         HealthGrpc.HealthStub client = HealthGrpc.newStub(getOrCreateGrpcChannel());
+        return attachCallHeaders(client);
+    }
+
+    public SchedulerServiceGrpc.SchedulerServiceBlockingStub getV3BlockingSchedulerClient() {
+        SchedulerServiceGrpc.SchedulerServiceBlockingStub client = SchedulerServiceGrpc.newBlockingStub(getOrCreateGrpcChannel());
         return attachCallHeaders(client);
     }
 


### PR DESCRIPTION
for now limited to `findLastSchedulingResult` operation only.
