### PR TITLE
prevent @Activator methods called multiple times

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
@@ -20,7 +20,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 import javax.inject.Singleton;
 
@@ -44,7 +46,7 @@ public class ActivationProvisionListener implements ActivationLifecycle, Provisi
 
     private static final Logger logger = LoggerFactory.getLogger(ActivationProvisionListener.class);
 
-    private final List<ServiceHolder> services = new CopyOnWriteArrayList<>();
+    private final Set<ServiceHolder> services = new CopyOnWriteArraySet<>();
 
     private long activationTime = -1;
 
@@ -188,6 +190,20 @@ public class ActivationProvisionListener implements ActivationLifecycle, Provisi
 
             activated = false;
             activationTime = -1;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof ServiceHolder)) {
+                return false;
+            }
+            ServiceHolder other = (ServiceHolder) obj;
+            return Objects.equals(this.injectee, other.injectee);
+        }
+
+        @Override
+        public int hashCode() {
+            return injectee.hashCode();
         }
     }
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
@@ -199,13 +198,16 @@ public class ActivationProvisionListener implements ActivationLifecycle, Provisi
             activationTime = -1;
         }
 
+        /**
+         * Two service holders are considered equal if they are holding the same instance (based on object identity).
+         */
         @Override
         public boolean equals(Object obj) {
             if (!(obj instanceof ServiceHolder)) {
                 return false;
             }
             ServiceHolder other = (ServiceHolder) obj;
-            return Objects.equals(this.injectee, other.injectee);
+            return this.injectee == other.injectee;
         }
 
         @Override

--- a/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
@@ -39,6 +39,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Guice {@link ProvisionListener} that scans services for presence of {@link Activator} and {@link Deactivator}
  * annotations, and adds them to activation/deactivation lifecycle.
+ * <p>
+ * Deactivations happen in the reverse order of activations.
  */
 @Singleton
 @SuppressLifecycleUninitialized
@@ -46,6 +48,11 @@ public class ActivationProvisionListener implements ActivationLifecycle, Provisi
 
     private static final Logger logger = LoggerFactory.getLogger(ActivationProvisionListener.class);
 
+    /**
+     * Keep all services that need activation/deactivation as a {@link Set} to avoid activating the same instance
+     * multiple times. <b>Note:</b> the {@link Set} implementation used <b>must</b> preserve insertion order, since
+     * deactivation needs to happen in the reverse order of activation.
+     */
     private final Set<ServiceHolder> services = new CopyOnWriteArraySet<>();
 
     private long activationTime = -1;

--- a/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/guice/internal/ActivationProvisionListener.java
@@ -121,8 +121,8 @@ public class ActivationProvisionListener implements ActivationLifecycle, Provisi
         private final List<Method> activateMethods;
         private final List<Method> deactivateMethods;
 
-        private boolean activated;
-        private long activationTime = -1;
+        private volatile boolean activated;
+        private volatile long activationTime = -1;
 
         ServiceHolder(Object injectee) {
             this.injectee = injectee;


### PR DESCRIPTION
Guice will call `onProvision()` multiple times even for a @Singleton some times (apparently when it is being injected multiple times).

Make sure each unique instance (based on `Object#equals()`) is only registered once to be activated.