### PR TITLE
Overload TaskState.Accepted in Kube integration

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -28,6 +28,11 @@ public final class TaskAttributes {
     public static final String TASK_ATTRIBUTES_AGENT_ITYPE = "agent.itype";
 
     /*
+     * Kube attributes.
+     */
+    public static final String TASK_ATTRIBUTES_POD_CREATED = "kube.podCreated";
+
+    /*
      * Task attributes.
      */
     public static final String TASK_ATTRIBUTES_TASK_INDEX = "task.index";

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/TaskStatus.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/TaskStatus.java
@@ -32,6 +32,16 @@ public class TaskStatus extends ExecutableStatus<TaskState> {
     public static final String REASON_NORMAL = "normal";
 
     /**
+     * Filled in to preserve state history continuity.
+     */
+    public static final String REASON_STATE_MISSING = "filledIn";
+
+    /**
+     * Task has a pod created for it (set in the Accepted state only).
+     */
+    public static final String REASON_POD_CREATED = "podCreated";
+
+    /**
      * Job was explicitly terminated by a user.
      */
     public static final String REASON_JOB_KILLED = "killed";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
@@ -17,11 +17,16 @@
 package com.netflix.titus.master.jobmanager.service;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.netflix.titus.api.jobmanager.model.job.ExecutableStatus;
 import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
@@ -31,13 +36,21 @@ import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.rx.ReactorExt;
 import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.master.mesos.TitusExecutorDetails;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeApiServerIntegrator;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodEvent;
 import io.kubernetes.client.models.V1ContainerState;
+import io.kubernetes.client.models.V1ContainerStateTerminated;
+import io.kubernetes.client.models.V1Pod;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
+
+import static com.netflix.titus.api.jobmanager.model.job.TaskState.Finished;
+import static com.netflix.titus.api.jobmanager.model.job.TaskState.Started;
 
 /**
  * TODO Incorporate this into {@link DefaultV3JobOperations} once Fenzo is removed.
@@ -93,43 +106,104 @@ public class KubeNotificationProcessor {
             logger.info("Pod notification, but no container info yet: {}", task.getId());
             return Mono.empty();
         }
+
         V1ContainerState containerState = event.getPod().getStatus().getContainerStatuses().get(0).getState();
         TaskState taskState = task.getStatus().getState();
+        Optional<TitusExecutorDetails> executorDetailsOpt = KubeUtil.getTitusExecutorDetails(event.getPod());
 
         logger.info("State: {}", containerState);
         if (containerState.getWaiting() != null) {
-            if (taskState == TaskState.Accepted) {
-                return updateTaskStatus(containerState, task, TaskState.Launched);
-            }
+            logger.debug("Ignoring 'waiting' state update, as task must stay in the 'Accepted' state here");
         } else if (containerState.getRunning() != null) {
             if (TaskState.isBefore(taskState, TaskState.Started)) {
-                return updateTaskStatus(containerState, task, TaskState.Started);
+                return updateTaskStatus(event.getPod(), task, TaskState.Started, executorDetailsOpt);
             }
         } else if (containerState.getTerminated() != null) {
             if (taskState != TaskState.Finished) {
-                return updateTaskStatus(containerState, task, TaskState.Finished);
+                return updateTaskStatus(event.getPod(), task, TaskState.Finished, executorDetailsOpt);
             }
         }
         return Mono.empty();
     }
 
-    private Mono<Void> updateTaskStatus(V1ContainerState containerState, Task task, TaskState newTaskState) {
+    private Mono<Void> updateTaskStatus(V1Pod pod,
+                                        Task task,
+                                        TaskState newTaskState,
+                                        Optional<TitusExecutorDetails> executorDetailsOpt) {
         return ReactorExt.toMono(v3JobOperations.updateTask(
                 task.getId(),
-                currentTask -> Optional.of(
-                        task.toBuilder()
-                                .withStatus(TaskStatus.newBuilder()
-                                        .withState(newTaskState)
-                                        .withReasonCode(TaskStatus.REASON_NORMAL)
-                                        .withReasonMessage("Kube pod notification")
-                                        .build()
-                                )
-                                .withStatusHistory(CollectionsExt.copyAndAdd(currentTask.getStatusHistory(), currentTask.getStatus()))
-                                .build()
-                ),
+                currentTask -> {
+                    TaskStatus newStatus = TaskStatus.newBuilder()
+                            .withState(newTaskState)
+                            .withReasonCode(TaskStatus.REASON_NORMAL)
+                            .withReasonMessage("Kube pod notification")
+                            .build();
+
+                    List<TaskStatus> newHistory = CollectionsExt.copyAndAdd(currentTask.getStatusHistory(), currentTask.getStatus());
+
+                    Task updatedTask = currentTask.toBuilder()
+                            .withStatus(newStatus)
+                            .withStatusHistory(newHistory)
+                            .build();
+
+
+                    Task fixedTask = fillInMissingStates(pod, updatedTask);
+                    Task taskWithPlacementData = JobManagerUtil.attachPlacementData(fixedTask, executorDetailsOpt);
+
+                    return Optional.of(taskWithPlacementData);
+                },
                 V3JobOperations.Trigger.Kube,
                 "Kube pod notification",
                 KUBE_CALL_METADATA
         ));
+    }
+
+    private Task fillInMissingStates(V1Pod pod, Task task) {
+        TaskState currentState = task.getStatus().getState();
+        if (currentState != Finished) {
+            return task;
+        }
+
+        Optional<V1ContainerStateTerminated> terminatedContainerStatusOpt = KubeUtil.findTerminatedContainerStatus(pod);
+        if (!terminatedContainerStatusOpt.isPresent()) {
+            return task;
+        }
+
+        V1ContainerStateTerminated containerStateTerminated = terminatedContainerStatusOpt.get();
+        DateTime startedAt = containerStateTerminated.getStartedAt();
+        if (startedAt == null) {
+            return task;
+        }
+
+        String taskId = task.getId();
+
+        List<TaskStatus> missingStatuses = new ArrayList<>();
+
+        TaskStatus.Builder statusTemplate = TaskStatus.newBuilder()
+                .withReasonCode(TaskStatus.REASON_STATE_MISSING)
+                .withReasonMessage("Filled in")
+                .withTimestamp(startedAt.getMillis());
+
+        Optional<TaskStatus> startInitiatedOpt = JobFunctions.findTaskStatus(task, TaskState.StartInitiated);
+        if (!startInitiatedOpt.isPresent()) {
+            logger.debug("Adding missing task status: StartInitiated for task: {}", taskId);
+            missingStatuses.add(statusTemplate.withState(TaskState.StartInitiated).build());
+        }
+        Optional<TaskStatus> startedOpt = JobFunctions.findTaskStatus(task, Started);
+        if (!startedOpt.isPresent()) {
+            logger.debug("Publishing missing task status: Started for task: {}", taskId);
+            missingStatuses.add(statusTemplate.withState(Started).build());
+        }
+
+        if (missingStatuses.isEmpty()) {
+            return task;
+        }
+
+        List<TaskStatus> newStatusHistory = new ArrayList<>(task.getStatusHistory());
+        newStatusHistory.addAll(missingStatuses);
+        newStatusHistory.sort(Comparator.comparing(ExecutableStatus::getState));
+
+        return task.toBuilder().withStatusHistory(newStatusHistory).build();
+
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodAddedEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodAddedEvent.java
@@ -16,31 +16,12 @@
 
 package com.netflix.titus.master.mesos.kubeapiserver.direct.model;
 
-import java.util.Objects;
-
 import io.kubernetes.client.models.V1Pod;
 
 public class PodAddedEvent extends PodEvent {
 
     public PodAddedEvent(V1Pod pod) {
         super(pod);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        PodAddedEvent that = (PodAddedEvent) o;
-        return Objects.equals(pod, that.pod);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(pod);
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodDeletedEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodDeletedEvent.java
@@ -41,20 +41,23 @@ public class PodDeletedEvent extends PodEvent {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        if (!super.equals(o)) {
+            return false;
+        }
         PodDeletedEvent that = (PodDeletedEvent) o;
-        return deletedFinalStateUnknown == that.deletedFinalStateUnknown &&
-                Objects.equals(pod, that.pod);
+        return deletedFinalStateUnknown == that.deletedFinalStateUnknown;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pod, deletedFinalStateUnknown);
+        return Objects.hash(super.hashCode(), deletedFinalStateUnknown);
     }
 
     @Override
     public String toString() {
         return "PodDeletedEvent{" +
-                "pod=" + pod +
+                "taskId='" + taskId + '\'' +
+                ", pod=" + pod +
                 ", deletedFinalStateUnknown=" + deletedFinalStateUnknown +
                 '}';
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodEvent.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.master.mesos.kubeapiserver.direct.model;
 
+import java.util.Objects;
+
 import io.kubernetes.client.models.V1Pod;
 
 public abstract class PodEvent {
@@ -34,6 +36,32 @@ public abstract class PodEvent {
 
     public V1Pod getPod() {
         return pod;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PodEvent podEvent = (PodEvent) o;
+        return Objects.equals(taskId, podEvent.taskId) &&
+                Objects.equals(pod, podEvent.pod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(taskId, pod);
+    }
+
+    @Override
+    public String toString() {
+        return "PodEvent{" +
+                "taskId='" + taskId + '\'' +
+                ", pod=" + pod +
+                '}';
     }
 
     public static PodAddedEvent onAdd(V1Pod pod) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodUpdatedEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodUpdatedEvent.java
@@ -41,20 +41,23 @@ public class PodUpdatedEvent extends PodEvent {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        if (!super.equals(o)) {
+            return false;
+        }
         PodUpdatedEvent that = (PodUpdatedEvent) o;
-        return Objects.equals(oldPod, that.oldPod) &&
-                Objects.equals(pod, that.pod);
+        return Objects.equals(oldPod, that.oldPod);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(oldPod, pod);
+        return Objects.hash(super.hashCode(), oldPod);
     }
 
     @Override
     public String toString() {
         return "PodUpdatedEvent{" +
-                "pod=" + pod +
+                "taskId='" + taskId + '\'' +
+                ", pod=" + pod +
                 ", oldPod=" + oldPod +
                 '}';
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/KubeSchedulerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/KubeSchedulerTest.java
@@ -58,7 +58,9 @@ public class KubeSchedulerTest {
                 .inActiveTasks((taskIdx, resubmit) -> ScenarioTemplates.triggerMesosFinishedEvent(taskIdx, resubmit, 0))
                 .advance().advance()
                 .inActiveTasks((taskIdx, resubmit) -> ScenarioTemplates.acceptTask(taskIdx, resubmit))
+                .ignoreAvailableEvents()
                 .template(ScenarioTemplates.killJob())
+                .advance()
                 .inActiveTasks((taskIdx, resubmit) -> js -> js
                         .template(ScenarioTemplates.reconcilerTaskKill(taskIdx, resubmit))
                         .expectTaskUpdatedInStore(taskIdx, resubmit, task -> assertThat(task.getStatus().getState()).isEqualTo(TaskState.Finished))


### PR DESCRIPTION
by adding `podCreated` reason code, to denote condition when Kube pod
was created for a task.

