### PR TITLE
Handle killTask failed pod phase

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -548,12 +548,10 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
                 newState = Started;
             } else if (phase.equalsIgnoreCase(SUCCEEDED)) {
                 newState = Finished;
-                if (hasDeletionTimestamp) {
-                    reasonCode = REASON_TASK_KILLED;
-                }
+                reasonCode = hasDeletionTimestamp ? REASON_TASK_KILLED : REASON_NORMAL;
             } else if (phase.equalsIgnoreCase(FAILED)) {
                 newState = Finished;
-                reasonCode = REASON_FAILED;
+                reasonCode = hasDeletionTimestamp ? REASON_TASK_KILLED : REASON_FAILED;
             } else {
                 titusRuntime.getCodeInvariants().inconsistent("Pod: %s has unknown phase mapping: %s", podName, phase);
                 return;


### PR DESCRIPTION
A pod can either have a terminal phase of Succeeded or Failed when trying to tear down the container. This PR maps the killed reason code correctly when the container is in the Failed phase.