### PR TITLE
publish more detailed metrics on failed placements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - 1.0.0.1
 
   mesos-master:
-    image: mesosphere/mesos-master:1.2.3
+    image: mesosphere/mesos-master:1.7.1
     networks:
       - titus
     restart: always

--- a/titus-ext/runner/Dockerfile.master
+++ b/titus-ext/runner/Dockerfile.master
@@ -13,15 +13,15 @@ RUN ./gradlew -PdisablePrivateRepo=true :titus-server-master:installDist
 
 FROM openjdk:8-jre
 RUN echo "deb http://repos.mesosphere.io/debian stretch main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF
 RUN apt-get -y update
-# we don't need a full mesos install, just libmesos, so we install the dependencies it needs,
-# and unpack it to prevent postinstall scripts
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qy install \
-    libcurl4 libevent-dev libsasl2-modules libcurl4-nss-dev libsvn1
-RUN cd /tmp; \
-    apt-get download mesos=1.1.3-2.0.1; \
-    dpkg --unpack mesos*.deb
+# we unpack the mesos package to prevent postinstall scripts
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qy download mesos && \
+    dpkg --unpack mesos*.deb && \
+    rm /var/lib/dpkg/info/mesos*.postinst -f && \
+    ( dpkg --configure mesos || true )
+# install mesos dependencies
+RUN DEBIAN_FRONTEND=noninteractive apt -qy --fix-broken install
 ENV MESOS_NATIVE_JAVA_LIBRARY=/usr/lib/libmesos.so
 COPY --from=builder /usr/src/titus-control-plane/titus-server-master/build/install/titus-server-master \
      /opt/titus-server-master

--- a/titus-ext/runner/Dockerfile.master
+++ b/titus-ext/runner/Dockerfile.master
@@ -11,7 +11,7 @@ COPY . /usr/src/titus-control-plane
 RUN ./gradlew -PdisablePrivateRepo=true :titus-server-master:installDist
 
 
-FROM openjdk:8-jre
+FROM openjdk:8-jre-stretch
 RUN echo "deb http://repos.mesosphere.io/debian stretch main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF
 RUN apt-get -y update

--- a/titus-ext/runner/Dockerfile.master
+++ b/titus-ext/runner/Dockerfile.master
@@ -15,13 +15,16 @@ FROM openjdk:8-jre-stretch
 RUN echo "deb http://repos.mesosphere.io/debian stretch main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF
 RUN apt-get -y update
-# unpack the mesos package to prevent postinstall scripts, and install its dependencies manually
+# unpack the mesos package to prevent postinstall scripts, fix its python libs location,
+# and install its dependencies manually
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qy download mesos && \
     dpkg --unpack mesos*.deb && \
-    rm -f /var/lib/dpkg/info/mesos*.postinst && \
-    apt install -qy libapr1 libaprutil1 curl libcurl3 libcurl4-openssl-dev libevent-2.0-5 libevent-core-2.0-5 \
-      libevent-dev libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5 libgdbm3 libsasl2-modules \
-      libserf-1-1 libsvn1
+    rm -f /var/lib/dpkg/info/mesos.postinst && \
+    mkdir -p /usr/local/lib/python2.7 && \
+    mv /usr/lib/python2.7/site-packages /usr/local/lib/python2.7/dist-packages && \
+    ln -s /usr/lib/python2.7/site-packages /usr/local/lib/python2.7/dist-packages && \
+    ( dpkg --configure mesos || true ) && \
+    apt -qy --fix-broken install
 ENV MESOS_NATIVE_JAVA_LIBRARY=/usr/lib/libmesos.so
 COPY --from=builder /usr/src/titus-control-plane/titus-server-master/build/install/titus-server-master \
      /opt/titus-server-master

--- a/titus-ext/runner/Dockerfile.master
+++ b/titus-ext/runner/Dockerfile.master
@@ -15,13 +15,13 @@ FROM openjdk:8-jre
 RUN echo "deb http://repos.mesosphere.io/debian stretch main" > /etc/apt/sources.list.d/mesosphere.list
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF
 RUN apt-get -y update
-# we unpack the mesos package to prevent postinstall scripts
+# unpack the mesos package to prevent postinstall scripts, and install its dependencies manually
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qy download mesos && \
     dpkg --unpack mesos*.deb && \
