### PR TITLE
Updated reconciliation streams for app auto scale controller 

### DIFF
--- a/titus-server-master/src/test/java/com/netflix/titus/master/appscale/endpoint.v3/grpc/DefaultAutoScalingServiceGrpcTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/appscale/endpoint.v3/grpc/DefaultAutoScalingServiceGrpcTest.java
@@ -26,6 +26,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.titus.api.appscale.model.PolicyType;
 import com.netflix.titus.api.appscale.service.AppScaleManager;
 import com.netflix.titus.api.appscale.store.AppScalePolicyStore;
+import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.grpc.protogen.DeletePolicyRequest;
 import com.netflix.titus.grpc.protogen.GetPolicyResult;
 import com.netflix.titus.grpc.protogen.JobId;
@@ -55,7 +56,9 @@ public class DefaultAutoScalingServiceGrpcTest {
             new AutoScalingPolicyTests.MockAlarmClient(),
             new AutoScalingPolicyTests.MockAppAutoScalingClient(), null,
             new DefaultRegistry(),
-            AutoScalingPolicyTests.mockAppScaleManagerConfiguration(), Schedulers.immediate());
+            AutoScalingPolicyTests.mockAppScaleManagerConfiguration(),
+            Schedulers.immediate(),
+            TitusRuntimes.test());
     private final DefaultAutoScalingServiceGrpc service = new DefaultAutoScalingServiceGrpc(appScaleManager);
 
     @Before

--- a/titus-server-master/src/test/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManagerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/appscale/service/DefaultAppScaleManagerTest.java
@@ -42,6 +42,7 @@ import com.netflix.titus.api.jobmanager.model.job.event.JobUpdateEvent;
 import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.api.model.callmetadata.CallMetadata;
+import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.runtime.store.v3.memory.InMemoryPolicyStore;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -82,9 +83,13 @@ public class DefaultAppScaleManagerTest {
         String jobIdTwo = UUID.randomUUID().toString();
         V3JobOperations v3JobOperations = mockV3Operations(jobIdOne, jobIdTwo);
 
-        DefaultAppScaleManager appScaleManager = new DefaultAppScaleManager(policyStore, mockAlarmClient, mockAppAutoScalingClient,
-                v3JobOperations, new DefaultRegistry(),
-                AutoScalingPolicyTests.mockAppScaleManagerConfiguration(), Schedulers.immediate());
+        DefaultAppScaleManager appScaleManager = new DefaultAppScaleManager(policyStore, mockAlarmClient,
+                mockAppAutoScalingClient,
+                v3JobOperations,
+                new DefaultRegistry(),
+                AutoScalingPolicyTests.mockAppScaleManagerConfiguration(),
+                Schedulers.immediate(),
+                mock(TitusRuntime.class));
 
         AutoScalingPolicy autoScalingPolicyOne;
         AutoScalingPolicy autoScalingPolicyTwo;
@@ -145,8 +150,11 @@ public class DefaultAppScaleManagerTest {
         DefaultAppScaleManager appScaleManager = new DefaultAppScaleManager(policyStore,
                 new AutoScalingPolicyTests.MockAlarmClient(),
                 appScalingClient,
-                v3JobOperations, new DefaultRegistry(),
-                AutoScalingPolicyTests.mockAppScaleManagerConfiguration(), Schedulers.immediate());
+                v3JobOperations,
+                new DefaultRegistry(),
+                AutoScalingPolicyTests.mockAppScaleManagerConfiguration(),
+                Schedulers.immediate(),
+                mock(TitusRuntime.class));
 
         List<String> refIds = submitTwoJobs(appScaleManager, jobIdOne, jobIdTwo, policyStore);
         Assertions.assertThat(refIds.size()).isEqualTo(2);
@@ -271,8 +279,11 @@ public class DefaultAppScaleManagerTest {
         V3JobOperations v3JobOperations = mockV3OperationsForJobs(jobIds);
         DefaultAppScaleManager appScaleManager = new DefaultAppScaleManager(policyStore, mockAlarmClient,
                 mockAppAutoScalingClient,
-                v3JobOperations, new DefaultRegistry(), AutoScalingPolicyTests.mockAppScaleManagerConfiguration(),
-                Schedulers.computation());
+                v3JobOperations,
+                new DefaultRegistry(),
+                AutoScalingPolicyTests.mockAppScaleManagerConfiguration(),
+                Schedulers.computation(),
+                mock(TitusRuntime.class));
 
         final CountDownLatch latch = new CountDownLatch(totalJobs);
         for (int i = 0; i < totalJobs; i++) {


### PR DESCRIPTION
### Making reconciliation streams more resilient

application auto scaling controller uses a number of reconciliation mechanism between Titus job state and AWS auto scaling state. Each of these Rx streams are subject to failure that are not retried by default. By wrapping those streams in TitusRuntime.persistentStream(..), they get unlimited exponential backed off retries.