### PR TITLE
use job runtime limits as the runtime prediction when sensible

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -174,10 +174,11 @@ public final class JobFunctions {
         return jobDescriptor.toBuilder().withExtensions(ext).build();
     }
 
-    public static JobDescriptor<?> filterOutSanitizationAttributes(JobDescriptor<?> jobDescriptor) {
+    public static JobDescriptor<?> filterOutGeneratedAttributes(JobDescriptor<?> jobDescriptor) {
         return jobDescriptor.toBuilder().withAttributes(
                 CollectionsExt.copyAndRemoveByKey(jobDescriptor.getAttributes(),
-                        key -> key.startsWith(JobAttributes.JOB_ATTRIBUTE_SANITIZATION_PREFIX)
+                        key -> key.startsWith(JobAttributes.JOB_ATTRIBUTE_SANITIZATION_PREFIX) ||
+                                key.startsWith(JobAttributes.PREDICTION_ATTRIBUTE_PREFIX)
                 )
         ).build();
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -520,10 +520,22 @@ public final class JobFunctions {
      * @see JobAttributes#JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC
      */
     public static Optional<Duration> getJobRuntimePrediction(Job job) {
-        if (!isBatchJob(job)) {
+        return getJobRuntimePrediction(job.getJobDescriptor());
+    }
+
+    /**
+     * Jobs can include a fractional runtime duration prediction in seconds, which are parsed with millisecond resolution.
+     *
+     * @return a duration (if present) with millisecond resolution
+     * @see JobAttributes#JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC
+     */
+    @SuppressWarnings("unchecked")
+    public static Optional<Duration> getJobRuntimePrediction(JobDescriptor jobDescriptor) {
+        if (!isBatchJob(jobDescriptor)) {
             return Optional.empty();
         }
-        return Optional.ofNullable(((Job<?>) job).getJobDescriptor().getAttributes().get(JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC))
+        Map<String, String> attributes = ((JobDescriptor<BatchJobExt>) jobDescriptor).getAttributes();
+        return Optional.ofNullable(attributes.get(JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC))
                 .flatMap(StringExt::parseDouble)
                 .map(seconds -> ((long) (seconds * 1000))) // seconds -> milliseconds
                 .map(Duration::ofMillis);

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ext/BatchJobExt.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ext/BatchJobExt.java
@@ -34,7 +34,7 @@ public class BatchJobExt implements JobDescriptor.JobDescriptorExt {
     @FieldInvariant(value = "value <= @constraints.getMaxBatchJobSize()", message = "Batch job too big #{value} > #{@constraints.getMaxBatchJobSize()}")
     private final int size;
 
-    @Min(value = 60_000, message = "Runtime limit too low (must be at least 60sec, but is #{#root}[ms])")
+    @Min(value = 5_000, message = "Runtime limit too low (must be at least 5sec, but is #{#root}[ms])")
     @FieldInvariant(value = "value <= @constraints.getMaxRuntimeLimitSec() * 1000", message = "Runtime limit too high #{value} > #{@constraints.getMaxRuntimeLimitSec() * 1000}")
     private final long runtimeLimitMs;
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ext/BatchJobExt.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ext/BatchJobExt.java
@@ -26,15 +26,18 @@ import com.netflix.titus.common.model.sanitizer.ClassFieldsNotNull;
 import com.netflix.titus.common.model.sanitizer.FieldInvariant;
 
 /**
+ *
  */
 @ClassFieldsNotNull
 public class BatchJobExt implements JobDescriptor.JobDescriptorExt {
+
+    public static final int RUNTIME_LIMIT_MIN = 5_000;
 
     @Min(value = 1, message = "Batch job must have at least one task")
     @FieldInvariant(value = "value <= @constraints.getMaxBatchJobSize()", message = "Batch job too big #{value} > #{@constraints.getMaxBatchJobSize()}")
     private final int size;
 
-    @Min(value = 5_000, message = "Runtime limit too low (must be at least 5sec, but is #{#root}[ms])")
+    @Min(value = RUNTIME_LIMIT_MIN, message = "Runtime limit too low (must be at least 5sec, but is #{#root}[ms])")
     @FieldInvariant(value = "value <= @constraints.getMaxRuntimeLimitSec() * 1000", message = "Runtime limit too high #{value} > #{@constraints.getMaxRuntimeLimitSec() * 1000}")
     private final long runtimeLimitMs;
 

--- a/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
@@ -16,8 +16,11 @@
 
 package com.netflix.titus.common.util;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 public final class FunctionExt {
     private static final Predicate TRUE_PREDICATE = ignored -> true;
@@ -37,4 +40,14 @@ public final class FunctionExt {
         }
         return opt;
     }
+
+    /**
+     * {@link UnaryOperator} does not have an equivalent of {@link Function#andThen(Function)}, so this can be used when
+     * the more specific type is required.
+     */
+    public static <T> UnaryOperator<T> andThen(UnaryOperator<T> op, UnaryOperator<T> after) {
+        Objects.requireNonNull(after);
+        return (T t) -> after.apply(op.apply(t));
+    }
+
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/FunctionExt.java
@@ -43,7 +43,7 @@ public final class FunctionExt {
 
     /**
      * {@link UnaryOperator} does not have an equivalent of {@link Function#andThen(Function)}, so this can be used when
-     * the more specific type is required.
+     * the more specific type ({@link UnaryOperator}) is required.
      */
     public static <T> UnaryOperator<T> andThen(UnaryOperator<T> op, UnaryOperator<T> after) {
         Objects.requireNonNull(after);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/DifferenceResolverUtils.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/DifferenceResolverUtils.java
@@ -147,7 +147,7 @@ public class DifferenceResolverUtils {
                 Job<BatchJobExt> batchJob = runningJobView.getJob();
 
                 // We expect runtime limit to be always set, so this is just extra safety measure.
-                long runtimeLimitMs = Math.max(60_000, batchJob.getJobDescriptor().getExtensions().getRuntimeLimitMs());
+                long runtimeLimitMs = Math.max(BatchJobExt.RUNTIME_LIMIT_MIN, batchJob.getJobDescriptor().getExtensions().getRuntimeLimitMs());
 
                 long deadline = task.getStatus().getTimestamp() + runtimeLimitMs;
                 if (deadline < clock.wallTime()) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -78,10 +78,9 @@ import com.netflix.titus.master.jobmanager.service.common.V3QAttributes;
 import com.netflix.titus.master.jobmanager.service.common.V3QueueableTask;
 import com.netflix.titus.master.mesos.LeaseRescindedEvent;
 import com.netflix.titus.master.mesos.MesosConfiguration;
-import com.netflix.titus.master.mesos.TaskInfoRequestFactory;
 import com.netflix.titus.master.mesos.TaskInfoRequest;
+import com.netflix.titus.master.mesos.TaskInfoRequestFactory;
 import com.netflix.titus.master.mesos.VirtualMachineMasterService;
-import com.netflix.titus.master.model.job.TitusQueuableTask;
 import com.netflix.titus.master.scheduler.TaskPlacementFailure.FailureKind;
 import com.netflix.titus.master.scheduler.constraint.SystemHardConstraint;
 import com.netflix.titus.master.scheduler.constraint.TaskCacheEventListener;
@@ -533,7 +532,7 @@ public class DefaultSchedulingService implements SchedulingService<V3QueueableTa
     private void processTaskSchedulingFailureCallbacks(Map<FailureKind, Map<V3QueueableTask, List<TaskPlacementFailure>>> failuresByKind) {
         for (V3QueueableTask failed : SchedulerUtils.collectFailedTasksIgnoring(failuresByKind,
                 FailureKind.IGNORED_FOR_OPPORTUNISTIC_SCHEDULING)) {
-            ((TitusQueuableTask) failed).opportunisticSchedulingFailed();
+            failed.opportunisticSchedulingFailed();
         }
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
@@ -28,7 +28,6 @@ import com.netflix.titus.master.integration.BaseIntegrationTest;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTemplates;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
 import com.netflix.titus.master.integration.v3.scenario.JobsScenarioBuilder;
-import com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates;
 import com.netflix.titus.master.scheduler.opportunistic.OpportunisticCpuAvailability;
 import com.netflix.titus.runtime.endpoint.admission.JobRuntimePredictionConfiguration;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMaster;
@@ -43,6 +42,11 @@ import org.junit.rules.RuleChain;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_ASG;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT;
+import static com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates.jobAccepted;
+import static com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates.killJob;
+import static com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates.launchJob;
+import static com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates.startJob;
+import static com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates.startLaunchedTask;
 import static com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCells.cellWithRuntimePredictions;
 import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskBatchJobDescriptor;
 
@@ -50,7 +54,7 @@ import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTask
 public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
     private static final JobDescriptor<BatchJobExt> BATCH_JOB_WITH_RUNTIME_PREDICTION = oneTaskBatchJobDescriptor().but(
             // runtime predictions are automatically set (and capped) to the runtime limit
-            jd -> jd.getExtensions().toBuilder().withRuntimeLimitMs(61000)
+            jd -> jd.getExtensions().toBuilder().withRuntimeLimitMs(60_000L)
     );
 
     private final JobRuntimePredictionConfiguration runtimePredictionConfig = () -> 300_000L;
@@ -77,13 +81,13 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         );
 
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .assertTask(task -> !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION) &&
                                         !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT),
                                 "Not scheduled on opportunistic CPUs")
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 )
         );
     }
@@ -103,13 +107,13 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         );
 
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .assertTask(task -> !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION) &&
                                         !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT),
                                 "Not scheduled on opportunistic CPUs")
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 )
         );
     }
