### PR TITLE
Limit threads used by ObserveJobs and add instrumentation

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/grpc/GrpcMasterEndpointConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/grpc/GrpcMasterEndpointConfiguration.java
@@ -20,8 +20,6 @@ import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
 import com.netflix.archaius.api.annotations.PropertyName;
 
-/**
- */
 @Configuration(prefix = "titus.master.grpcServer")
 public interface GrpcMasterEndpointConfiguration {
 
@@ -44,4 +42,11 @@ public interface GrpcMasterEndpointConfiguration {
      */
     @DefaultValue("false")
     boolean isJobSizeValidationEnabled();
+
+    /**
+     * Max number of threads used to handle expensive server streaming calls. 2 threads per available CPU is usually a
+     * good start, tweak as necessary.
+     */
+    @DefaultValue("256")
+    int getServerStreamsThreadPoolSize();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -605,7 +605,6 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                 .observeOn(observeJobsScheduler)
                 .subscribeOn(observeJobsScheduler, false)
                 .map(event -> GrpcJobManagementModelConverters.toGrpcJobChangeNotification(event, logStorageInfo))
-                // TODO(fabio): move only snapshot generation to the observeJobsScheduler instead of the entire stream
                 .compose(ObservableExt.head(() -> {
                     List<JobChangeNotification> snapshot = createJobsSnapshot(jobsPredicate, tasksPredicate);
                     snapshot.add(SNAPSHOT_END_MARKER);
@@ -636,7 +635,6 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                 .observeOn(observeJobsScheduler)
                 .subscribeOn(observeJobsScheduler, false)
                 .map(event -> GrpcJobManagementModelConverters.toGrpcJobChangeNotification(event, logStorageInfo))
-                // TODO(fabio): move only snapshot generation to the observeJobsScheduler instead of the entire stream
                 .compose(ObservableExt.head(() -> {
                     List<JobChangeNotification> snapshot = createJobSnapshot(jobId);
                     snapshot.add(SNAPSHOT_END_MARKER);

--- a/titus-supplementary-component/job-activity-history-springboot/src/main/java/com/netflix/titus/supplementary/jobactivity/JobActivityMain.java
+++ b/titus-supplementary-component/job-activity-history-springboot/src/main/java/com/netflix/titus/supplementary/jobactivity/JobActivityMain.java
@@ -19,6 +19,7 @@ package com.netflix.titus.supplementary.jobactivity;
 import javax.inject.Named;
 
 import com.netflix.titus.common.runtime.InternalRuntimeComponent;
+import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.runtime.connector.common.reactor.GrpcToReactorClientFactoryComponent;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagementDataReplicationComponent;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagerConnectorComponent;
@@ -59,8 +60,9 @@ public class JobActivityMain {
 
     @Bean
     public JobActivityGrpcServer getJobActivityHistoryGrpcServer(GrpcEndpointConfiguration configuration,
-                                                                 JobActivityGrpcService jobActivityGrpcService) {
-        return new JobActivityGrpcServer(configuration, jobActivityGrpcService);
+                                                                 JobActivityGrpcService jobActivityGrpcService,
+                                                                 TitusRuntime runtime) {
+        return new JobActivityGrpcServer(configuration, jobActivityGrpcService, runtime);
     }
 
     public static void main(String[] args) {

--- a/titus-supplementary-component/job-activity-history/src/main/java/com/netflix/titus/supplementary/jobactivity/endpoint/grpc/JobActivityGrpcServer.java
+++ b/titus-supplementary-component/job-activity-history/src/main/java/com/netflix/titus/supplementary/jobactivity/endpoint/grpc/JobActivityGrpcServer.java
@@ -19,6 +19,7 @@ package com.netflix.titus.supplementary.jobactivity.endpoint.grpc;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.runtime.endpoint.common.grpc.AbstractTitusGrpcServer;
 import com.netflix.titus.runtime.endpoint.common.grpc.GrpcEndpointConfiguration;
 
@@ -27,7 +28,8 @@ public class JobActivityGrpcServer extends AbstractTitusGrpcServer {
 
     @Inject
     public JobActivityGrpcServer(GrpcEndpointConfiguration configuration,
-                                 JobActivityGrpcService jobActivityGrpcService) {
-        super(configuration, jobActivityGrpcService);
+                                 JobActivityGrpcService jobActivityGrpcService,
+                                 TitusRuntime runtime) {
+        super(configuration, jobActivityGrpcService, runtime);
     }
 }


### PR DESCRIPTION
TitusMaster servers can be DoS'd with very few `ObserveJobs` calls. Currently, each `ObserveJobs` stream will consume a new thread in a TitusMaster server. Additionally, gRPC will by default use a different thread pool for each `Channel`. In a typical server configuration, the maximum number of threads is in the dozens of thousands.

These changes considerably improve (by 10x or more) our ability to handle server streaming calls:

* use a single thread pool for all gRPC tasks, instead of a separate thread pool per channel (default with gRPC)
* limit the number of threads used for server streaming (ObserveJobs) tasks, instead of using an unbounded thread pool and potentially spawning a new thread per request while stream snapshots are being generated (an expensive operation). This will cause calls to sit on a queue when snapshots can't be generated fast enough, i.e. requests are queued when we are overloaded
* metrics for thread pool sizes, busy thread counts, and task counts on gRPC thread pools

I did some load testing with an empty Titus stack, and after these changes we were able to sustain ~300 `ObserveJobs` calls/sec with little additional threads from what is pre-allocated in the fixed size thread pools. 100k concurrent streams were no problem and consumed not more than a few hundred threads. This is significantly better than what we saw in the past.

The only remaining problem is with `rx.unsubscribe()`, called when gRPC streams are canceled. That is sadly blocking inside the RxJava stack, and putting pressure on gRPC thread pools and the Rx Computation Scheduler. Canceling 100k `ObserveJobs` streams consumed ~4k threads for a few seconds and caused the hiccup sensor to complain about threads blocked in the Rx Computation Scheduler.

Unsubscription being expensive can still be a problem, and we will need another solution for it. But these changes put us in a much better shape.