### PR TITLE
use self signed certificates valid with newer JDKs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ subprojects {
         runtimeHealthVersion = '1.1.+'
         configMagicVersion = '0.11'
         swaggerUiVersion = '2.1.4'
-        okHttpVersion = '3.8.0'
+        okHttpVersion = '3.+'
         cassandraDriverVersion = '3.3.+'
         commonsCliVersion = '1.3.+'
         caffeineVersion = '2.6.+'
@@ -123,7 +123,6 @@ subprojects {
         // Superceded by governator-api
         exclude group: 'com.netflix.governator', module: 'governator-annotations'
         resolutionStrategy {
-            force 'org.bouncycastle:bcprov-jdk15on:1.50'
             // remove this pin once we fix the jackson version issues
             force 'com.fasterxml.jackson.core:jackson-databind:2.9.9.1'
         }

--- a/titus-api/dependencies.lock
+++ b/titus-api/dependencies.lock
@@ -202,13 +202,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -779,13 +779,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1356,13 +1356,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1997,13 +1997,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2575,13 +2575,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3626,7 +3626,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -3652,7 +3652,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4458,7 +4458,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5723,7 +5723,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -5749,7 +5749,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -6555,7 +6555,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7820,7 +7820,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7846,7 +7846,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8652,7 +8652,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9918,7 +9918,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9944,7 +9944,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10750,7 +10750,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-client/dependencies.lock
+++ b/titus-client/dependencies.lock
@@ -224,13 +224,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -835,13 +835,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1446,13 +1446,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2121,13 +2121,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2733,13 +2733,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3796,7 +3796,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -3822,7 +3822,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4628,7 +4628,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5893,7 +5893,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -5919,7 +5919,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -6725,7 +6725,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7990,7 +7990,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -8016,7 +8016,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8822,7 +8822,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -10088,7 +10088,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -10114,7 +10114,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10920,7 +10920,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-common-api/dependencies.lock
+++ b/titus-common-api/dependencies.lock
@@ -196,13 +196,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -765,13 +765,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1334,13 +1334,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1967,13 +1967,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2537,13 +2537,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3586,7 +3586,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -3612,7 +3612,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4418,7 +4418,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5683,7 +5683,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -5709,7 +5709,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -6515,7 +6515,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7780,7 +7780,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7806,7 +7806,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8612,7 +8612,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9878,7 +9878,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9904,7 +9904,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10710,7 +10710,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-common-client/dependencies.lock
+++ b/titus-common-client/dependencies.lock
@@ -230,13 +230,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -849,13 +849,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1468,13 +1468,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2151,13 +2151,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2771,13 +2771,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3425,13 +3425,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4171,13 +4171,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4917,13 +4917,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5664,13 +5664,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]

--- a/titus-common-ext/kube/dependencies.lock
+++ b/titus-common-ext/kube/dependencies.lock
@@ -221,7 +221,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -247,7 +247,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -583,7 +583,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -978,7 +978,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -1004,7 +1004,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -1340,7 +1340,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -1735,7 +1735,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -1761,7 +1761,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -2097,7 +2097,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -2556,7 +2556,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -2582,7 +2582,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -2918,7 +2918,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -3314,7 +3314,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -3340,7 +3340,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -3676,7 +3676,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -4133,7 +4133,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -4159,7 +4159,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4540,7 +4540,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -5045,7 +5045,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -5071,7 +5071,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -5452,7 +5452,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -5957,7 +5957,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -5983,7 +5983,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -6364,7 +6364,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -6870,7 +6870,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -6896,7 +6896,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7277,7 +7277,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]

--- a/titus-common-runtime/dependencies.lock
+++ b/titus-common-runtime/dependencies.lock
@@ -206,13 +206,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -791,13 +791,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1376,13 +1376,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2025,13 +2025,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2611,13 +2611,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3207,13 +3207,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3848,13 +3848,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4489,13 +4489,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5131,13 +5131,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]

--- a/titus-common-server/dependencies.lock
+++ b/titus-common-server/dependencies.lock
@@ -240,13 +240,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -897,13 +897,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1554,13 +1554,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2275,13 +2275,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2933,13 +2933,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3615,13 +3615,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4371,13 +4371,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5127,13 +5127,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5884,13 +5884,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]