@@ -128,53 +132,53 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         );
 
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "2")
                         // free up launch guard
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 ));
 
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "2")
                         // free up launch guard
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 ));
 
         // all opportunistic CPUs have been claimed, next task can't use it
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .assertTask(task -> !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION) &&
                                         !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT),
                                 "Not scheduled on opportunistic CPUs")
                         // free up launch guard
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 )
         );
 
         // free up opportunistic CPUs, window is still valid
-        jobsScenarioBuilder.takeJob(0).template(ScenarioTemplates.killJob());
+        jobsScenarioBuilder.takeJob(0).template(killJob());
 
         // opportunistic CPUs are available again, and window is still valid (6h expiration)
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "2")
                         // free up launch guard
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 ));
     }
 
@@ -191,13 +195,13 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
                 j.getContainer().but(c -> c.getContainerResources().toBuilder().withCpu(4))
         );
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .assertTask(task -> !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION) &&
                                         !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT),
                                 "Not scheduled on opportunistic CPUs")
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 )
         );
     }
@@ -215,13 +219,13 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
                 j.getContainer().but(c -> c.getContainerResources().toBuilder().withCpu(4))
         );
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "2")
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 )
         );
     }
@@ -232,8 +236,10 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         Instant expiresAt = Instant.now().plus(Duration.ofHours(6));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 4);
         titusStackResource.getMaster().getSimulatedCloud().updateAgentGroupCapacity("flex1", 1, 1, 1);
