### PR TITLE
allow useMavenLocal to be disabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,13 @@ plugins {
     id 'nebula.ospackage' version '8.1.0'
 }
 
+ext.useMavenLocal = project.hasProperty('useMavenLocal') ? project.getProperty('useMavenLocal').toBoolean() : false
+
 allprojects {
     apply plugin: 'nebula.dependency-lock'
     apply plugin: 'idea'
 
-    if (project.hasProperty('useMavenLocal')) {
+    if (useMavenLocal) {
         repositories {
             mavenLocal()
         }


### PR DESCRIPTION
new versions of IntelliJ only allow gradle overrides through a gradle.properties file. This will allow useMavenLocal to be overriden from the command line when a custom gradle.properties sets it to true.