### PR TITLE
revert #746, fix ENI consistency check

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
@@ -97,15 +97,4 @@ public interface JobManagerConfiguration {
      */
     @DefaultValue("false")
     boolean isFailOnDataValidation();
-
-    /**
-     * Do not prevent tasks with inconsistent  ENI assignment to be loaded during activation. Inconsistencies will still
-     * be reported during activation and {@link JobManagerConfiguration#getMaxFailedTasks()} can still prevent
-     * activation if there are too many inconsistencies.
-     * <p>
-     * Use with caution to recover from situations where tasks were corrupted, but still can be recovered by
-     * reconciliation when a new leader is being activated.
-     */
-    @DefaultValue("false")
-    boolean isForceLoadTasksWithInconsistentEni();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/SecurityGroupUtils.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/SecurityGroupUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.jobmanager.service.common;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class SecurityGroupUtils {
+    private static final String SECURITY_GROUP_DELIMITER = ":";
+
+    public static String normalizeSecurityGroups(String securityGroups) {
+        return normalizedSecurityGroupsIdentifier(Arrays.asList(securityGroups.split(SECURITY_GROUP_DELIMITER)));
+    }
+
+    static String normalizedSecurityGroupsIdentifier(List<String> securityGroups) {
+        // make sure the security groups are sorted when loading two level resources
+        List<String> sortedSecurityGroups = new ArrayList<>(securityGroups);
+        Collections.sort(sortedSecurityGroups);
+        return String.join(SECURITY_GROUP_DELIMITER, sortedSecurityGroups);
+    }
+
+}


### PR DESCRIPTION
... by not considering the order of security groups in the same ENI. It is only required they are the same set of SGs.

#744 changed the way security groups are considered to be equal, so the consistency check needed to change as well.

cc @corindwyer for visibility