-        instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.awaitDesiredSize(1).any(instance -> instance.addOpportunisticCpus(availability))
+        instanceGroupsScenarioBuilder.apply("flex1", group -> group
+                .awaitDesiredSize(1)
+                .awaitDesiredInstanceCount() // ensure the agent is scaled down
+                .any(instance -> instance.addOpportunisticCpus(availability))
         );
 
         JobDescriptor<BatchJobExt> regularJob = oneTaskBatchJobDescriptor().but(
@@ -245,30 +251,36 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         );
 
         String regularJobId = jobsScenarioBuilder.schedule(regularJob,
-                jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.launchJob())
+                // move to StartInitiated to prevent "stuck in Launched" errors
+                jobScenarioBuilder -> jobScenarioBuilder.template(startJob(TaskStatus.TaskState.StartInitiated))
                         .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                                 .expectTaskOnAgent() /* potentially hold launch guard */
+                                .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                                 .expectNoTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT)
                         )
         ).takeJobId(0);
 
         String opportunisticJobId = jobsScenarioBuilder.schedule(opportunisticJob,
-                jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.jobAccepted())
-                        .expectAllTasksCreated()
+                jobScenarioBuilder -> jobScenarioBuilder.template(jobAccepted()).expectAllTasksCreated()
         ).takeJobId(1);
 
         // free up potential launch guards
