### PR TITLE
always use the first InternalIP address as the host ip

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -452,7 +452,7 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         V1ObjectMeta metadata = node.getMetadata();
         String nodeIp = node.getStatus().getAddresses().stream()
                 .filter(a -> a.getType().equalsIgnoreCase(INTERNAL_IP) && NetworkExt.isIpV4(a.getAddress()))
-                .findAny()
+                .findFirst()
                 .map(V1NodeAddress::getAddress)
                 .orElse("UnknownIpAddress");
 


### PR DESCRIPTION
### Description of the Change
* Always use the first ipv4 InternalIP address as the host ip.