### PR TITLE
ci: temporary fix for the docker-compose test

### DIFF
--- a/titus-ext/runner/Dockerfile.agent
+++ b/titus-ext/runner/Dockerfile.agent
@@ -2,6 +2,10 @@ FROM titusoss/titus-agent
 
 RUN echo "deb http://repos.mesosphere.io/ubuntu xenial main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+
+# TODO: temporary workaround to avoid trying to fetch legacy docker package info, this will be fixed by the switch to k8s
+RUN rm -f /etc/apt/sources.list.d/docker.list
+
 RUN apt-get -y update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qy --no-install-recommends install \
     jq mesos=1.1.3-2.0.1


### PR DESCRIPTION
Temporarily stop trying to update package info from repositories that are long gone.

The proper fix will come when we replace mesos with k8s in the docker-compose configuration.