-        jobsScenarioBuilder.takeJob(regularJobId).template(ScenarioTemplates.startLaunchedTasks());
+        jobsScenarioBuilder.takeJob(regularJobId).template(jobScenarioBuilder ->
+                jobScenarioBuilder.allTasks(taskScenarioBuilder -> taskScenarioBuilder
+                        .transitionUntil(TaskStatus.TaskState.Started)
+                        .expectStateUpdateSkipOther(TaskStatus.TaskState.Started)
+                )
+        );
 
         // opportunistic scheduling can now proceed without decrementing allocated opportunistic CPUs
         jobsScenarioBuilder.takeJob(opportunisticJobId)
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectStateUpdateSkipOther(TaskStatus.TaskState.Launched)
+                        .template(startLaunchedTask())
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "4")
-                        .template(ScenarioTemplates.startLaunchedTask())
                 );
     }
 
@@ -289,7 +301,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         );
 
         String opportunisticJobId = jobsScenarioBuilder.schedule(opportunisticJob, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.jobAccepted())
+                .template(jobAccepted())
                 .expectAllTasksCreated()
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectSchedulingFailed()
@@ -329,19 +341,19 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
                 )
         );
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "2")
                         // free up launch guard
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 ));
 
         titusStackResource.getMaster().updateProperty("titus.feature.opportunisticResourcesSchedulingEnabled", "false");
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
@@ -349,19 +361,19 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
                                         !task.getTaskContext().containsKey(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT),
                                 "Not scheduled on opportunistic CPUs")
                         // free up launch guard
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 ));
 
         titusStackResource.getMaster().updateProperty("titus.feature.opportunisticResourcesSchedulingEnabled", "true");
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
+                .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "2")
                         // free up launch guard
-                        .template(ScenarioTemplates.startLaunchedTask())
+                        .template(startLaunchedTask())
                 ));
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
@@ -20,9 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 
-import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
-import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.grpc.protogen.TaskStatus;
@@ -31,8 +29,9 @@ import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTem
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
 import com.netflix.titus.master.integration.v3.scenario.JobsScenarioBuilder;
 import com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates;
-import com.netflix.titus.master.integration.v3.scenario.TaskScenarioBuilder;
 import com.netflix.titus.master.scheduler.opportunistic.OpportunisticCpuAvailability;
+import com.netflix.titus.runtime.endpoint.admission.JobRuntimePredictionConfiguration;
+import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMaster;
 import com.netflix.titus.testkit.junit.category.IntegrationTest;
 import com.netflix.titus.testkit.junit.master.TitusStackResource;
 import org.junit.Before;
@@ -44,19 +43,19 @@ import org.junit.rules.RuleChain;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_AGENT_ASG;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT;
-import static com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCells.basicCell;
+import static com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCells.cellWithRuntimePredictions;
 import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskBatchJobDescriptor;
 
 @Category(IntegrationTest.class)
 public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