-    rm /var/lib/dpkg/info/mesos*.postinst -f && \
-    ( dpkg --configure mesos || true )
-# install mesos dependencies
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qyf install
+    rm -f /var/lib/dpkg/info/mesos*.postinst && \
+    apt install -qy libapr1 libaprutil1 curl libcurl3 libcurl4-openssl-dev libevent-2.0-5 libevent-core-2.0-5 \
+      libevent-dev libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5 libgdbm3 libsasl2-modules \
+      libserf-1-1 libsvn1
 ENV MESOS_NATIVE_JAVA_LIBRARY=/usr/lib/libmesos.so
 COPY --from=builder /usr/src/titus-control-plane/titus-server-master/build/install/titus-server-master \
      /opt/titus-server-master

--- a/titus-ext/runner/Dockerfile.master
+++ b/titus-ext/runner/Dockerfile.master
@@ -21,7 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qy download mesos && \
     rm /var/lib/dpkg/info/mesos*.postinst -f && \
     ( dpkg --configure mesos || true )
 # install mesos dependencies
-RUN DEBIAN_FRONTEND=noninteractive apt -qy --fix-broken install
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qyf install
 ENV MESOS_NATIVE_JAVA_LIBRARY=/usr/lib/libmesos.so
 COPY --from=builder /usr/src/titus-control-plane/titus-server-master/build/install/titus-server-master \
      /opt/titus-server-master

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -288,7 +288,7 @@ public class DefaultSchedulingService implements SchedulingService<V3QueueableTa
         });
 
         this.taskPlacementRecorder = new TaskPlacementRecorder(config, masterConfiguration, schedulingService, v3JobOperations, v3TaskInfoRequestFactory, opportunisticCpuCache, titusRuntime);
-        this.taskPlacementFailureClassifier = new TaskPlacementFailureClassifier<>(titusRuntime);
+        this.taskPlacementFailureClassifier = new TaskPlacementFailureClassifier<>(titusRuntime, SchedulerUtils::applicationAndCapacityGroupTags);
 
         totalTasksPerIterationGauge = registry.gauge(METRIC_SCHEDULING_SERVICE + "totalTasksPerIteration");
         assignedTasksPerIterationGauge = registry.gauge(METRIC_SCHEDULING_SERVICE + "assignedTasksPerIteration");

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerUtils.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerUtils.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableMap;
 import com.netflix.fenzo.TaskRequest;
 import com.netflix.fenzo.TaskTracker;
 import com.netflix.fenzo.VirtualMachineCurrentState;
@@ -32,6 +33,7 @@ import com.netflix.fenzo.queues.QueuableTask;
 import com.netflix.titus.api.agent.model.AgentInstance;
 import com.netflix.titus.api.agent.model.AgentInstanceGroup;
 import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.model.Tier;
@@ -169,5 +171,13 @@ public class SchedulerUtils {
         Set<String> instanceTaints = StringExt.splitByCommaIntoSet(instanceTaintsValue);
 
         return CollectionsExt.merge(instanceGroupTaints, instanceTaints);
+    }
+
+    public static Map<String, String> applicationAndCapacityGroupTags(V3QueueableTask task) {
+        JobDescriptor<?> jobDescriptor = task.getJob().getJobDescriptor();
+        return ImmutableMap.<String, String>builder()
+                .put("applicationName", jobDescriptor.getApplicationName())
+                .put("capacityGroup", jobDescriptor.getCapacityGroup())
+                .build();
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerUtils.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerUtils.java
@@ -175,9 +175,13 @@ public class SchedulerUtils {
 
     public static Map<String, String> applicationAndCapacityGroupTags(V3QueueableTask task) {
         JobDescriptor<?> jobDescriptor = task.getJob().getJobDescriptor();
+        int tierNumber = task.getQAttributes().getTierNumber();
+        String tier = tierNumber >= 0 && tierNumber < Tier.values().length ?
+                Tier.values()[tierNumber].name().toLowerCase() : "unknown";
         return ImmutableMap.<String, String>builder()
                 .put("applicationName", jobDescriptor.getApplicationName())
                 .put("capacityGroup", jobDescriptor.getCapacityGroup())
+                .put("tier", tier)
                 .build();
     }
 }


### PR DESCRIPTION
Currently, we only publish a gauge with the total number of tasks that failed placement in the last scheduling iteration.

This adds a new (counter) metric with more insights into why placements failed and for what application/capacityGroup. It will also count *all* failures from all scheduling iterations.

Failures are grouped by `(applicationName, capacityGroup)` to limit the cardinality of the new metric.