### PR TITLE
opportunistic: filter out non-schedulable agents

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -531,7 +531,8 @@ public class DefaultSchedulingService implements SchedulingService<V3QueueableTa
      * are transient and should be retried on every iteration.
      */
     private void processTaskSchedulingFailureCallbacks(Map<FailureKind, Map<V3QueueableTask, List<TaskPlacementFailure>>> failuresByKind) {
-        for (V3QueueableTask failed : SchedulerUtils.collectFailedTasksIgnoring(failuresByKind, FailureKind.TRANSIENT)) {
+        for (V3QueueableTask failed : SchedulerUtils.collectFailedTasksIgnoring(failuresByKind,
+                FailureKind.IGNORED_FOR_OPPORTUNISTIC_SCHEDULING)) {
             ((TitusQueuableTask) failed).opportunisticSchedulingFailed();
         }
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
@@ -20,8 +20,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.netflix.titus.api.model.Tier;
+import com.netflix.titus.master.clusteroperations.ClusterAgentAutoScaler;
 
 public class TaskPlacementFailure {
 
@@ -71,15 +73,23 @@ public class TaskPlacementFailure {
 
         /**
          * Failures that are expected to go away, and should not be acted upon
-         *
-         * @see DefaultSchedulingService
          */
         public static final Set<FailureKind> TRANSIENT = Sets.immutableEnumSet(WaitingForInUseIpAllocation, LaunchGuard);
 
         /**
+         * <tt>TRANSIENT</tt> and <tt>NoActiveAgent</tt> (all agents are non-schedulable for a task) must never modify
+         * opportunistic scheduling behavior.
+         *
+         * @see DefaultSchedulingService
+         */
+        public static final Set<FailureKind> IGNORED_FOR_OPPORTUNISTIC_SCHEDULING = ImmutableSet.<FailureKind>builder()
+                .addAll(TRANSIENT)
+                .add(NoActiveAgents).build();
+
+        /**
          * Failures that should never trigger cluster autoscaling
          *
-         * @see com.netflix.titus.master.clusteroperations.ClusterAgentAutoScaler
+         * @see ClusterAgentAutoScaler
          */
         public static final Set<FailureKind> NEVER_TRIGGER_AUTOSCALING = Sets.immutableEnumSet(WaitingForInUseIpAllocation, OpportunisticResource);
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/OpportunisticCpuConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/OpportunisticCpuConstraint.java
@@ -19,6 +19,9 @@ package com.netflix.titus.master.scheduler.constraint;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -61,20 +64,19 @@ public class OpportunisticCpuConstraint implements SystemConstraint {
         }
     }
 
+    private static final Set<String> FAILURE_REASONS = Stream.of(Failure.values())
+            .map(f -> f.toResult().getFailureReason())
+            .collect(Collectors.toSet());
+
+    public static boolean isOpportunisticCpuConstraintReason(String reason) {
+        return reason != null && FAILURE_REASONS.contains(reason);
+    }
+
     private final SchedulerConfiguration configuration;
     private final FeatureActivationConfiguration featureConfiguration;
     private final TaskCache taskCache;
     private final OpportunisticCpuCache opportunisticCpuCache;
     private final TitusRuntime titusRuntime;
-
-    public static boolean isOpportunisticCpuConstraintReason(String reason) {
-        for (Failure failure : Failure.values()) {
-            if (failure.toResult().getFailureReason().equals(reason)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     @Inject
     public OpportunisticCpuConstraint(SchedulerConfiguration configuration,


### PR DESCRIPTION
... when deciding to reduce opportunistic allocations. If all scheduling constraint failures are from non-schedulable agents (disabled, gpu, etc), keep opportunistic tasks queued as-is.