### PR TITLE
Add `skipSystemFailures` task query filter

### DIFF
--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/JobQueryCriteria.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/JobQueryCriteria.java
@@ -18,6 +18,7 @@ package com.netflix.titus.runtime.endpoint;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -49,6 +50,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
     private final Optional<String> jobGroupDetail;
     private final Optional<String> jobGroupSequence;
     private final boolean needsMigration;
+    private final boolean skipSystemFailures;
     private final int limit;
 
     private JobQueryCriteria(Set<String> jobIds,
@@ -69,6 +71,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                              String jobGroupDetail,
                              String jobGroupSequence,
                              boolean needsMigration,
+                             boolean skipSystemFailures,
                              int limit) {
         this.jobIds = nonNull(jobIds);
         this.taskIds = nonNull(taskIds);
@@ -88,6 +91,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
         this.jobGroupDetail = Optional.ofNullable(jobGroupDetail);
         this.jobGroupSequence = Optional.ofNullable(jobGroupSequence);
         this.needsMigration = needsMigration;
+        this.skipSystemFailures = skipSystemFailures;
         this.limit = limit;
     }
 
@@ -167,6 +171,10 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
         return needsMigration;
     }
 
+    public boolean isSkipSystemFailures() {
+        return skipSystemFailures;
+    }
+
     public int getLimit() {
         return limit;
     }
@@ -219,88 +227,32 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         JobQueryCriteria<?, ?> that = (JobQueryCriteria<?, ?>) o;
-
-        if (includeArchived != that.includeArchived) {
-            return false;
-        }
-        if (labelsAndOp != that.labelsAndOp) {
-            return false;
-        }
-        if (needsMigration != that.needsMigration) {
-            return false;
-        }
-        if (limit != that.limit) {
-            return false;
-        }
-        if (jobIds != null ? !jobIds.equals(that.jobIds) : that.jobIds != null) {
-            return false;
-        }
-        if (taskIds != null ? !taskIds.equals(that.taskIds) : that.taskIds != null) {
-            return false;
-        }
-        if (jobState != null ? !jobState.equals(that.jobState) : that.jobState != null) {
-            return false;
-        }
-        if (taskStates != null ? !taskStates.equals(that.taskStates) : that.taskStates != null) {
-            return false;
-        }
-        if (taskStateReasons != null ? !taskStateReasons.equals(that.taskStateReasons) : that.taskStateReasons != null) {
-            return false;
-        }
-        if (owner != null ? !owner.equals(that.owner) : that.owner != null) {
-            return false;
-        }
-        if (labels != null ? !labels.equals(that.labels) : that.labels != null) {
-            return false;
-        }
-        if (imageName != null ? !imageName.equals(that.imageName) : that.imageName != null) {
-            return false;
-        }
-        if (imageTag != null ? !imageTag.equals(that.imageTag) : that.imageTag != null) {
-            return false;
-        }
-        if (appName != null ? !appName.equals(that.appName) : that.appName != null) {
-            return false;
-        }
-        if (capacityGroup != null ? !capacityGroup.equals(that.capacityGroup) : that.capacityGroup != null) {
-            return false;
-        }
-        if (jobType != null ? !jobType.equals(that.jobType) : that.jobType != null) {
-            return false;
-        }
-        if (jobGroupStack != null ? !jobGroupStack.equals(that.jobGroupStack) : that.jobGroupStack != null) {
-            return false;
-        }
-        if (jobGroupDetail != null ? !jobGroupDetail.equals(that.jobGroupDetail) : that.jobGroupDetail != null) {
-            return false;
-        }
-        return jobGroupSequence != null ? jobGroupSequence.equals(that.jobGroupSequence) : that.jobGroupSequence == null;
+        return includeArchived == that.includeArchived &&
+                labelsAndOp == that.labelsAndOp &&
+                needsMigration == that.needsMigration &&
+                skipSystemFailures == that.skipSystemFailures &&
+                limit == that.limit &&
+                Objects.equals(jobIds, that.jobIds) &&
+                Objects.equals(taskIds, that.taskIds) &&
+                Objects.equals(jobState, that.jobState) &&
+                Objects.equals(taskStates, that.taskStates) &&
+                Objects.equals(taskStateReasons, that.taskStateReasons) &&
+                Objects.equals(owner, that.owner) &&
+                Objects.equals(labels, that.labels) &&
+                Objects.equals(imageName, that.imageName) &&
+                Objects.equals(imageTag, that.imageTag) &&
+                Objects.equals(appName, that.appName) &&
+                Objects.equals(capacityGroup, that.capacityGroup) &&
+                Objects.equals(jobType, that.jobType) &&
+                Objects.equals(jobGroupStack, that.jobGroupStack) &&
+                Objects.equals(jobGroupDetail, that.jobGroupDetail) &&
+                Objects.equals(jobGroupSequence, that.jobGroupSequence);
     }
 
     @Override
     public int hashCode() {
-        int result = jobIds != null ? jobIds.hashCode() : 0;
-        result = 31 * result + (taskIds != null ? taskIds.hashCode() : 0);
-        result = 31 * result + (includeArchived ? 1 : 0);
-        result = 31 * result + (jobState != null ? jobState.hashCode() : 0);
-        result = 31 * result + (taskStates != null ? taskStates.hashCode() : 0);
-        result = 31 * result + (taskStateReasons != null ? taskStateReasons.hashCode() : 0);
-        result = 31 * result + (owner != null ? owner.hashCode() : 0);
-        result = 31 * result + (labels != null ? labels.hashCode() : 0);
-        result = 31 * result + (labelsAndOp ? 1 : 0);
-        result = 31 * result + (imageName != null ? imageName.hashCode() : 0);
-        result = 31 * result + (imageTag != null ? imageTag.hashCode() : 0);
-        result = 31 * result + (appName != null ? appName.hashCode() : 0);
-        result = 31 * result + (capacityGroup != null ? capacityGroup.hashCode() : 0);
-        result = 31 * result + (jobType != null ? jobType.hashCode() : 0);
-        result = 31 * result + (jobGroupStack != null ? jobGroupStack.hashCode() : 0);
-        result = 31 * result + (jobGroupDetail != null ? jobGroupDetail.hashCode() : 0);
-        result = 31 * result + (jobGroupSequence != null ? jobGroupSequence.hashCode() : 0);
-        result = 31 * result + (needsMigration ? 1 : 0);
-        result = 31 * result + limit;
-        return result;
+        return Objects.hash(jobIds, taskIds, includeArchived, jobState, taskStates, taskStateReasons, owner, labels, labelsAndOp, imageName, imageTag, appName, capacityGroup, jobType, jobGroupStack, jobGroupDetail, jobGroupSequence, needsMigration, skipSystemFailures, limit);
     }
 
     @Override
