### PR TITLE
reduce flakiness on OpportunisticCpuSchedulingTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           keys:
             - v2-gradle-cache
       - run:
-          command: ./gradlew testAll --parallel --no-daemon --max-workers 2 --stacktrace
+          command: ./gradlew testAll --no-daemon --max-workers 2 --stacktrace
           no_output_timeout: 20m
       - run:
           name: Save test results

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,4 +30,5 @@ nebula.features.publishing.immutableSnapshotsEnabled=true
 
 # JFrog does not support sha512 checksums
 # See: https://github.com/gradle/gradle/issues/11308
+# and: https://www.jfrog.com/jira/browse/RTFACT-21426
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/OpportunisticCpuSchedulingTest.java
@@ -98,7 +98,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         Instant expiresAt = Instant.now().plus(Duration.ofSeconds(45));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 4);
         instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.any(instance -> instance.addOpportunisticCpus(availability))
+                group -> group.all(instance -> instance.addOpportunisticCpus(availability))
         );
 
         // job runtime is 12s, but opportunistic cpus are available for 10s
@@ -123,14 +123,16 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         String allocationId = UUID.randomUUID().toString();
         Instant expiresAt = Instant.now().plus(Duration.ofHours(6));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 4);
-        instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.any(instance -> instance.addOpportunisticCpus(availability))
+        titusStackResource.getMaster().getSimulatedCloud().updateAgentGroupCapacity("flex1", 1, 1, 1);
+        instanceGroupsScenarioBuilder.apply("flex1", group -> group
+                .awaitDesiredSize(1)
+                .awaitDesiredInstanceCount() // ensure the agent is scaled down
+                .all(instance -> instance.addOpportunisticCpus(availability))
         );
 
         JobDescriptor<BatchJobExt> jobDescriptor = BATCH_JOB_WITH_RUNTIME_PREDICTION.but(j ->
                 j.getContainer().but(c -> c.getContainerResources().toBuilder().withCpu(2))
         );
-
         jobsScenarioBuilder.schedule(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
                 .template(launchJob())
                 .allTasks(taskScenarioBuilder -> taskScenarioBuilder
@@ -188,7 +190,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         Instant expiresAt = Instant.now().minus(Duration.ofMillis(1));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 10);
         instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.any(instance -> instance.addOpportunisticCpus(availability))
+                group -> group.all(instance -> instance.addOpportunisticCpus(availability))
         );
 
         JobDescriptor<BatchJobExt> jobDescriptor = BATCH_JOB_WITH_RUNTIME_PREDICTION.but(j ->
@@ -212,7 +214,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         Instant expiresAt = Instant.now().plus(Duration.ofHours(6));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 2);
         instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.any(instance -> instance.addOpportunisticCpus(availability))
+                group -> group.all(instance -> instance.addOpportunisticCpus(availability))
         );
 
         JobDescriptor<BatchJobExt> jobDescriptor = BATCH_JOB_WITH_RUNTIME_PREDICTION.but(j ->
@@ -239,7 +241,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         instanceGroupsScenarioBuilder.apply("flex1", group -> group
                 .awaitDesiredSize(1)
                 .awaitDesiredInstanceCount() // ensure the agent is scaled down
-                .any(instance -> instance.addOpportunisticCpus(availability))
+                .all(instance -> instance.addOpportunisticCpus(availability))
         );
 
         JobDescriptor<BatchJobExt> regularJob = oneTaskBatchJobDescriptor().but(
@@ -293,7 +295,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         Instant expiresAt = Instant.now().plus(Duration.ofHours(6));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 4);
         instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.any(instance -> instance.addOpportunisticCpus(availability))
+                group -> group.all(instance -> instance.addOpportunisticCpus(availability))
         );
 
         JobDescriptor<BatchJobExt> opportunisticJob = BATCH_JOB_WITH_RUNTIME_PREDICTION.but(j ->
@@ -328,7 +330,7 @@ public class OpportunisticCpuSchedulingTest extends BaseIntegrationTest {
         Instant expiresAt = Instant.now().plus(Duration.ofHours(6));
         OpportunisticCpuAvailability availability = new OpportunisticCpuAvailability(allocationId, expiresAt, 4);
         instanceGroupsScenarioBuilder.apply("flex1",
-                group -> group.any(instance -> instance.addOpportunisticCpus(availability))
+                group -> group.all(instance -> instance.addOpportunisticCpus(availability))
         );
 
         JobDescriptor<BatchJobExt> jobDescriptor = BATCH_JOB_WITH_RUNTIME_PREDICTION.but(j ->

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/InstanceGroupScenarioBuilder.java
@@ -89,6 +89,15 @@ public class InstanceGroupScenarioBuilder {
         return instances.containsKey(instanceId);
     }
 
+    public InstanceGroupScenarioBuilder all(Consumer<InstanceScenarioBuilder> transformer) {
+        checkIsKnown();
+        Preconditions.checkElementIndex(0, instances.values().size(), "At least one agent instance available");
+        instances.values().forEach(instance ->
+                transformer.accept(new InstanceScenarioBuilder(titusStackResource, instance))
+        );
+        return this;
+    }
+
     public InstanceGroupScenarioBuilder any(Consumer<InstanceScenarioBuilder> transformer) {
         checkIsKnown();
         ArrayList<AgentInstance> instancesList = new ArrayList<>(instances.values());


### PR DESCRIPTION
The testkit will periodically revoke and recreate mesos offers. That caused a race where sometimes agents with opportunistic windows had their offers revoked and tasks were wrongly scheduled on agents that didn't have a pre-configured opportunistic availability.