### PR TITLE
Job Attribute for skipping entry point concatenation 

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -99,9 +99,9 @@ public final class JobAttributes {
     public static final String JOB_ATTRIBUTES_RUNTIME_PREDICTION_AB_TEST = PREDICTION_ATTRIBUTE_PREFIX + "abTest";
 
     /**
-     * Do not concatenate entry point into a single string
+     * Do not parse entry point into shell command, argument list
      */
-    public static final String JOB_PARAMETER_ATTRIBUTES_ENTRY_POINT_SKIP_JOIN = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "entryPoint.skipJoin";
+    public static final String JOB_PARAMETER_ATTRIBUTES_ENTRY_POINT_SKIP_SHELL_PARSING = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "entryPoint.skipShellParsing";
 
     /**
      * Allow jobs to completely opt-out of having their runtime automatically predicted during admission

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -99,6 +99,11 @@ public final class JobAttributes {
     public static final String JOB_ATTRIBUTES_RUNTIME_PREDICTION_AB_TEST = PREDICTION_ATTRIBUTE_PREFIX + "abTest";
 
     /**
+     * Do not concatenate entry point into a single string
+     */
+    public static final String JOB_PARAMETER_ATTRIBUTES_ENTRY_POINT_SKIP_JOIN = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "entryPoint.skipJoin";
+
+    /**
      * Allow jobs to completely opt-out of having their runtime automatically predicted during admission
      */
     public static final String JOB_PARAMETER_SKIP_RUNTIME_PREDICTION = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "runtimePrediction.skip";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoFactory.java
@@ -264,7 +264,7 @@ public class DefaultV3TaskInfoFactory implements TaskInfoFactory<Protos.TaskInfo
     }
 
     private boolean shouldSkipEntryPointJoin(Map<String, String> jobAttributes) {
-        return Boolean.parseBoolean(jobAttributes.getOrDefault(JobAttributes.JOB_PARAMETER_ATTRIBUTES_ENTRY_POINT_SKIP_JOIN,
+        return Boolean.parseBoolean(jobAttributes.getOrDefault(JobAttributes.JOB_PARAMETER_ATTRIBUTES_ENTRY_POINT_SKIP_SHELL_PARSING,
                 "false").trim());
 
     }


### PR DESCRIPTION
### New job attribute titusParameter.entryPoint.skipShellParsing support

New job attribute titusParameter.entryPoint.skipShellParsing is created to support a use case that can override the default but deprecated behavior in how control plane deals with the entry point (as list of strings) when 'command' is not provided. 