### PR TITLE
Start publishing snapshot builds from master

### DIFF
--- a/scripts/ci/travis/build-release
+++ b/scripts/ci/travis/build-release
@@ -9,7 +9,7 @@ elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   ./gradlew build --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -Prelease.travisci=true build --stacktrace
+  ./gradlew -Prelease.travisci=true build immutableSnapshot --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in


### PR DESCRIPTION
Anything that gets merged to `master` gets published as a snapshot. Version strings will look like `0.1.1-snapshot.20200303225245`. `0.1.1` comes from the last semver git tag on the branch.