-    private static final JobDescriptor<BatchJobExt> BATCH_JOB_WITH_RUNTIME_PREDICTION = JobFunctions.appendJobDescriptorAttribute(
-            oneTaskBatchJobDescriptor(), JobAttributes.JOB_ATTRIBUTES_RUNTIME_PREDICTION_SEC, "12.6" /* seconds */
+    private static final JobDescriptor<BatchJobExt> BATCH_JOB_WITH_RUNTIME_PREDICTION = oneTaskBatchJobDescriptor().but(
+            // runtime predictions are automatically set (and capped) to the runtime limit
+            jd -> jd.getExtensions().toBuilder().withRuntimeLimitMs(61000)
     );
 
-    private final TitusStackResource titusStackResource = new TitusStackResource(basicCell(2));
-
+    private final JobRuntimePredictionConfiguration runtimePredictionConfig = () -> 300_000L;
+    private final TitusStackResource titusStackResource = new TitusStackResource(cellWithRuntimePredictions(EmbeddedTitusMaster.CELL_NAME, 2, runtimePredictionConfig));
     private final JobsScenarioBuilder jobsScenarioBuilder = new JobsScenarioBuilder(titusStackResource);
-
     private final InstanceGroupsScenarioBuilder instanceGroupsScenarioBuilder = new InstanceGroupsScenarioBuilder(titusStackResource);
 
     @Rule
@@ -92,7 +91,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
     @Test(timeout = TEST_TIMEOUT_MS)
     public void availabilityNotLongEnough() throws Exception {
         String allocationId = UUID.randomUUID().toString();
-        Instant expiresAt = Instant.now().plus(Duration.ofSeconds(10));
+        Instant expiresAt = Instant.now().plus(Duration.ofSeconds(45));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 4);
         instanceGroupsScenarioBuilder.apply("flex1",
                 group -> group.any(instance -> instance.addOpportunisticCpus(availability))
@@ -232,42 +231,43 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         String allocationId = UUID.randomUUID().toString();
         Instant expiresAt = Instant.now().plus(Duration.ofHours(6));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 4);
+        titusStackResource.getMaster().getSimulatedCloud().updateAgentGroupCapacity("flex1", 1, 1, 1);
         instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.any(instance -> instance.addOpportunisticCpus(availability))
+                group -> group.awaitDesiredSize(1).any(instance -> instance.addOpportunisticCpus(availability))
         );
 
-        JobDescriptor<BatchJobExt> regularJob = oneTaskBatchJobDescriptor().but(j ->
-                j.getExtensions().toBuilder().withSize(2) // one per available agent machine
+        JobDescriptor<BatchJobExt> regularJob = oneTaskBatchJobDescriptor().but(
+                // 10min > config.opportunisticRuntimeLimit (5min)
+                j -> j.getExtensions().toBuilder().withRuntimeLimitMs(10 * 60 * 1000)
         );
         JobDescriptor<BatchJobExt> opportunisticJob = BATCH_JOB_WITH_RUNTIME_PREDICTION.but(j ->
                 j.getContainer().but(c -> c.getContainerResources().toBuilder().withCpu(4))
         );
 
-        String regularJobId = jobsScenarioBuilder.schedule(regularJob, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.launchJob())
-                .allTasks(TaskScenarioBuilder::expectTaskOnAgent /* hold launch guard */)
+        String regularJobId = jobsScenarioBuilder.schedule(regularJob,
+                jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.launchJob())
+                        .allTasks(taskScenarioBuilder -> taskScenarioBuilder
+                                .expectTaskOnAgent() /* potentially hold launch guard */
+                                .expectNoTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT)
+                        )
         ).takeJobId(0);
 
-        String opportunisticJobId = jobsScenarioBuilder.schedule(opportunisticJob, jobScenarioBuilder -> jobScenarioBuilder
-                .template(ScenarioTemplates.jobAccepted())
-                .expectAllTasksCreated()
-                .allTasks(taskScenarioBuilder -> taskScenarioBuilder
-                        .expectSchedulingFailed()
-                        .assertTask(task -> task.getStatus().getState().equals(TaskState.Accepted), "are still waiting for launchguards")
-                )
+        String opportunisticJobId = jobsScenarioBuilder.schedule(opportunisticJob,
+                jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.jobAccepted())
+                        .expectAllTasksCreated()
         ).takeJobId(1);
 
