### PR TITLE
New scheduling constraints

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintValidator.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintValidator.java
@@ -44,7 +44,7 @@ public class SchedulingConstraintValidator implements ConstraintValidator<Schedu
      * TODO Convert names to IDL defined format when job is created.
      */
     private static final Set<String> CONSTRAINT_NAMES = asSet("uniquehost", "exclusivehost", "zonebalance",
-            "activehost", "availabilityzone", "machineid", "machinegroup", "machinetype");
+            "activehost", "availabilityzone", "machineid", "machinegroup", "machinetype", "toleration");
 
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
     @Retention(RetentionPolicy.RUNTIME)

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintValidator.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintValidator.java
@@ -44,7 +44,7 @@ public class SchedulingConstraintValidator implements ConstraintValidator<Schedu
      * TODO Convert names to IDL defined format when job is created.
      */
     private static final Set<String> CONSTRAINT_NAMES = asSet("uniquehost", "exclusivehost", "zonebalance",
-            "activehost", "availabilityzone", "machineid", "machinetype");
+            "activehost", "availabilityzone", "machineid", "machinegroup", "machinetype");
 
     @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
     @Retention(RetentionPolicy.RUNTIME)

--- a/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScaler.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScaler.java
@@ -108,7 +108,7 @@ public class ClusterAgentAutoScaler {
 
     private static final Comparator<AgentInstanceGroup> PREFER_ACTIVE_INSTANCE_GROUP_COMPARATOR = Comparator.comparing(ig -> ig.getLifecycleStatus().getState());
     private static final Comparator<AgentInstanceGroup> PREFER_PHASED_OUT_INSTANCE_GROUP_COMPARATOR = PREFER_ACTIVE_INSTANCE_GROUP_COMPARATOR.reversed();
-    private static final Set<String> IGNORED_HARD_CONSTRAINT_NAMES = asSet("machineid", "machinegroup", "machinetype");
+    private static final Set<String> IGNORED_HARD_CONSTRAINT_NAMES = asSet("machineid", "machinegroup", "machinetype", "toleration");
     private static final Set<FailureKind> IGNORED_FAILURE_KINDS_WITH_LAUNCHGUARD = ImmutableSet.<FailureKind>builder()
             .addAll(FailureKind.NEVER_TRIGGER_AUTOSCALING)
             .add(FailureKind.LaunchGuard)

--- a/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScaler.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScaler.java
@@ -108,7 +108,7 @@ public class ClusterAgentAutoScaler {
 
     private static final Comparator<AgentInstanceGroup> PREFER_ACTIVE_INSTANCE_GROUP_COMPARATOR = Comparator.comparing(ig -> ig.getLifecycleStatus().getState());
     private static final Comparator<AgentInstanceGroup> PREFER_PHASED_OUT_INSTANCE_GROUP_COMPARATOR = PREFER_ACTIVE_INSTANCE_GROUP_COMPARATOR.reversed();
-    private static final Set<String> IGNORED_HARD_CONSTRAINT_NAMES = asSet("machineid", "machinetype");
+    private static final Set<String> IGNORED_HARD_CONSTRAINT_NAMES = asSet("machineid", "machinegroup", "machinetype");
     private static final Set<FailureKind> IGNORED_FAILURE_KINDS_WITH_LAUNCHGUARD = ImmutableSet.<FailureKind>builder()
             .addAll(FailureKind.NEVER_TRIGGER_AUTOSCALING)
             .add(FailureKind.LaunchGuard)

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/AgentManagementConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/AgentManagementConstraint.java
@@ -34,17 +34,14 @@ import com.netflix.titus.api.agent.model.InstanceLifecycleState;
 import com.netflix.titus.api.agent.service.AgentManagementService;
 import com.netflix.titus.api.agent.service.AgentStatusMonitor;
 import com.netflix.titus.api.model.Tier;
-import com.netflix.titus.common.util.CollectionsExt;
-import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.scheduler.SchedulerAttributes;
 import com.netflix.titus.master.scheduler.SchedulerConfiguration;
 import com.netflix.titus.master.scheduler.SchedulerUtils;
 
-import static com.netflix.titus.api.jobmanager.JobAttributes.JOB_PARAMETER_ATTRIBUTES_TOLERATIONS;
-import static com.netflix.titus.common.util.StringExt.nonNull;
-import static com.netflix.titus.master.scheduler.SchedulerAttributes.TAINTS;
+import static com.netflix.titus.master.scheduler.SchedulerUtils.getTaints;
 import static com.netflix.titus.master.scheduler.SchedulerUtils.getTier;
+import static com.netflix.titus.master.scheduler.SchedulerUtils.getTolerations;
 
 /**
  * A system constraint that integrates with agent management in order to determine whether or a not a task
@@ -219,22 +216,5 @@ public class AgentManagementConstraint implements SystemConstraint {
         Set<String> taints = getTaints(instanceGroup, instance);
         Set<String> tolerations = getTolerations(taskRequest);
         return tolerations.containsAll(taints);
-    }
-
-    private Set<String> getTolerations(V3QueueableTask taskRequest) {
-        String jobTolerationValue = nonNull(
-                (String) taskRequest.getJob().getJobDescriptor().getAttributes().get(JOB_PARAMETER_ATTRIBUTES_TOLERATIONS)
-        ).toLowerCase();
-        return StringExt.splitByCommaIntoSet(jobTolerationValue);
-    }
-
-    private Set<String> getTaints(AgentInstanceGroup instanceGroup, AgentInstance instance) {
-        String instanceGroupTaintsValue = nonNull(instanceGroup.getAttributes().get(TAINTS)).toLowerCase();
-        Set<String> instanceGroupTaints = StringExt.splitByCommaIntoSet(instanceGroupTaintsValue);
-
-        String instanceTaintsValue = nonNull(instance.getAttributes().get(TAINTS)).toLowerCase();
-        Set<String> instanceTaints = StringExt.splitByCommaIntoSet(instanceTaintsValue);
-
-        return CollectionsExt.merge(instanceGroupTaints, instanceTaints);
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/AvailabilityZoneConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/AvailabilityZoneConstraint.java
@@ -24,14 +24,12 @@ import com.netflix.fenzo.TaskTrackerState;
 import com.netflix.fenzo.VirtualMachineCurrentState;
 import com.netflix.titus.api.agent.model.AgentInstance;
 import com.netflix.titus.api.agent.service.AgentManagementService;
-import com.netflix.titus.common.annotation.Experimental;
 import com.netflix.titus.master.scheduler.SchedulerConfiguration;
 import com.netflix.titus.master.scheduler.SchedulerUtils;
 
 /**
- * Experimental constraint such that workloads can prefer a machine in a specific availability zone.
+ * Constraint such that workloads can prefer a machine in a specific availability zone.
  */
-@Experimental(deadline = "06/2019")
 public class AvailabilityZoneConstraint implements ConstraintEvaluator {
 
     public static final String NAME = "AvailabilityZoneConstraint";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/MachineGroupConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/MachineGroupConstraint.java
@@ -28,22 +28,22 @@ import com.netflix.titus.master.scheduler.SchedulerConfiguration;
 import com.netflix.titus.master.scheduler.SchedulerUtils;
 
 /**
- * Constraint such that workloads can prefer a specific machine type.
+ * Constraint such that workloads can prefer a specific machine group.
  */
-public class MachineTypeConstraint implements ConstraintEvaluator {
-    public static final String NAME = "MachineTypeConstraint";
+public class MachineGroupConstraint implements ConstraintEvaluator {
+    public static final String NAME = "MachineGroupConstraint";
 
     private static final Result VALID = new Result(true, null);
     private static final Result MACHINE_DOES_NOT_EXIST = new Result(false, "The machine does not exist");
-    private static final Result MACHINE_TYPE_DOES_NOT_MATCH = new Result(false, "The machine type does not match the specified machine type");
+    private static final Result MACHINE_GROUP_DOES_NOT_MATCH = new Result(false, "The machine group does not match the specified name");
     private final SchedulerConfiguration configuration;
     private final AgentManagementService agentManagementService;
-    private final String machineType;
+    private final String machineGroup;
 
-    public MachineTypeConstraint(SchedulerConfiguration configuration, AgentManagementService agentManagementService, String machineType) {
+    public MachineGroupConstraint(SchedulerConfiguration configuration, AgentManagementService agentManagementService, String machineId) {
         this.configuration = configuration;
         this.agentManagementService = agentManagementService;
-        this.machineType = machineType;
+        this.machineGroup = machineId;
     }
 
     @Override
@@ -59,7 +59,7 @@ public class MachineTypeConstraint implements ConstraintEvaluator {
         }
 
         AgentInstance agentInstance = instanceOpt.get();
-        String instanceInstanceType = agentInstance.getAttributes().getOrDefault(configuration.getMachineTypeAttributeName(), "");
-        return instanceInstanceType.equalsIgnoreCase(machineType) ? VALID : MACHINE_TYPE_DOES_NOT_MATCH;
+
+        return agentInstance.getInstanceGroupId().equalsIgnoreCase(machineGroup) ? VALID : MACHINE_GROUP_DOES_NOT_MATCH;
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/MachineIdConstraint.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/MachineIdConstraint.java
@@ -24,14 +24,12 @@ import com.netflix.fenzo.TaskTrackerState;
 import com.netflix.fenzo.VirtualMachineCurrentState;
 import com.netflix.titus.api.agent.model.AgentInstance;
 import com.netflix.titus.api.agent.service.AgentManagementService;
-import com.netflix.titus.common.annotation.Experimental;
 import com.netflix.titus.master.scheduler.SchedulerConfiguration;
 import com.netflix.titus.master.scheduler.SchedulerUtils;
 
 /**
- * Experimental constraint such that workloads can prefer a specific machine id.
+ * Constraint such that workloads can prefer a specific machine id.
  */
-@Experimental(deadline = "06/2019")
 public class MachineIdConstraint implements ConstraintEvaluator {
     public static final String NAME = "MachineIdConstraint";
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/V3ConstraintEvaluatorTransformer.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/V3ConstraintEvaluatorTransformer.java
@@ -44,11 +44,12 @@ import org.slf4j.LoggerFactory;
  * <li>zoneBalance</li>
  * </ul>
  * <p>
- * Experimental Constraints:
+ * Advanced Constraints:
  * <ul>
  * <li>activeHost</li>
  * <li>availabilityZone</li>
  * <li>machineId</li>
+ * <li>machineGroup</li>
  * <li>machineType</li>
  * </ul>
  */
@@ -68,6 +69,7 @@ public class V3ConstraintEvaluatorTransformer implements ConstraintEvaluatorTran
     private static final String ACTIVE_HOST = "activehost";
     private static final String AVAILABILITY_ZONE = "availabilityzone";
     private static final String MACHINE_ID = "machineid";
+    private static final String MACHINE_GROUP = "machinegroup";
     private static final String MACHINE_TYPE = "machinetype";
 
     private final MasterConfiguration config;
@@ -111,6 +113,10 @@ public class V3ConstraintEvaluatorTransformer implements ConstraintEvaluatorTran
                 return StringExt.isNotEmpty(value)
                         ? Optional.of(new MachineIdConstraint(schedulerConfiguration, agentManagementService, value))
                         : Optional.empty();
+            case MACHINE_GROUP:
+                return StringExt.isNotEmpty(value)
+                        ? Optional.of(new MachineGroupConstraint(schedulerConfiguration, agentManagementService, value))
+                        : Optional.empty();
             case MACHINE_TYPE:
                 return StringExt.isNotEmpty(value)
                         ? Optional.of(new MachineTypeConstraint(schedulerConfiguration, agentManagementService, value))
@@ -144,6 +150,10 @@ public class V3ConstraintEvaluatorTransformer implements ConstraintEvaluatorTran
             case MACHINE_ID:
                 return StringExt.isNotEmpty(value)
                         ? Optional.of(AsSoftConstraint.get(new MachineIdConstraint(schedulerConfiguration, agentManagementService, value)))
+                        : Optional.empty();
+            case MACHINE_GROUP:
+                return StringExt.isNotEmpty(value)
+                        ? Optional.of(AsSoftConstraint.get(new MachineGroupConstraint(schedulerConfiguration, agentManagementService, value)))
                         : Optional.empty();
             case MACHINE_TYPE:
                 return StringExt.isNotEmpty(value)

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/V3ConstraintEvaluatorTransformer.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/V3ConstraintEvaluatorTransformer.java
@@ -65,12 +65,13 @@ public class V3ConstraintEvaluatorTransformer implements ConstraintEvaluatorTran
     private static final String UNIQUE_HOST = "uniquehost";
     private static final String ZONE_BALANCE = "zonebalance";
 
-    // Experimental Constraints
+    // Advanced Constraints
     private static final String ACTIVE_HOST = "activehost";
     private static final String AVAILABILITY_ZONE = "availabilityzone";
     private static final String MACHINE_ID = "machineid";
     private static final String MACHINE_GROUP = "machinegroup";
     private static final String MACHINE_TYPE = "machinetype";
+    private static final String TOLERATION = "toleration";
 
     private final MasterConfiguration config;
     private final SchedulerConfiguration schedulerConfiguration;
@@ -121,6 +122,10 @@ public class V3ConstraintEvaluatorTransformer implements ConstraintEvaluatorTran
                 return StringExt.isNotEmpty(value)
                         ? Optional.of(new MachineTypeConstraint(schedulerConfiguration, agentManagementService, value))
                         : Optional.empty();
+            case TOLERATION:
+                return StringExt.isNotEmpty(value)
+                        ? Optional.of(new TolerationConstraint(schedulerConfiguration, agentManagementService, value))
+                        : Optional.empty();
         }
         logger.error("Unknown or not supported job hard constraint: {}", name);
         return Optional.empty();
@@ -158,6 +163,10 @@ public class V3ConstraintEvaluatorTransformer implements ConstraintEvaluatorTran
             case MACHINE_TYPE:
                 return StringExt.isNotEmpty(value)
                         ? Optional.of(AsSoftConstraint.get(new MachineTypeConstraint(schedulerConfiguration, agentManagementService, value)))
+                        : Optional.empty();
+            case TOLERATION:
+                return StringExt.isNotEmpty(value)
+                        ? Optional.of(AsSoftConstraint.get(new TolerationConstraint(schedulerConfiguration, agentManagementService, value)))
                         : Optional.empty();
         }
         logger.error("Unknown or not supported job hard constraint: {}", name);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/scheduler/constraint/MachineGroupConstraintTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/scheduler/constraint/MachineGroupConstraintTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.scheduler.constraint;
+
+import java.util.Optional;
+
+import com.netflix.fenzo.ConstraintEvaluator.Result;
+import com.netflix.titus.api.agent.model.AgentInstance;
+import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.master.scheduler.SchedulerConfiguration;
+import com.netflix.titus.testkit.model.agent.AgentGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.TASK_ID;
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.createTaskRequest;
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.createTaskTrackerState;
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.createVirtualMachineCurrentStateMock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MachineGroupConstraintTest {
+    private static final String MACHINE_ID = "1234";
+    private static final String MACHINE_GROUP = "group-1234";
+
+    private final SchedulerConfiguration schedulerConfiguration = mock(SchedulerConfiguration.class);
+    private final AgentManagementService agentManagementService = mock(AgentManagementService.class);
+
+    private final MachineGroupConstraint constraint = new MachineGroupConstraint(schedulerConfiguration, agentManagementService, MACHINE_GROUP);
+
+    @Before
+    public void setUp() throws Exception {
+        when(schedulerConfiguration.getInstanceAttributeName()).thenReturn("id");
+    }
+
+    @Test
+    public void machineDoesNotExist() {
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.empty());
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.getFailureReason()).isEqualToIgnoringCase("The machine does not exist");
+    }
+
+    @Test
+    public void machineGroupDoesNotMatch() {
+        AgentInstance instance = AgentGenerator.agentInstances().getValue().toBuilder().withId(MACHINE_ID).withInstanceGroupId("").build();
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.of(instance));
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.getFailureReason()).isEqualToIgnoringCase("The machine group does not match the specified name");
+    }
+
+    @Test
+    public void machineGroupDoesMatch() {
+        AgentInstance instance = AgentGenerator.agentInstances().getValue().toBuilder().withId(MACHINE_ID).withInstanceGroupId(MACHINE_GROUP).build();
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.of(instance));
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isTrue();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/scheduler/constraint/TolerationConstraintTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/scheduler/constraint/TolerationConstraintTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.scheduler.constraint;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import com.netflix.fenzo.ConstraintEvaluator.Result;
+import com.netflix.titus.api.agent.model.AgentInstance;
+import com.netflix.titus.api.agent.model.AgentInstanceGroup;
+import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.master.scheduler.SchedulerConfiguration;
+import com.netflix.titus.testkit.model.agent.AgentGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.netflix.titus.master.scheduler.SchedulerAttributes.TAINTS;
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.TASK_ID;
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.createTaskRequest;
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.createTaskTrackerState;
+import static com.netflix.titus.master.scheduler.SchedulerTestUtils.createVirtualMachineCurrentStateMock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TolerationConstraintTest {
+    private static final String MACHINE_ID = "1234";
+    private static final String MACHINE_GROUP = "group-1234";
+    private static final String TOLERATION = "toleration1";
+
+    private final SchedulerConfiguration schedulerConfiguration = mock(SchedulerConfiguration.class);
+    private final AgentManagementService agentManagementService = mock(AgentManagementService.class);
+
+    private final TolerationConstraint constraint = new TolerationConstraint(schedulerConfiguration, agentManagementService, TOLERATION);
+
+    @Before
+    public void setUp() throws Exception {
+        when(schedulerConfiguration.getInstanceAttributeName()).thenReturn("id");
+    }
+
+    @Test
+    public void machineDoesNotExist() {
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.empty());
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.getFailureReason()).isEqualToIgnoringCase("The machine does not exist");
+    }
+
+    @Test
+    public void machineGroupDoesExist() {
+        AgentInstance instance = AgentGenerator.agentInstances().getValue().toBuilder().withId(MACHINE_ID).withInstanceGroupId("").build();
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.of(instance));
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.getFailureReason()).isEqualToIgnoringCase("The machine group does not exist");
+    }
+
+    @Test
+    public void machineTaintMatchesToleration() {
+        AgentInstance instance = AgentGenerator.agentInstances().getValue().toBuilder().withId(MACHINE_ID)
+                .withInstanceGroupId(MACHINE_GROUP)
+                .withAttributes(Collections.singletonMap(TAINTS, TOLERATION))
+                .build();
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.of(instance));
+        AgentInstanceGroup instanceGroup = AgentGenerator.agentServerGroups().getValue().toBuilder()
+                .withId(MACHINE_GROUP)
+                .build();
+        when(agentManagementService.findInstanceGroup(MACHINE_GROUP)).thenReturn(Optional.of(instanceGroup));
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void machineGroupTaintMatchesToleration() {
+        AgentInstance instance = AgentGenerator.agentInstances().getValue().toBuilder().withId(MACHINE_ID)
+                .withInstanceGroupId(MACHINE_GROUP)
+                .build();
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.of(instance));
+        AgentInstanceGroup instanceGroup = AgentGenerator.agentServerGroups().getValue().toBuilder()
+                .withId(MACHINE_GROUP)
+                .withAttributes(Collections.singletonMap(TAINTS, TOLERATION))
+                .build();
+        when(agentManagementService.findInstanceGroup(MACHINE_GROUP)).thenReturn(Optional.of(instanceGroup));
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void taintsDoNotMatchToleration() {
+        AgentInstance instance = AgentGenerator.agentInstances().getValue().toBuilder().withId(MACHINE_ID)
+                .withInstanceGroupId(MACHINE_GROUP)
+                .build();
+        when(agentManagementService.findAgentInstance(MACHINE_ID)).thenReturn(Optional.of(instance));
+        AgentInstanceGroup instanceGroup = AgentGenerator.agentServerGroups().getValue().toBuilder()
+                .withId(MACHINE_GROUP)
+                .build();
+        when(agentManagementService.findInstanceGroup(MACHINE_GROUP)).thenReturn(Optional.of(instanceGroup));
+        Result result = constraint.evaluate(createTaskRequest(TASK_ID), createVirtualMachineCurrentStateMock(MACHINE_ID), createTaskTrackerState());
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.getFailureReason()).isEqualToIgnoringCase("The machine or machine group does not have a matching taint");
+    }
+}


### PR DESCRIPTION
### Description of the Change
Add new scheduling constraints:
* machineGroup - specify a specific group of machines to land on (instance group name)
* toleration - specify a toleration to land on a machine with the matching taint name