@@ -324,6 +276,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                 ", jobGroupDetail=" + jobGroupDetail +
                 ", jobGroupSequence=" + jobGroupSequence +
                 ", needsMigration=" + needsMigration +
+                ", skipSystemFailures=" + skipSystemFailures +
                 ", limit=" + limit +
                 '}';
     }
@@ -347,6 +300,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
         private String jobGroupDetail;
         private String jobGroupSequence;
         private boolean needsMigration;
+        private boolean skipSystemFailures;
         private int limit;
 
         private Builder() {
@@ -442,6 +396,11 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
             return this;
         }
 
+        public Builder<TASK_STATE, JOB_TYPE> withSkipSystemFailures(boolean skipSystemFailures) {
+            this.skipSystemFailures = skipSystemFailures;
+            return this;
+        }
+
         public Builder<TASK_STATE, JOB_TYPE> withLimit(int limit) {
             this.limit = limit;
             return this;
@@ -460,13 +419,14 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                     .withAppName(appName)
                     .withJobType(jobType)
                     .withNeedsMigration(needsMigration)
+                    .withSkipSystemFailures(skipSystemFailures)
                     .withLimit(limit);
         }
 
         public JobQueryCriteria<TASK_STATE, JOB_TYPE> build() {
             return new JobQueryCriteria<>(jobIds, taskIds, includeArchived, jobState, taskStates, taskStateReasons, owner, labels,
                     labelsAndOp, imageName, imageTag, appName, capacityGroup, jobType, jobGroupStack, jobGroupDetail, jobGroupSequence,
-                    needsMigration, limit);
+                    needsMigration, skipSystemFailures, limit);
         }
     }
 }

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobQueryModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobQueryModelConverters.java
@@ -51,7 +51,7 @@ public class GrpcJobQueryModelConverters extends CommonRuntimeGrpcModelConverter
             "jobIds", "taskIds", "owner", "appName", "applicationName", "imageName", "imageTag", "capacityGroup",
             "jobGroupStack", "jobGroupDetail", "jobGroupSequence",
             "jobType", "attributes", "attributes.op", "labels", "labels.op", "jobState", "taskStates", "taskStateReasons",
