### PR TITLE
Add NETFLIX_EXECUTOR env variable

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
@@ -187,6 +187,7 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
 
         containerInfoBuilder.putTitusProvidedEnv("TITUS_JOB_ID", task.getJobId());
         containerInfoBuilder.putTitusProvidedEnv("TITUS_TASK_ID", task.getId());
+        containerInfoBuilder.putTitusProvidedEnv("NETFLIX_EXECUTOR", "titus");
         containerInfoBuilder.putTitusProvidedEnv("NETFLIX_INSTANCE_ID", task.getId());
         containerInfoBuilder.putTitusProvidedEnv("TITUS_TASK_INSTANCE_ID", task.getId());
         containerInfoBuilder.putTitusProvidedEnv("TITUS_TASK_ORIGINAL_ID", task.getOriginalId());


### PR DESCRIPTION
This allows for a single source to determine what compute environment a workload is running in - both EC2 and Newt will set this as well.