--- a/titus-common-testkit/dependencies.lock
+++ b/titus-common-testkit/dependencies.lock
@@ -246,13 +246,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -946,13 +946,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1646,13 +1646,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2410,13 +2410,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3111,13 +3111,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3822,13 +3822,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4547,13 +4547,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5272,13 +5272,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5998,13 +5998,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]

--- a/titus-common/build.gradle
+++ b/titus-common/build.gradle
@@ -40,4 +40,5 @@ dependencies {
 
     testCompile project(':titus-testkit')
     testCompile "com.squareup.okhttp3:mockwebserver:${okHttpVersion}"
+    testCompile "com.squareup.okhttp3:okhttp-tls:${okHttpVersion}"
 }

--- a/titus-common/dependencies.lock
+++ b/titus-common/dependencies.lock
@@ -177,11 +177,11 @@
             "requested": "0.59.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -683,11 +683,11 @@
             "requested": "0.59.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1189,11 +1189,11 @@
             "requested": "0.59.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1769,11 +1769,11 @@
             "requested": "0.59.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2286,11 +2286,11 @@
             "requested": "0.59.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3312,16 +3312,21 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0",
+            "locked": "3.14.6",
+            "requested": "3.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
-                "com.squareup.okhttp3:mockwebserver"
+                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls"
             ]
+        },
+        "com.squareup.okhttp3:okhttp-tls": {
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp:logging-interceptor": {
             "locked": "2.7.5",
@@ -3344,7 +3349,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4161,9 +4166,9 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
@@ -5445,16 +5450,21 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0",
+            "locked": "3.14.6",
+            "requested": "3.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
-                "com.squareup.okhttp3:mockwebserver"
+                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls"
             ]
+        },
+        "com.squareup.okhttp3:okhttp-tls": {
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp:logging-interceptor": {
             "locked": "2.7.5",
@@ -5477,7 +5487,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -6294,9 +6304,9 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
@@ -7578,16 +7588,21 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0",
+            "locked": "3.14.6",
+            "requested": "3.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
-                "com.squareup.okhttp3:mockwebserver"
+                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls"
             ]
