### PR TITLE
Enable junit categories be extended

### DIFF
--- a/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/FunctionalTest.java
+++ b/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/FunctionalTest.java
@@ -17,7 +17,7 @@
 package com.netflix.titus.testkit.junit.category;
 
 /**
- * Integration tests that require external services, and cannot be run in isolation.
+ * A functional test is a {@link RemoteIntegrationTest} that is appropriate for reoccurring functional/regression testing.
  */
-public interface RemoteIntegrationTest {
+public interface FunctionalTest extends RemoteIntegrationTest {
 }

--- a/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/IntegrationNotParallelizableTest.java
+++ b/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/IntegrationNotParallelizableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,5 +19,5 @@ package com.netflix.titus.testkit.junit.category;
 /**
  * Integration tests that cannot run in parallel should include this annotation (and only this one).
  */
-public @interface IntegrationNotParallelizableTest {
+public interface IntegrationNotParallelizableTest {
 }

--- a/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/IntegrationTest.java
+++ b/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,5 +19,5 @@ package com.netflix.titus.testkit.junit.category;
 /**
  * A marker annotation for the integration tests.
  */
-public @interface IntegrationTest {
+public interface IntegrationTest {
 }

--- a/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/SmokeTest.java
+++ b/titus-common-testkit/src/main/java/com/netflix/titus/testkit/junit/category/SmokeTest.java
@@ -17,7 +17,7 @@
 package com.netflix.titus.testkit.junit.category;
 
 /**
- * Integration tests that require external services, and cannot be run in isolation.
+ * A smoke test is {@link FunctionalTest} that is appropriate for use during regular smoke testing.
  */
-public interface RemoteIntegrationTest {
+public interface SmokeTest extends FunctionalTest {
 }


### PR DESCRIPTION
Switch JUnit categories to plain interfaces from annotations to allow extending and move Smoke and Functional test categories from CMB to Titus testkit common.