### PR TITLE
loadbalancer: allow C* ResultSet pagination during activation

### DIFF
--- a/titus-ext/cassandra/src/main/java/com/netflix/titus/ext/cassandra/store/CassandraLoadBalancerStore.java
+++ b/titus-ext/cassandra/src/main/java/com/netflix/titus/ext/cassandra/store/CassandraLoadBalancerStore.java
@@ -194,7 +194,7 @@ public class CassandraLoadBalancerStore implements LoadBalancerStore {
     }
 
     private Mono<Void> loadAllAssociations(boolean failOnError) {
-        return ReactorExt.toFlux(storeHelper.execute(selectAssociations.bind().setFetchSize(FETCH_SIZE)))
+        return ReactorExt.toFlux(storeHelper.execute(selectAssociations.bind()))
                 .timeout(Duration.ofMillis(FETCH_TIMEOUT_MS))
                 .next()
                 .flatMapMany(Flux::fromIterable)


### PR DESCRIPTION
... to reduce the amount of memory and queue pressure on the C* driver during leader activation (when all LB associations are loaded).