-            "needsMigration"
+            "needsMigration", "skipSystemFailures"
     );
 
     public static JobQueryCriteria<TaskStatus.TaskState, JobSpecCase> toJobQueryCriteria(ObserveJobsQuery query) {
@@ -108,6 +108,7 @@ public class GrpcJobQueryModelConverters extends CommonRuntimeGrpcModelConverter
         trimAndApplyIfNonEmpty(criteriaMap.get("jobGroupSequence"), criteriaBuilder::withJobGroupSequence);
 
         criteriaBuilder.withNeedsMigration(criteriaMap.getOrDefault("needsMigration", "false").equalsIgnoreCase("true"));
+        criteriaBuilder.withSkipSystemFailures(criteriaMap.getOrDefault("skipSystemFailures", "false").equalsIgnoreCase("true"));
 
         // Job state
         String jobStateStr = criteriaMap.get("jobState");

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
@@ -271,6 +271,11 @@ public class GatewayJobServiceGateway extends JobServiceGatewayDelegate {
                     if (!expectedStateReasons.isEmpty() && !expectedStateReasons.contains(task.getStatus().getReasonCode())) {
                         return false;
                     }
+                    if(taskQueryCriteria.isSkipSystemFailures()) {
+                        if(com.netflix.titus.api.jobmanager.model.job.TaskStatus.isSystemError(task.getStatus())) {
+                            return false;
+                        }
+                    }
 
                     return true;
                 })

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/query/V3TaskQueryCriteriaEvaluator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/query/V3TaskQueryCriteriaEvaluator.java
@@ -48,6 +48,7 @@ public class V3TaskQueryCriteriaEvaluator extends V3AbstractQueryCriteriaEvaluat
         applyTaskStates(criteria.getTaskStates()).ifPresent(predicates::add);
         applyTaskStateReasons(criteria.getTaskStateReasons()).ifPresent(predicates::add);
         applyNeedsMigration(criteria.isNeedsMigration(), titusRuntime).ifPresent(predicates::add);
+        applySkipSystemFailures(criteria.isSkipSystemFailures()).ifPresent(predicates::add);
         return predicates;
     }
 
@@ -100,5 +101,15 @@ public class V3TaskQueryCriteriaEvaluator extends V3AbstractQueryCriteriaEvaluat
                     return serviceTask.getMigrationDetails() != null && serviceTask.getMigrationDetails().isNeedsMigration();
                 }
         );
+    }
+
+    private static Optional<Predicate<Pair<Job<?>, Task>>> applySkipSystemFailures(boolean skipSystemFailures) {
+        if (!skipSystemFailures) {
+            return Optional.empty();
+        }
+        return Optional.of(jobAndTask -> {
+            Task task = jobAndTask.getRight();
+            return !com.netflix.titus.api.jobmanager.model.job.TaskStatus.isSystemError(task.getStatus());
+        });
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/grpc/query/V3TaskQueryCriteriaEvaluatorTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/grpc/query/V3TaskQueryCriteriaEvaluatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.v3.grpc.query;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+import com.netflix.titus.grpc.protogen.TaskStatus;
+import com.netflix.titus.runtime.endpoint.JobQueryCriteria;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class V3TaskQueryCriteriaEvaluatorTest {
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.internal();
+
+    @Test
+    public void testTaskWithSystemErrorFilter() {
+        JobQueryCriteria<TaskStatus.TaskState, JobDescriptor.JobSpecCase> criteria = JobQueryCriteria.<TaskStatus.TaskState, JobDescriptor.JobSpecCase>newBuilder()
+                .withSkipSystemFailures(true)
+                .build();
+        V3TaskQueryCriteriaEvaluator evaluator = new V3TaskQueryCriteriaEvaluator(criteria, titusRuntime);
+
+        Job<?> job = JobGenerator.oneBatchJob();
+
+        // Check non finished task
+        Task task = JobGenerator.oneBatchTask();
+        assertThat(evaluator.test(Pair.of(job, task))).isTrue();
+
+        // Check finished task with non system error reason code
+        Task finishedTask = task.toBuilder().withStatus(com.netflix.titus.api.jobmanager.model.job.TaskStatus.newBuilder()
+                .withState(TaskState.Finished)
+                .withReasonCode(com.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_NORMAL)
+                .build()
+        ).build();
+        assertThat(evaluator.test(Pair.of(job, finishedTask))).isTrue();
+
+        // Check finish that with system error
+        Task taskWithSystemError = task.toBuilder().withStatus(com.netflix.titus.api.jobmanager.model.job.TaskStatus.newBuilder()
+                .withState(TaskState.Finished)
+                .withReasonCode(com.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_LOCAL_SYSTEM_ERROR)
+                .build()
+        ).build();
+        assertThat(evaluator.test(Pair.of(job, taskWithSystemError))).isFalse();
+    }
+}


### PR DESCRIPTION
to simplify querying for batch tasks with retry limits. As system error
retries are unbounded, the task list can be arbitrary long.