+        },
+        "com.squareup.okhttp3:okhttp-tls": {
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp:logging-interceptor": {
             "locked": "2.7.5",
@@ -7610,7 +7625,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8427,9 +8442,9 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
@@ -9712,16 +9727,21 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
-            "requested": "3.8.0",
+            "locked": "3.14.6",
+            "requested": "3.+",
             "transitive": [
                 "com.netflix.titus:titus-common",
-                "com.squareup.okhttp3:mockwebserver"
+                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls"
             ]
+        },
+        "com.squareup.okhttp3:okhttp-tls": {
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp:logging-interceptor": {
             "locked": "2.7.5",
@@ -9744,7 +9764,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10561,9 +10581,9 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
+                "com.squareup.okhttp3:okhttp-tls",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",

--- a/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/OkHttpClientTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/OkHttpClientTest.java
@@ -18,6 +18,7 @@ package com.netflix.titus.common.network.http.internal.okhttp;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -31,10 +32,11 @@ import com.netflix.titus.common.network.http.Response;
 import com.netflix.titus.common.network.http.StatusCode;
 import com.netflix.titus.common.network.http.internal.RoundRobinEndpointResolver;
 import okhttp3.Interceptor;
-import okhttp3.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -44,14 +46,16 @@ public class OkHttpClientTest {
 
     private static final String TEST_REQUEST_BODY = "Test Request Body";
     private static final String TEST_RESPONSE_BODY = "Test Response Body";
-    private MockWebServer server = new MockWebServer();
+    private MockWebServer server;
 
     @Before
     public void setUp() throws Exception {
+        server = new MockWebServer();
     }
 
     @After
     public void tearDown() throws Exception {
+        server.shutdown();
     }
 
     @Test
@@ -213,10 +217,16 @@ public class OkHttpClientTest {
 
     @Test
     public void testGetWithSslContext() throws Exception {
-        SslClient sslClient = SslClient.localhost();
+        String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
+        HeldCertificate localhostCertificate = new HeldCertificate.Builder()
+                .addSubjectAlternativeName(localhost)
+                .build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+                .heldCertificate(localhostCertificate)
+                .build();
 
         MockWebServer sslServer = new MockWebServer();
-        sslServer.useHttps(sslClient.socketFactory, false);
+        sslServer.useHttps(serverCertificates.sslSocketFactory(), false);
         String url = sslServer.url("/").toString();
 
         MockResponse mockResponse = new MockResponse()
@@ -224,9 +234,12 @@ public class OkHttpClientTest {
                 .setResponseCode(StatusCode.OK.getCode());
         sslServer.enqueue(mockResponse);
 
+        HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+                .addTrustedCertificate(localhostCertificate.certificate())
+                .build();
         HttpClient client = OkHttpClient.newBuilder()
-                .sslContext(sslClient.sslContext)
-                .trustManager(sslClient.trustManager)
+                .sslContext(clientCertificates.sslContext())
+                .trustManager(clientCertificates.trustManager())
                 .build();
 
         Request request = new Request.Builder()

--- a/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/OkHttpClientTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/OkHttpClientTest.java
@@ -225,37 +225,38 @@ public class OkHttpClientTest {
                 .heldCertificate(localhostCertificate)
                 .build();
 
-        MockWebServer sslServer = new MockWebServer();
-        sslServer.useHttps(serverCertificates.sslSocketFactory(), false);
-        String url = sslServer.url("/").toString();
+        try(MockWebServer sslServer = new MockWebServer()) {
+            sslServer.useHttps(serverCertificates.sslSocketFactory(), false);
+            String url = sslServer.url("/").toString();
 
-        MockResponse mockResponse = new MockResponse()
-                .setBody(TEST_RESPONSE_BODY)
-                .setResponseCode(StatusCode.OK.getCode());
-        sslServer.enqueue(mockResponse);
+            MockResponse mockResponse = new MockResponse()
+                    .setBody(TEST_RESPONSE_BODY)
+                    .setResponseCode(StatusCode.OK.getCode());
+            sslServer.enqueue(mockResponse);
 
-        HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
-                .addTrustedCertificate(localhostCertificate.certificate())
-                .build();
-        HttpClient client = OkHttpClient.newBuilder()
-                .sslContext(clientCertificates.sslContext())
-                .trustManager(clientCertificates.trustManager())
-                .build();
+            HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+                    .addTrustedCertificate(localhostCertificate.certificate())
+                    .build();
+            HttpClient client = OkHttpClient.newBuilder()
+                    .sslContext(clientCertificates.sslContext())
+                    .trustManager(clientCertificates.trustManager())
+                    .build();
 
-        Request request = new Request.Builder()
-                .url(url)
-                .get()
-                .build();
+            Request request = new Request.Builder()
+                    .url(url)
+                    .get()
+                    .build();
 
-        Response response = client.execute(request);
-        Assertions.assertThat(response.isSuccessful()).isTrue();
+            Response response = client.execute(request);
+            Assertions.assertThat(response.isSuccessful()).isTrue();
 
-        InputStream inputStream = response.getBody().get(InputStream.class);
-        String actualResponseBody = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
-        Assertions.assertThat(actualResponseBody).isEqualTo(TEST_RESPONSE_BODY);
+            InputStream inputStream = response.getBody().get(InputStream.class);
+            String actualResponseBody = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+            Assertions.assertThat(actualResponseBody).isEqualTo(TEST_RESPONSE_BODY);
 
-        RecordedRequest recordedRequest = sslServer.takeRequest(1, TimeUnit.MILLISECONDS);
-        Assertions.assertThat(recordedRequest).isNotNull();
-        Assertions.assertThat(recordedRequest.getBodySize()).isLessThanOrEqualTo(0);
+            RecordedRequest recordedRequest = sslServer.takeRequest(1, TimeUnit.MILLISECONDS);
+            Assertions.assertThat(recordedRequest).isNotNull();
+            Assertions.assertThat(recordedRequest.getBodySize()).isLessThanOrEqualTo(0);
+        }
     }
 }

--- a/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/RxOkHttpClientTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/RxOkHttpClientTest.java
@@ -18,6 +18,7 @@ package com.netflix.titus.common.network.http.internal.okhttp;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -31,10 +32,11 @@ import com.netflix.titus.common.network.http.RxHttpClient;
 import com.netflix.titus.common.network.http.StatusCode;
 import com.netflix.titus.common.network.http.internal.RoundRobinEndpointResolver;
 import okhttp3.Interceptor;
-import okhttp3.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -44,14 +46,16 @@ public class RxOkHttpClientTest {
 
     private static final String TEST_REQUEST_BODY = "Test Request Body";
     private static final String TEST_RESPONSE_BODY = "Test Response Body";
-    private MockWebServer server = new MockWebServer();
+    private MockWebServer server;
 
     @Before
     public void setUp() throws Exception {
+        server = new MockWebServer();
     }
 
     @After
     public void tearDown() throws Exception {
+        server.shutdown();
     }
 
     @Test
@@ -215,10 +219,16 @@ public class RxOkHttpClientTest {
 
     @Test
     public void testGetWithSslContext() throws Exception {
-        SslClient sslClient = SslClient.localhost();
+        String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
+        HeldCertificate localhostCertificate = new HeldCertificate.Builder()
+                .addSubjectAlternativeName(localhost)
+                .build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+                .heldCertificate(localhostCertificate)
+                .build();
 
         MockWebServer sslServer = new MockWebServer();
-        sslServer.useHttps(sslClient.socketFactory, false);
+        sslServer.useHttps(serverCertificates.sslSocketFactory(), false);
         String url = sslServer.url("/").toString();
 
         MockResponse mockResponse = new MockResponse()
@@ -226,9 +236,12 @@ public class RxOkHttpClientTest {
                 .setResponseCode(StatusCode.OK.getCode());
         sslServer.enqueue(mockResponse);
 
+        HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+                .addTrustedCertificate(localhostCertificate.certificate())
+                .build();
         RxHttpClient client = RxOkHttpClient.newBuilder()
-                .sslContext(sslClient.sslContext)
-                .trustManager(sslClient.trustManager)
+                .sslContext(clientCertificates.sslContext())
+                .trustManager(clientCertificates.trustManager())
                 .build();
 
         Request request = new Request.Builder()

--- a/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/RxOkHttpClientTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/network/http/internal/okhttp/RxOkHttpClientTest.java
@@ -227,37 +227,38 @@ public class RxOkHttpClientTest {
                 .heldCertificate(localhostCertificate)
                 .build();
 
-        MockWebServer sslServer = new MockWebServer();
-        sslServer.useHttps(serverCertificates.sslSocketFactory(), false);
-        String url = sslServer.url("/").toString();
+        try (MockWebServer sslServer = new MockWebServer()) {
+            sslServer.useHttps(serverCertificates.sslSocketFactory(), false);
+            String url = sslServer.url("/").toString();
 
-        MockResponse mockResponse = new MockResponse()
-                .setBody(TEST_RESPONSE_BODY)
-                .setResponseCode(StatusCode.OK.getCode());
-        sslServer.enqueue(mockResponse);
+            MockResponse mockResponse = new MockResponse()
+                    .setBody(TEST_RESPONSE_BODY)
+                    .setResponseCode(StatusCode.OK.getCode());
+            sslServer.enqueue(mockResponse);
 
-        HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
-                .addTrustedCertificate(localhostCertificate.certificate())
-                .build();
-        RxHttpClient client = RxOkHttpClient.newBuilder()
-                .sslContext(clientCertificates.sslContext())
-                .trustManager(clientCertificates.trustManager())
-                .build();
+            HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+                    .addTrustedCertificate(localhostCertificate.certificate())
+                    .build();
+            RxHttpClient client = RxOkHttpClient.newBuilder()
+                    .sslContext(clientCertificates.sslContext())
+                    .trustManager(clientCertificates.trustManager())
+                    .build();
 
-        Request request = new Request.Builder()
-                .url(url)
-                .get()
-                .build();
+            Request request = new Request.Builder()
+                    .url(url)
+                    .get()
+                    .build();
 
-        Response response = client.execute(request).toBlocking().first();
-        Assertions.assertThat(response.isSuccessful()).isTrue();
+            Response response = client.execute(request).toBlocking().first();
+            Assertions.assertThat(response.isSuccessful()).isTrue();
 
-        InputStream inputStream = response.getBody().get(InputStream.class);
-        String actualResponseBody = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
-        Assertions.assertThat(actualResponseBody).isEqualTo(TEST_RESPONSE_BODY);
+            InputStream inputStream = response.getBody().get(InputStream.class);
+            String actualResponseBody = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+            Assertions.assertThat(actualResponseBody).isEqualTo(TEST_RESPONSE_BODY);
 
-        RecordedRequest recordedRequest = sslServer.takeRequest(1, TimeUnit.MILLISECONDS);
-        Assertions.assertThat(recordedRequest).isNotNull();
-        Assertions.assertThat(recordedRequest.getBodySize()).isLessThanOrEqualTo(0);
+            RecordedRequest recordedRequest = sslServer.takeRequest(1, TimeUnit.MILLISECONDS);
+            Assertions.assertThat(recordedRequest).isNotNull();
+            Assertions.assertThat(recordedRequest.getBodySize()).isLessThanOrEqualTo(0);
+        }
     }
 }

--- a/titus-ext/aws/dependencies.lock
+++ b/titus-ext/aws/dependencies.lock
@@ -7,19 +7,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -31,23 +31,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -467,13 +467,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1043,7 +1043,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1386,19 +1386,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1410,23 +1410,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -1846,13 +1846,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2422,7 +2422,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2765,19 +2765,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -2789,23 +2789,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -3225,13 +3225,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3801,7 +3801,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4208,19 +4208,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -4232,23 +4232,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -4668,13 +4668,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5244,7 +5244,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5588,19 +5588,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -5612,23 +5612,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -6048,13 +6048,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6624,7 +6624,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -6986,19 +6986,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7010,23 +7010,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -7697,7 +7697,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7723,7 +7723,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8560,7 +8560,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9181,19 +9181,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9205,23 +9205,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -9892,7 +9892,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9918,7 +9918,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10755,7 +10755,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11376,19 +11376,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -11400,23 +11400,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -12087,7 +12087,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -12113,7 +12113,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12950,7 +12950,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13572,19 +13572,19 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-applicationautoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-autoscaling": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-cloudwatch": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-core": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -13596,23 +13596,23 @@
             ]
         },
         "com.amazonaws:aws-java-sdk-ec2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-elasticloadbalancingv2": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-iam": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:aws-java-sdk-sts": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "requested": "1.11.+"
         },
         "com.amazonaws:jmespath-java": {
-            "locked": "1.11.714",
+            "locked": "1.11.716",
             "transitive": [
                 "com.amazonaws:aws-java-sdk-applicationautoscaling",
                 "com.amazonaws:aws-java-sdk-autoscaling",
@@ -14283,7 +14283,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -14309,7 +14309,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -15146,7 +15146,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-ext/cassandra-testkit/dependencies.lock
+++ b/titus-ext/cassandra-testkit/dependencies.lock
@@ -338,13 +338,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1291,13 +1291,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2244,13 +2244,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3261,13 +3261,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4215,13 +4215,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5179,13 +5179,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6182,13 +6182,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -7185,13 +7185,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -8189,13 +8189,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]

--- a/titus-ext/cassandra/dependencies.lock
+++ b/titus-ext/cassandra/dependencies.lock
@@ -253,13 +253,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -929,13 +929,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -1605,13 +1605,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2345,13 +2345,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3022,13 +3022,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4123,7 +4123,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -4149,7 +4149,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4955,7 +4955,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -6223,7 +6223,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -6249,7 +6249,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7055,7 +7055,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -8323,7 +8323,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -8349,7 +8349,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -9155,7 +9155,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -10424,7 +10424,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -10450,7 +10450,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -11256,7 +11256,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-ext/eureka/dependencies.lock
+++ b/titus-ext/eureka/dependencies.lock
@@ -354,7 +354,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -536,7 +536,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -562,7 +562,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -1248,7 +1248,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2003,7 +2003,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -2185,7 +2185,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -2211,7 +2211,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -2897,7 +2897,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -3652,7 +3652,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -3834,7 +3834,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -3860,7 +3860,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4546,7 +4546,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5365,7 +5365,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -5547,7 +5547,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -5573,7 +5573,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -6259,7 +6259,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7015,7 +7015,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -7197,7 +7197,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7223,7 +7223,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7909,7 +7909,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -8806,7 +8806,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -9041,7 +9041,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9067,7 +9067,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -9937,7 +9937,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11060,7 +11060,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -11295,7 +11295,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11321,7 +11321,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12191,7 +12191,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13314,7 +13314,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -13549,7 +13549,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13575,7 +13575,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14445,7 +14445,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -15569,7 +15569,7 @@
             ]
         },
         "com.netflix.eureka:eureka-client": {
-            "locked": "1.9.17",
+            "locked": "1.9.18",
             "requested": "1.+"
         },
         "com.netflix.fenzo:fenzo-core": {
@@ -15804,7 +15804,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -15830,7 +15830,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -16700,7 +16700,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-ext/jooq/dependencies.lock
+++ b/titus-ext/jooq/dependencies.lock
@@ -416,13 +416,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -967,7 +967,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1748,13 +1748,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2299,7 +2299,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -3080,13 +3080,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3631,7 +3631,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4524,13 +4524,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5075,7 +5075,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5857,13 +5857,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6408,7 +6408,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7457,7 +7457,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7483,7 +7483,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8295,7 +8295,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9603,7 +9603,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9629,7 +9629,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10441,7 +10441,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11749,7 +11749,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11775,7 +11775,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12587,7 +12587,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13896,7 +13896,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13922,7 +13922,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14734,7 +14734,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-ext/jooqflyway/dependencies.lock
+++ b/titus-ext/jooqflyway/dependencies.lock
@@ -416,13 +416,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -971,7 +971,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1749,13 +1749,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2304,7 +2304,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -3082,13 +3082,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3637,7 +3637,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4523,13 +4523,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5078,7 +5078,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5857,13 +5857,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6412,7 +6412,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7458,7 +7458,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7484,7 +7484,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8300,7 +8300,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9605,7 +9605,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9631,7 +9631,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10447,7 +10447,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11752,7 +11752,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11778,7 +11778,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12594,7 +12594,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13900,7 +13900,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13926,7 +13926,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14742,7 +14742,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-ext/zookeeper/dependencies.lock
+++ b/titus-ext/zookeeper/dependencies.lock
@@ -475,7 +475,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -501,7 +501,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -1142,7 +1142,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1982,7 +1982,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -2008,7 +2008,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -2649,7 +2649,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -3489,7 +3489,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -3515,7 +3515,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4156,7 +4156,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5060,7 +5060,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -5086,7 +5086,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -5727,7 +5727,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -6568,7 +6568,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -6594,7 +6594,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7235,7 +7235,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -8278,7 +8278,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -8304,7 +8304,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -9144,7 +9144,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -10414,7 +10414,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -10440,7 +10440,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -11280,7 +11280,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -12550,7 +12550,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -12576,7 +12576,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -13416,7 +13416,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -14687,7 +14687,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -14713,7 +14713,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -15553,7 +15553,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-server-federation/dependencies.lock
+++ b/titus-server-federation/dependencies.lock
@@ -406,13 +406,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -951,7 +951,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1687,13 +1687,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2232,7 +2232,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2968,13 +2968,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3513,7 +3513,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4313,13 +4313,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4858,7 +4858,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5595,13 +5595,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6140,7 +6140,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7169,11 +7169,11 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "com.squareup.okhttp3:mockwebserver"
@@ -7200,7 +7200,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8016,9 +8016,8 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
@@ -9309,11 +9308,11 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "com.squareup.okhttp3:mockwebserver"
@@ -9340,7 +9339,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10156,9 +10155,8 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
@@ -11449,11 +11447,11 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "com.squareup.okhttp3:mockwebserver"
@@ -11480,7 +11478,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12296,9 +12294,8 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",
@@ -13590,11 +13587,11 @@
             ]
         },
         "com.squareup.okhttp3:mockwebserver": {
-            "locked": "3.8.0",
-            "requested": "3.8.0"
+            "locked": "3.14.6",
+            "requested": "3.+"
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common",
                 "com.squareup.okhttp3:mockwebserver"
@@ -13621,7 +13618,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14437,9 +14434,8 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
-                "com.squareup.okhttp3:mockwebserver",
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
                 "org.mock-server:mockserver-core",

--- a/titus-server-gateway/dependencies.lock
+++ b/titus-server-gateway/dependencies.lock
@@ -415,13 +415,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -963,7 +963,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1710,13 +1710,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2258,7 +2258,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -3005,13 +3005,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3553,7 +3553,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4364,13 +4364,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4912,7 +4912,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5660,13 +5660,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6208,7 +6208,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7245,7 +7245,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7271,7 +7271,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8082,7 +8082,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9381,7 +9381,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9407,7 +9407,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10218,7 +10218,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11517,7 +11517,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11543,7 +11543,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12354,7 +12354,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13654,7 +13654,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13680,7 +13680,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14491,7 +14491,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-server-master/dependencies.lock
+++ b/titus-server-master/dependencies.lock
@@ -460,7 +460,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -486,7 +486,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -1095,7 +1095,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1914,7 +1914,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -1940,7 +1940,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -2549,7 +2549,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -3368,7 +3368,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -3394,7 +3394,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -4003,7 +4003,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4886,7 +4886,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -4912,7 +4912,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -5521,7 +5521,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -6341,7 +6341,7 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -6367,7 +6367,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -6976,7 +6976,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -8029,7 +8029,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -8055,7 +8055,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -8886,7 +8886,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -10212,7 +10212,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -10238,7 +10238,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -11069,7 +11069,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -12395,7 +12395,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -12421,7 +12421,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -13252,7 +13252,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -14579,7 +14579,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -14605,7 +14605,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -15436,7 +15436,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-server-runtime/dependencies.lock
+++ b/titus-server-runtime/dependencies.lock
@@ -388,13 +388,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -929,7 +929,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1641,13 +1641,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2182,7 +2182,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2894,13 +2894,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3435,7 +3435,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4211,13 +4211,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4752,7 +4752,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5465,13 +5465,13 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6006,7 +6006,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7011,7 +7011,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7037,7 +7037,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7848,7 +7848,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9122,7 +9122,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9148,7 +9148,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -9959,7 +9959,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11233,7 +11233,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11259,7 +11259,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12070,7 +12070,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13345,7 +13345,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13371,7 +13371,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14182,7 +14182,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-supplementary-component/job-activity-history-springboot/dependencies.lock
+++ b/titus-supplementary-component/job-activity-history-springboot/dependencies.lock
@@ -669,7 +669,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -695,7 +695,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -1475,7 +1475,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2735,7 +2735,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -2761,7 +2761,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -3547,7 +3547,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4834,7 +4834,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -4860,7 +4860,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -5646,7 +5646,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -6995,7 +6995,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7021,7 +7021,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7801,7 +7801,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9062,7 +9062,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9088,7 +9088,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -9874,7 +9874,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11170,7 +11170,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11196,7 +11196,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -11983,7 +11983,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13258,7 +13258,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13284,7 +13284,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14077,7 +14077,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -15377,7 +15377,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -15403,7 +15403,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -16190,7 +16190,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -17466,7 +17466,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -17492,7 +17492,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -18285,7 +18285,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-supplementary-component/job-activity-history/dependencies.lock
+++ b/titus-supplementary-component/job-activity-history/dependencies.lock
@@ -406,13 +406,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -951,7 +951,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1689,13 +1689,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2234,7 +2234,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2972,13 +2972,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3517,7 +3517,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4319,13 +4319,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4864,7 +4864,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5603,13 +5603,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6148,7 +6148,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7156,7 +7156,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7182,7 +7182,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7988,7 +7988,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9255,7 +9255,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9281,7 +9281,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10087,7 +10087,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11354,7 +11354,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11380,7 +11380,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12186,7 +12186,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13454,7 +13454,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13480,7 +13480,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14286,7 +14286,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-supplementary-component/task-relocation-springboot/dependencies.lock
+++ b/titus-supplementary-component/task-relocation-springboot/dependencies.lock
@@ -412,13 +412,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -944,7 +944,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1707,13 +1707,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2272,7 +2272,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -3111,13 +3111,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3676,7 +3676,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4557,13 +4557,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -5089,7 +5089,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5853,13 +5853,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6418,7 +6418,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7246,13 +7246,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -7803,7 +7803,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -8597,13 +8597,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -9187,7 +9187,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -10035,13 +10035,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -10592,7 +10592,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11387,13 +11387,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -11977,7 +11977,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-supplementary-component/task-relocation/dependencies.lock
+++ b/titus-supplementary-component/task-relocation/dependencies.lock
@@ -406,13 +406,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -951,7 +951,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1689,13 +1689,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2234,7 +2234,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2972,13 +2972,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3517,7 +3517,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4319,13 +4319,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4864,7 +4864,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5603,13 +5603,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6148,7 +6148,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7156,7 +7156,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7182,7 +7182,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7988,7 +7988,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9260,7 +9260,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9286,7 +9286,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10092,7 +10092,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11364,7 +11364,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11390,7 +11390,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12196,7 +12196,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13469,7 +13469,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13495,7 +13495,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14301,7 +14301,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-supplementary-component/tasks-publisher-springboot/dependencies.lock
+++ b/titus-supplementary-component/tasks-publisher-springboot/dependencies.lock
@@ -669,7 +669,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -695,7 +695,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -1475,7 +1475,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2736,7 +2736,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -2762,7 +2762,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -3548,7 +3548,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4836,7 +4836,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -4862,7 +4862,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -5648,7 +5648,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -6998,7 +6998,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7024,7 +7024,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7804,7 +7804,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9066,7 +9066,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9092,7 +9092,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -9878,7 +9878,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11175,7 +11175,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11201,7 +11201,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -11988,7 +11988,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13264,7 +13264,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13290,7 +13290,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14083,7 +14083,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -15384,7 +15384,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -15410,7 +15410,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -16197,7 +16197,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -17474,7 +17474,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -17500,7 +17500,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -18293,7 +18293,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-supplementary-component/tasks-publisher/dependencies.lock
+++ b/titus-supplementary-component/tasks-publisher/dependencies.lock
@@ -406,13 +406,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -951,7 +951,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -1690,13 +1690,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -2235,7 +2235,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2974,13 +2974,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -3519,7 +3519,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4322,13 +4322,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -4867,7 +4867,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -5607,13 +5607,13 @@
             "project": true
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
             ]
@@ -6152,7 +6152,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.52",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -7161,7 +7161,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -7187,7 +7187,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7993,7 +7993,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -9261,7 +9261,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -9287,7 +9287,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -10093,7 +10093,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -11361,7 +11361,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11387,7 +11387,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -12193,7 +12193,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13462,7 +13462,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13488,7 +13488,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -14294,7 +14294,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",

--- a/titus-testkit/dependencies.lock
+++ b/titus-testkit/dependencies.lock
@@ -647,7 +647,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -673,7 +673,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -1472,7 +1472,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -2698,7 +2698,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -2724,7 +2724,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -3523,7 +3523,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -4749,7 +4749,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -4775,7 +4775,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -5574,7 +5574,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -6864,7 +6864,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -6890,7 +6890,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -7689,7 +7689,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -8916,7 +8916,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -8942,7 +8942,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -9741,7 +9741,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -10978,7 +10978,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -11004,7 +11004,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -11808,7 +11808,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -13048,7 +13048,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -13074,7 +13074,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -13878,7 +13878,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -15118,7 +15118,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -15144,7 +15144,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -15948,7 +15948,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",
@@ -17189,7 +17189,7 @@
             ]
         },
         "com.squareup.okhttp3:okhttp": {
-            "locked": "3.8.0",
+            "locked": "3.14.6",
             "transitive": [
                 "com.netflix.titus:titus-common"
             ]
@@ -17215,7 +17215,7 @@
             ]
         },
         "com.squareup.okio:okio": {
-            "locked": "1.13.0",
+            "locked": "1.17.2",
             "transitive": [
                 "com.squareup.okhttp3:okhttp",
                 "com.squareup.okhttp:okhttp"
@@ -18019,7 +18019,7 @@
             ]
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.50",
+            "locked": "1.61",
             "transitive": [
                 "org.bouncycastle:bcmail-jdk15on",
                 "org.bouncycastle:bcpkix-jdk15on",


### PR DESCRIPTION
Newer JDKs (e.g. the ones we use on CircleCI) are now rejecting self signed certificates with invalid `CN` fields.

This fixes okhttp TLS tests on CircleCI.