### PR TITLE
Remove requirement that IP byte arrays be base64 encoded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,6 @@ subprojects {
         okHttpVersion = '3.8.0'
         cassandraDriverVersion = '3.3.+'
         commonsCliVersion = '1.3.+'
-        commonsCodecVersion = '1.13'
         caffeineVersion = '2.6.+'
         rxJavaInteropVersion = '0.13.+'
         kubernetesClientVersion = '6.0.1'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobAssertions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobAssertions.java
@@ -36,7 +36,6 @@ import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.StringExt;
-import org.apache.commons.codec.binary.Base64;
 
 import static com.netflix.titus.common.util.StringExt.isAsciiDigit;
 import static com.netflix.titus.common.util.StringExt.isAsciiLetter;
@@ -94,10 +93,6 @@ public class JobAssertions {
         int totalSize = entryPoint.stream().mapToInt(e -> StringExt.isEmpty(e) ? 0 : e.getBytes(UTF_8).length).sum();
 
         return totalSize <= MAX_ENTRY_POINT_SIZE_SIZE_BYTES;
-    }
-
-    public boolean isBase64(byte[] bytes) {
-        return Base64.isBase64(bytes);
     }
 
     public Map<String, String> validateEnvironmentVariableNames(Map<String, String> environment) {

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/SignedIpAddressAllocation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/SignedIpAddressAllocation.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import javax.validation.Valid;
 
 import com.netflix.titus.common.model.sanitizer.ClassFieldsNotNull;
-import com.netflix.titus.common.model.sanitizer.FieldInvariant;
 
 @ClassFieldsNotNull
 public class SignedIpAddressAllocation {
@@ -29,34 +28,14 @@ public class SignedIpAddressAllocation {
     @Valid
     private final IpAddressAllocation ipAddressAllocation;
 
-    @FieldInvariant(
-            value = "@asserts.isBase64(value)",
-            message = "Must be base64 encoded"
-    )
     private final byte[] authoritativePublicKey;
 
-    @FieldInvariant(
-            value = "@asserts.isBase64(value)",
-            message = "Must be base64 encoded"
-    )
     private final byte[] hostPublicKey;
 
-    @FieldInvariant(
-            value = "@asserts.isBase64(value)",
-            message = "Must be base64 encoded"
-    )
     private final byte[] hostPublicKeySignature;
 
-    @FieldInvariant(
-            value = "@asserts.isBase64(value)",
-            message = "Must be base64 encoded"
-    )
     private final byte[] message;
 
-    @FieldInvariant(
-            value = "@asserts.isBase64(value)",
-            message = "Must be base64 encoded"
-    )
     private final byte[] messageSignature;
 
     public SignedIpAddressAllocation(IpAddressAllocation ipAddressAllocation,

--- a/titus-common/build.gradle
+++ b/titus-common/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     compile "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     compile "javax.servlet:javax.servlet-api:${servletVersion}"
     compile "javax.ws.rs:jsr311-api:1.1.1"
-    compile "commons-codec:commons-codec:${commonsCodecVersion}"
 
     // Java Bean validation/EL and SpEL
     compile "javax.el:javax.el-api:${javaxElVersion}"

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobIpAllocationsTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobIpAllocationsTest.java
@@ -17,7 +17,6 @@
 package com.netflix.titus.master.integration.v3.job;
 
 import java.util.AbstractMap;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
@@ -239,24 +238,6 @@ public class JobIpAllocationsTest extends BaseIntegrationTest {
             }
         }
         assertThat(verified).isTrue();
-    }
-
-    /**
-     * Tests a job without a Base64 encoded signature is rejected.
-     */
-    @Test(timeout = 30_000)
-    public void testBase64Validation() throws Exception {
-        String invalidSignature = "!";
-        byte[] invalidSignatureBytes = invalidSignature.getBytes();
-        JobDescriptor<ServiceJobExt> invalidJobDescriptor = ONE_TASK_SERVICE_JOB
-                .but(j -> j.getContainer()
-                        .but(c -> c.getContainerResources().toBuilder().withSignedIpAddressAllocations(Collections.singletonList(
-                                c.getContainerResources().getSignedIpAddressAllocations().get(0).toBuilder().withHostPublicKeySignature(invalidSignatureBytes).build()
-                        )))
-                );
-        submitBadJob(client,
-                toGrpcJobDescriptor(invalidJobDescriptor),
-                "container.containerResources.ipSignedAddressAllocations[0].hostPublicKeySignature");
     }
 
     /**


### PR DESCRIPTION
These fields are already base64 encoded going over the wire and and when written to disk.