-        // free up launch guards
+        // free up potential launch guards
         jobsScenarioBuilder.takeJob(regularJobId).template(ScenarioTemplates.startLaunchedTasks());
 
         // opportunistic scheduling can now proceed without decrementing allocated opportunistic CPUs
         jobsScenarioBuilder.takeJob(opportunisticJobId)
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
                         .expectStateUpdateSkipOther(TaskStatus.TaskState.Launched)
+                        .expectTaskOnAgent()
                         .expectTaskContext(TASK_ATTRIBUTES_AGENT_ASG, "flex1")
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, allocationId)
                         .expectTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "4")
-                        // free up launch guard
                         .template(ScenarioTemplates.startLaunchedTask())
                 );
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSubmitAndControlNegativeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSubmitAndControlNegativeTest.java
@@ -234,7 +234,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
     public void testBatchJobWithTooLowRuntimeLimit() throws Exception {
         submitBadJob(
                 client,
-                BATCH_JOB_DESCR_BUILDER.setBatch(BATCH_JOB_SPEC_BUILDER.setRuntimeLimitSec(5)).build(),
+                BATCH_JOB_DESCR_BUILDER.setBatch(BATCH_JOB_SPEC_BUILDER.setRuntimeLimitSec(4)).build(),
                 "extensions.runtimeLimitMs"
         );
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Subscription;
 
+import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static com.netflix.titus.runtime.endpoint.v3.grpc.GrpcAgentModelConverters.toGrpcDeploymentState;
 import static com.netflix.titus.runtime.endpoint.v3.grpc.GrpcAgentModelConverters.toGrpcLifecycleState;
 import static com.netflix.titus.runtime.endpoint.v3.grpc.GrpcAgentModelConverters.toGrpcTier;
@@ -141,6 +142,12 @@ public class InstanceGroupScenarioBuilder {
         return this;
     }
 
+    public InstanceGroupScenarioBuilder awaitDesiredInstanceCount() {
+        checkIsKnown();
+        waitAtMost(TIMEOUT_MS, TimeUnit.MILLISECONDS).until(this::hasDesiredInstanceCount);
+        return this;
+    }
+
     public InstanceGroupScenarioBuilder awaitDesiredSize(int expectedDesired) {
         checkIsKnown();
 
@@ -164,6 +171,13 @@ public class InstanceGroupScenarioBuilder {
         }
         com.netflix.titus.grpc.protogen.InstanceLifecycleState grpcState = toGrpcDeploymentState(state);
         return instances.values().stream().allMatch(i -> i.getLifecycleStatus().getState() == grpcState);
+    }
+
+    private boolean hasDesiredInstanceCount() {
+        if (instanceGroup == null) {
+            return false;
+        }
+        return instanceGroup.getDesired() == instances.size();
     }
 
     boolean isSynchronizedWithCloud() {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
@@ -65,9 +65,9 @@ public class InstanceGroupScenarioBuilder {
     private final ConcurrentMap<String, AgentInstance> instances = new ConcurrentHashMap<>();
 
     InstanceGroupScenarioBuilder(TitusStackResource titusStackResource, EmbeddedTitusOperations titusOperations,
-                                        SimulatedTitusAgentCluster simulatedAgentCluster,
-                                        InstanceGroupsScenarioBuilder parent,
-                                        Observable<AgentChangeEvent> events) {
+                                 SimulatedTitusAgentCluster simulatedAgentCluster,
+                                 InstanceGroupsScenarioBuilder parent,
+                                 Observable<AgentChangeEvent> events) {
         this.titusStackResource = titusStackResource;
         this.simulatedCluster = simulatedAgentCluster;
         this.client = titusOperations.getV3BlockingGrpcAgentClient();
@@ -82,6 +82,10 @@ public class InstanceGroupScenarioBuilder {
 
     public void shutdown() {
         eventSubscription.unsubscribe();
+    }
+
+    public boolean hasInstance(String instanceId) {
+        return instances.containsKey(instanceId);
     }
 
     public InstanceGroupScenarioBuilder any(Consumer<InstanceScenarioBuilder> transformer) {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupsScenarioBuilder.java
@@ -171,7 +171,7 @@ public class InstanceGroupsScenarioBuilder extends ExternalResource {
         return eventStreamObserver.toObservable().filter(e -> getInstanceGroupId(e).map(id -> id.equals(instanceGroupId)).orElse(false));
     }
 
-    public static Optional<String> getInstanceGroupId(AgentChangeEvent event) {
+    public Optional<String> getInstanceGroupId(AgentChangeEvent event) {
         switch (event.getEventCase()) {
             case INSTANCEGROUPUPDATE:
                 return Optional.of(event.getInstanceGroupUpdate().getInstanceGroup().getId());
@@ -180,8 +180,10 @@ public class InstanceGroupsScenarioBuilder extends ExternalResource {
             case AGENTINSTANCEUPDATE:
                 return Optional.of(event.getAgentInstanceUpdate().getInstance().getInstanceGroupId());
             case AGENTINSTANCEREMOVED:
-                // FIXME We have to iterate through all instance groups to find the destination
-                break;
+                return instanceGroupScenarioBuilders.entrySet().stream()
+                        .filter(entry -> entry.getValue().hasInstance(event.getAgentInstanceRemoved().getInstanceId()))
+                        .map(Map.Entry::getKey)
+                        .findFirst();
             case SNAPSHOTEND:
                 return Optional.empty();
         }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/TaskScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/TaskScenarioBuilder.java
@@ -307,6 +307,15 @@ public class TaskScenarioBuilder {
         return this;
     }
 
+    public TaskScenarioBuilder expectNoTaskContext(String key) {
+        logger.info("[{}] Expecting current task to not have taskContext key {}", discoverActiveTest(), key);
+        Preconditions.checkArgument(
+                !getTask().getTaskContext().containsKey(key),
+                "Task context contains {}", key
+        );
+        return this;
+    }
+
     public TaskScenarioBuilder expectStateUpdates(TaskStatus.TaskState... expectedStates) {
         logger.info("[{}] Expecting sequence of events with task states {}...", discoverActiveTest(), asList(expectedStates));
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobRuntimePredictionConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+
+@Configuration(prefix = "titus.admissionSanitizer.jobRuntimePrediction")
+public interface JobRuntimePredictionConfiguration {
+
+    @DefaultValue("300000")
+    long getMaxOpportunisticRuntimeLimitMs();
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
@@ -19,10 +19,10 @@ package com.netflix.titus.runtime.jobmanager.gateway;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
 import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
@@ -61,7 +61,9 @@ public class SanitizingJobServiceGateway extends JobServiceGatewayDelegate {
     public Observable<String> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata) {
         com.netflix.titus.api.jobmanager.model.job.JobDescriptor coreJobDescriptor;
         try {
-            coreJobDescriptor = JobFunctions.filterOutSanitizationAttributes(GrpcJobManagementModelConverters.toCoreJobDescriptor(jobDescriptor));
+            coreJobDescriptor = JobFunctions.filterOutGeneratedAttributes(
+                    GrpcJobManagementModelConverters.toCoreJobDescriptor(jobDescriptor)
+            );
         } catch (Exception e) {
             return Observable.error(TitusServiceException.invalidArgument(e));
         }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
@@ -258,7 +258,9 @@ public class EmbeddedTitusGateway {
                 .withMaster(embeddedTitusMaster)
                 .withHttpPort(httpPort)
                 .withGrpcPort(grpcPort)
-                .withProperties(properties);
+                .withProperties(properties)
+                .withJobValidator(validator)
+                .withJobSanitizer(jobSanitizer);
     }
 
     public static Builder aDefaultTitusGateway() {


### PR DESCRIPTION
* ignore prediction attributes passed in when creating jobs (these are to be generated)
* cap runtime predictions to the runtime limit for batch jobs that have a limit
* use the job runtime limit as a fallback when no predictions are selected for a job
* lower the minimum job runtime limit to 5s (from 60s) to allow short running batch jobs to specify a runtime limit