### PR TITLE
Add grpc to reactor server support for cglib proxies

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/GrpcToReactorServerFactory.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/GrpcToReactorServerFactory.java
@@ -23,5 +23,10 @@ public interface GrpcToReactorServerFactory {
 
     <REACT_SERVICE> ServerServiceDefinition apply(ServiceDescriptor serviceDefinition, REACT_SERVICE reactService);
 
+    /**
+     * This method is used when the {@link REACT_SERVICE} is a CGLIB proxy and additional class details need to be provided to the factory.
+     * If the {@link REACT_SERVICE} is a CGLIB proxy class it does not retain generic type information from the proxy target class so a
+     * detailed description of the target class is needed.
+     */
     <REACT_SERVICE> ServerServiceDefinition apply(ServiceDescriptor serviceDefinition, REACT_SERVICE reactService, Class<REACT_SERVICE> reactorDetailedFallbackClass);
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/GrpcToReactorServerFactory.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/GrpcToReactorServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,4 +22,6 @@ import io.grpc.ServiceDescriptor;
 public interface GrpcToReactorServerFactory {
 
     <REACT_SERVICE> ServerServiceDefinition apply(ServiceDescriptor serviceDefinition, REACT_SERVICE reactService);
+
+    <REACT_SERVICE> ServerServiceDefinition apply(ServiceDescriptor serviceDefinition, REACT_SERVICE reactService, Class<REACT_SERVICE> reactorDetailedFallbackClass);
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/server/DefaultGrpcToReactorServerFactory.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/server/DefaultGrpcToReactorServerFactory.java
@@ -34,7 +34,7 @@ public class DefaultGrpcToReactorServerFactory<CONTEXT> implements GrpcToReactor
 
     @Override
     public <REACT_SERVICE> ServerServiceDefinition apply(ServiceDescriptor serviceDescriptor, REACT_SERVICE reactService) {
-        return apply(serviceDescriptor, reactService, null);
+        return apply(serviceDescriptor, reactService, (Class<REACT_SERVICE>) reactService.getClass());
     }
 
     @Override

--- a/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/server/DefaultGrpcToReactorServerFactory.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/server/DefaultGrpcToReactorServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,14 @@ public class DefaultGrpcToReactorServerFactory<CONTEXT> implements GrpcToReactor
 
     @Override
     public <REACT_SERVICE> ServerServiceDefinition apply(ServiceDescriptor serviceDescriptor, REACT_SERVICE reactService) {
+        return apply(serviceDescriptor, reactService, null);
+    }
+
+    @Override
+    public <REACT_SERVICE> ServerServiceDefinition apply(ServiceDescriptor serviceDescriptor, REACT_SERVICE reactService, Class<REACT_SERVICE> reactorDetailedFallbackClass) {
         return GrpcToReactorServerBuilder.<REACT_SERVICE, CONTEXT>newBuilder(serviceDescriptor, reactService)
                 .withContext(contextType, contextResolver)
+                .withReactorFallbackClass(reactorDetailedFallbackClass)
                 .build();
     }
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/server/GrpcToReactorServerBuilder.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/grpc/reactor/server/GrpcToReactorServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ class GrpcToReactorServerBuilder<REACT_SERVICE, CONTEXT> {
 
     private final ServiceDescriptor serviceDescriptor;
     private final REACT_SERVICE reactorService;
+    private Class<REACT_SERVICE> reactorDetailedFallbackClass;
     private Class<CONTEXT> contextType;
     private Supplier<CONTEXT> contextResolver;
 
@@ -43,13 +44,18 @@ class GrpcToReactorServerBuilder<REACT_SERVICE, CONTEXT> {
         return this;
     }
 
+    GrpcToReactorServerBuilder<REACT_SERVICE, CONTEXT> withReactorFallbackClass(Class<REACT_SERVICE> reactorDetailedFallbackClass) {
+        this.reactorDetailedFallbackClass = reactorDetailedFallbackClass;
+        return this;
+    }
+
     static <REACT_SERVICE, CONTEXT> GrpcToReactorServerBuilder<REACT_SERVICE, CONTEXT> newBuilder(
             ServiceDescriptor grpcServiceDescriptor, REACT_SERVICE reactService) {
         return new GrpcToReactorServerBuilder<>(grpcServiceDescriptor, reactService);
     }
 
     ServerServiceDefinition build() {
-        MethodHandlersBuilder<CONTEXT> handlersBuilder = new MethodHandlersBuilder<>(reactorService, serviceDescriptor, contextType, contextResolver);
+        MethodHandlersBuilder<CONTEXT, REACT_SERVICE> handlersBuilder = new MethodHandlersBuilder<>(reactorService, serviceDescriptor, contextType, contextResolver, reactorDetailedFallbackClass);
 
         ServerServiceDefinition.Builder builder = ServerServiceDefinition.builder(serviceDescriptor);
         handlersBuilder.getUnaryMethodHandlers().forEach(handler -> {


### PR DESCRIPTION
Spring security annotations result in cglib proxied classes. These classes do no retain enough generic type information for the grpc to reactor method handler to work with, so we pass additional class details in these cases.