### PR TITLE
Fix flaky integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,13 @@ matrix:
   fast_finish: true
   include:
     - name: "Unit Tests"
-      env: TITUS_INTEGRATION_TEST=false
-    - name: "Integration Tests"
-      env: TITUS_INTEGRATION_TEST=true
+      env: TITUS_TEST_GROUP=unit
+    - name: "Integration Tests (exclude master)"
+      env: TITUS_TEST_GROUP=integrationExcludeMaster
+    - name: "Integration Tests (only master)"
+      env: TITUS_TEST_GROUP=integrationOnlyMaster
+    - name: "Integration Tests (not parallelizable)"
+      env: TITUS_TEST_GROUP=integrationNotParallelizable
     - name: "Docker Compose Integration"
       sudo: required
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,12 @@ matrix:
       env: TITUS_TEST_GROUP=unit
     - name: "Integration Tests (exclude master)"
       env: TITUS_TEST_GROUP=integrationExcludeMaster
-    - name: "Integration Tests (only master)"
-      env: TITUS_TEST_GROUP=integrationOnlyMaster
+    - name: "Integration Tests (only master 1)"
+      env: TITUS_TEST_GROUP=integrationOnlyMaster1
+    - name: "Integration Tests (only master 2)"
+      env: TITUS_TEST_GROUP=integrationOnlyMaster2
+    - name: "Integration Tests (only master 3)"
+      env: TITUS_TEST_GROUP=integrationOnlyMaster3
     - name: "Integration Tests (not parallelizable)"
       env: TITUS_TEST_GROUP=integrationNotParallelizable
     - name: "Docker Compose Integration"

--- a/build.gradle
+++ b/build.gradle
@@ -190,8 +190,14 @@ subprojects {
 
         if( "excludeMaster".equalsIgnoreCase(integrationTestScope)) {
             exclude 'com/netflix/titus/master/integration/**/*'
-        } else if( "onlyMaster".equalsIgnoreCase(integrationTestScope)) {
+        } else if( "onlyMaster1".equalsIgnoreCase(integrationTestScope)) {
             include 'com/netflix/titus/master/integration/**/*'
+            exclude 'com/netflix/titus/master/integration/v3/job/**/*'
+        } else if( "onlyMaster2".equalsIgnoreCase(integrationTestScope)) {
+            include 'com/netflix/titus/master/integration/v3/job/**/*'
+            exclude 'com/netflix/titus/master/integration/v3/job/query/*'
+        } else if( "onlyMaster3".equalsIgnoreCase(integrationTestScope)) {
+            include 'com/netflix/titus/master/integration/v3/job/query/*'
         }
 
         useJUnit {

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
 }
 
 ext.useMavenLocal = project.hasProperty('useMavenLocal') ? project.getProperty('useMavenLocal').toBoolean() : false
+ext.integrationTestScope = project.hasProperty('integrationTestScope') ? project.getProperty('integrationTestScope') : ""
 
 allprojects {
     apply plugin: 'nebula.dependency-lock'
@@ -186,6 +187,12 @@ subprojects {
     task integrationTest(type: Test) {
         maxParallelForks = processorTarget
         shouldRunAfter test
+
+        if( "excludeMaster".equalsIgnoreCase(integrationTestScope)) {
+            exclude 'com/netflix/titus/master/integration/**/*'
+        } else if( "onlyMaster".equalsIgnoreCase(integrationTestScope)) {
+            include 'com/netflix/titus/master/integration/**/*'
+        }
 
         useJUnit {
             includeCategories 'com.netflix.titus.testkit.junit.category.IntegrationTest'

--- a/scripts/ci/travis/build-release
+++ b/scripts/ci/travis/build-release
@@ -1,9 +1,15 @@
 #!/bin/bash
 # Used as the script step on Travis
 
-if [ "$TITUS_INTEGRATION_TEST" == "true" ]; then
+if [ "$TITUS_TEST_GROUP" == "integrationExcludeMaster" ]; then
   echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
-  ./gradlew testAll --parallel --stacktrace
+  ./gradlew -PintegrationTestScope=excludeMaster integrationTest --parallel --stacktrace
+elif [ "$TITUS_TEST_GROUP" == "integrationOnlyMaster" ]; then
+  echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
+  ./gradlew -PintegrationTestScope=onlyMaster integrationTest --parallel --stacktrace
+elif [ "$TITUS_TEST_GROUP" == "integrationNotParallelizable" ]; then
+  echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
+  ./gradlew integrationNotParallelizableTest --parallel --stacktrace
 elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build --stacktrace

--- a/scripts/ci/travis/build-release
+++ b/scripts/ci/travis/build-release
@@ -4,9 +4,15 @@
 if [ "$TITUS_TEST_GROUP" == "integrationExcludeMaster" ]; then
   echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
   ./gradlew -PintegrationTestScope=excludeMaster integrationTest --parallel --stacktrace
-elif [ "$TITUS_TEST_GROUP" == "integrationOnlyMaster" ]; then
+elif [ "$TITUS_TEST_GROUP" == "integrationOnlyMaster1" ]; then
   echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
-  ./gradlew -PintegrationTestScope=onlyMaster integrationTest --parallel --stacktrace
+  ./gradlew -PintegrationTestScope=onlyMaster1 integrationTest --parallel --stacktrace
+elif [ "$TITUS_TEST_GROUP" == "integrationOnlyMaster2" ]; then
+  echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
+  ./gradlew -PintegrationTestScope=onlyMaster2 integrationTest --parallel --stacktrace
+elif [ "$TITUS_TEST_GROUP" == "integrationOnlyMaster3" ]; then
+  echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
+  ./gradlew -PintegrationTestScope=onlyMaster3 integrationTest --parallel --stacktrace
 elif [ "$TITUS_TEST_GROUP" == "integrationNotParallelizable" ]; then
   echo -e "Running integration tests (PR=$TRAVIS_PULL_REQUEST) => Branch [$TRAVIS_BRANCH]"
   ./gradlew integrationNotParallelizableTest --parallel --stacktrace

--- a/scripts/hlb/titus.hlb.template
+++ b/scripts/hlb/titus.hlb.template
@@ -40,7 +40,7 @@ fs gradle(fs src, string tasks) {
 }
 
 fs titusBuild() {
-    gradle source "testAll"
+    gradle source "--continue clean testAll"
 }
 
 fs homeMetatron() {

--- a/thlb.sh
+++ b/thlb.sh
@@ -2,7 +2,7 @@
 
 PROJECT_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 HLB_SCRIPT=${PROJECT_ROOT}/build/titus.hlb
-mkdir -p ${PROJECT_ROOT}/build && rm ${HLB_SCRIPT}
+mkdir -p ${PROJECT_ROOT}/build && rm -f ${HLB_SCRIPT}
 
 # HLB does not support environment variables yet (see https://github.com/openllb/hlb/issues/2)
 sed -e "s/@{{USER}}/${USER}/g" ${PROJECT_ROOT}/scripts/hlb/titus.hlb.template > ${HLB_SCRIPT}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/BaseIntegrationTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/BaseIntegrationTest.java
@@ -25,6 +25,8 @@ import org.junit.experimental.categories.Category;
 @Category(IntegrationTest.class)
 public class BaseIntegrationTest {
 
+    protected static final long SHORT_TIMEOUT_MS = 5_000;
+
     protected static final long TEST_TIMEOUT_MS = 30_000;
 
     protected static final long LONG_TEST_TIMEOUT_MS = 60_000;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/BaseIntegrationTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/BaseIntegrationTest.java
@@ -16,7 +16,10 @@
 
 package com.netflix.titus.master.integration;
 
+import java.security.Permission;
+
 import com.netflix.titus.testkit.junit.category.IntegrationTest;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 @Category(IntegrationTest.class)
@@ -25,4 +28,31 @@ public class BaseIntegrationTest {
     protected static final long TEST_TIMEOUT_MS = 30_000;
 
     protected static final long LONG_TEST_TIMEOUT_MS = 60_000;
+
+    static class PreventSystemExitSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission perm) {
+        }
+
+        @Override
+        public void checkPermission(Permission perm, Object context) {
+        }
+
+        @Override
+        public void checkExit(int status) {
+            if (status != 0) {
+                String message = "System exit requested with error " + status;
+                throw new IllegalStateException(message);
+            }
+        }
+    }
+
+    private static final SecurityManager securityManager = new PreventSystemExitSecurityManager();
+
+    @BeforeClass
+    public static void setSecurityManager() {
+        if (System.getSecurityManager() != securityManager) {
+            System.setSecurityManager(securityManager);
+        }
+    }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v2/CapacityGuaranteeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v2/CapacityGuaranteeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration;
+package com.netflix.titus.master.integration.v2;
 
 import com.netflix.titus.api.agent.model.InstanceGroupLifecycleState;
 import com.netflix.titus.api.jobmanager.model.job.ContainerResources;
@@ -25,6 +25,7 @@ import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.aws.AwsInstanceType;
+import com.netflix.titus.master.integration.BaseIntegrationTest;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
 import com.netflix.titus.master.integration.v3.scenario.JobsScenarioBuilder;
 import com.netflix.titus.testkit.client.TitusMasterClient;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v2/CapacityManagementTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v2/CapacityManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration;
+package com.netflix.titus.master.integration.v2;
 
 import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.master.integration.BaseIntegrationTest;
 import com.netflix.titus.testkit.client.TitusMasterClient;
 import com.netflix.titus.testkit.data.core.ApplicationSlaSample;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedClouds;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/HealthTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/HealthTest.java
@@ -48,7 +48,7 @@ public class HealthTest extends BaseIntegrationTest {
     @Rule
     public final RuleChain ruleChain = RuleChain.outerRule(titusStackResource);
 
-    @Test(timeout = 30_000L)
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void healthStatus() throws Exception {
         TestStreamObserver<HealthCheckResponse> testStreamObserver = new TestStreamObserver<>();
         titusStackResource.getOperations().getHealthClient().check(HealthCheckRequest.newBuilder().build(), testStreamObserver);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/agent/ResourceSchedulingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/agent/ResourceSchedulingTest.java
@@ -56,9 +56,6 @@ public class ResourceSchedulingTest extends BaseIntegrationTest {
                             new SimulatedCloud().createAgentInstanceGroups(
                                     new SimulatedAgentGroupDescriptor("flex1", AwsInstanceType.M5_Metal.name(), 0, 1, 1, 2)
                             ))
-                            .toBuilder()
-                            .withProperty("titus.scheduler.globalTaskLaunchingConstraintEvaluatorEnabled", "false")
-                            .build()
             )
             .withDefaultGateway()
             .build()

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/appscale/AutoScalingGrpcTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/appscale/AutoScalingGrpcTest.java
@@ -70,7 +70,7 @@ public class AutoScalingGrpcTest extends BaseIntegrationTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testGetPolicyById() throws Exception {
         String jobId = "Titus-123";
 
@@ -97,7 +97,7 @@ public class AutoScalingGrpcTest extends BaseIntegrationTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testDeletePolicyById() throws Exception {
         // Put a policy
         String jobId = "Titus-1";
@@ -136,7 +136,7 @@ public class AutoScalingGrpcTest extends BaseIntegrationTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testGetNonexistentJob() throws Exception {
         String jobId = "Titus-0";
         JobId getPolicyRequest = JobId.newBuilder().setId(jobId).build();
@@ -153,7 +153,7 @@ public class AutoScalingGrpcTest extends BaseIntegrationTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     @Ignore // GRPC request/response semantics requires that a value is always returned
     public void testGetNonexistentPolicy() throws Exception {
         ScalingPolicyID scalingPolicyID = ScalingPolicyID.newBuilder().setId("deadbeef").build();
@@ -170,7 +170,7 @@ public class AutoScalingGrpcTest extends BaseIntegrationTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void getAllPolicies() throws Exception {
         Set<ScalingPolicyID> policyIDSet = new HashSet<>();
         int numJobs = 2;
@@ -197,7 +197,7 @@ public class AutoScalingGrpcTest extends BaseIntegrationTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testUpdatePolicyConfigurationForTargetTracking() throws Exception {
         String jobId = "Titus-123";
         PutPolicyRequest putPolicyRequest = AutoScalingTestUtils.generatePutPolicyRequest(jobId, PolicyType.TargetTrackingScaling);
@@ -240,7 +240,7 @@ public class AutoScalingGrpcTest extends BaseIntegrationTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testUpdatePolicyConfigurationForStepScaling() throws Exception {
         String jobId = "Titus-123";
         PutPolicyRequest putPolicyRequest = AutoScalingTestUtils.generatePutPolicyRequest(jobId, PolicyType.StepScaling);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
@@ -118,6 +118,9 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
      */
     private static final String PRE_CREATED_JOBS_LABEL = "precreatedJob";
 
+    private static final JobDescriptor<BatchJobExt> BATCH_JOB_TEMPLATE = oneTaskBatchJobDescriptor();
+    private static final JobDescriptor<ServiceJobExt> SERVICE_JOB_TEMPLATE = oneTaskServiceJobDescriptor();
+
     private static JobManagementServiceGrpc.JobManagementServiceBlockingStub client;
 
     private static final List<String> batchJobsWithCreatedTasks = new ArrayList<>();
@@ -133,12 +136,12 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
         client = titusStackResource.getGateway().getV3BlockingGrpcClient();
 
         // Jobs with launched tasks
-        JobDescriptor<BatchJobExt> batchJobDescriptor = oneTaskBatchJobDescriptor().toBuilder()
+        JobDescriptor<BatchJobExt> batchJobDescriptor = BATCH_JOB_TEMPLATE.toBuilder()
                 .withOwner(Owner.newBuilder().withTeamEmail(BATCH_OWNER).build())
                 .withApplicationName(BATCH_APPLICATION)
                 .withCapacityGroup(BATCH_CAPACITY_GROUP)
                 .withJobGroupInfo(BATCH_JOB_GROUP_INFO)
-                .withContainer(oneTaskBatchJobDescriptor().getContainer().toBuilder()
+                .withContainer(BATCH_JOB_TEMPLATE.getContainer().toBuilder()
                         .withImage(Image.newBuilder().withName(BATCH_IMAGE_NAME).withTag(BATCH_IMAGE_TAG).build())
                         .build()
                 )
@@ -153,12 +156,12 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
             String taskId = jobsScenarioBuilder.takeJob(jobId).getTaskByIndex(0).getTask().getId();
             batchTasks.add(taskId);
         });
-        JobDescriptor<ServiceJobExt> serviceJobDescriptor = oneTaskServiceJobDescriptor().toBuilder()
+        JobDescriptor<ServiceJobExt> serviceJobDescriptor = SERVICE_JOB_TEMPLATE.toBuilder()
                 .withOwner(Owner.newBuilder().withTeamEmail(SERVICE_OWNER).build())
                 .withApplicationName(SERVICE_APPLICATION)
                 .withCapacityGroup(SERVICE_CAPACITY_GROUP)
                 .withJobGroupInfo(SERVICE_JOB_GROUP_INFO)
-                .withContainer(oneTaskServiceJobDescriptor().getContainer().toBuilder()
+                .withContainer(SERVICE_JOB_TEMPLATE.getContainer().toBuilder()
                         .withImage(Image.newBuilder().withName(SERVICE_IMAGE_NAME).withTag(SERVICE_IMAGE_TAG).build())
                         .build()
                 )
@@ -176,7 +179,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
 
         // Finished job with 5 tasks
         int numberOfTasks = 5;
-        JobDescriptor<BatchJobExt> jobDescriptor = oneTaskBatchJobDescriptor()
+        JobDescriptor<BatchJobExt> jobDescriptor = BATCH_JOB_TEMPLATE
                 .but(jd -> jd.getExtensions().toBuilder().withSize(numberOfTasks).build());
 
         jobsScenarioBuilder.schedule(jobDescriptor, 1, jobScenarioBuilder -> jobScenarioBuilder
@@ -308,7 +311,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
     public void testSearchByTaskStateV3() {
         Function<Function<JobScenarioBuilder, JobScenarioBuilder>, String> jobSubmitter = template ->
                 jobsScenarioBuilder.scheduleAndReturnJob(
-                        oneTaskBatchJobDescriptor().toBuilder().withApplicationName("testSearchByTaskStateV3").build(),
+                        BATCH_JOB_TEMPLATE.toBuilder().withApplicationName("testSearchByTaskStateV3").build(),
                         jobScenarioBuilder -> jobScenarioBuilder.template(template)
                 ).getId();
 
@@ -320,6 +323,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
         testSearchByTaskStateV3("Launched", jobLaunchedId, jobsScenarioBuilder.takeTaskId(jobLaunchedId, 0));
         testSearchByTaskStateV3("StartInitiated", startInitiatedJobId, jobsScenarioBuilder.takeTaskId(startInitiatedJobId, 0));
         testSearchByTaskStateV3("Started", startedJobId, jobsScenarioBuilder.takeTaskId(startedJobId, 0));
+
         testSearchByTaskStateV3("KillInitiated", killInitiatedJobId, jobsScenarioBuilder.takeTaskId(killInitiatedJobId, 0));
     }
 
@@ -348,7 +352,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
 
     @Test(timeout = 30_000)
     public void testSearchByTaskReasonInFinishedJobV3() {
-        JobDescriptor<BatchJobExt> jobDescriptor = JobFunctions.changeBatchJobSize(oneTaskBatchJobDescriptor(), 2);
+        JobDescriptor<BatchJobExt> jobDescriptor = JobFunctions.changeBatchJobSize(BATCH_JOB_TEMPLATE, 2);
 
         String jobId = jobsScenarioBuilder.scheduleAndReturnJob(jobDescriptor, jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.launchJob())
@@ -448,7 +452,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
     public void testSearchByJobDescriptorAttributesV3() {
         List<String> jobIds = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
-            JobDescriptor<BatchJobExt> jobDescriptor = oneTaskBatchJobDescriptor().toBuilder()
+            JobDescriptor<BatchJobExt> jobDescriptor = BATCH_JOB_TEMPLATE.toBuilder()
                     .withApplicationName("testSearchByJobDescriptorAttributesV3")
                     .withAttributes(CollectionsExt.asMap(
                             String.format("job%d.key1", i), "value1",
@@ -530,7 +534,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
         String[] expectedTaskIds = new String[numberOfJobs];
         for (int i = 0; i < numberOfJobs; i++) {
             String jobId = jobsScenarioBuilder.scheduleAndReturnJob(
-                    oneTaskBatchJobDescriptor().toBuilder().withApplicationName("testSearchByCellV3").build(),
+                    BATCH_JOB_TEMPLATE.toBuilder().withApplicationName("testSearchByCellV3").build(),
                     jobScenarioBuilder -> jobScenarioBuilder.template(ScenarioTemplates.launchJob())
             ).getId();
             expectedJobIds[i] = jobId;
@@ -661,7 +665,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
 
     @Test(timeout = 30_000)
     public void testFieldsFiltering() {
-        JobDescriptor<BatchJobExt> jobDescriptor = oneTaskBatchJobDescriptor().toBuilder()
+        JobDescriptor<BatchJobExt> jobDescriptor = BATCH_JOB_TEMPLATE.toBuilder()
                 .withApplicationName("testFieldsFiltering")
                 .withAttributes(ImmutableMap.of("keyA", "valueA", "keyB", "valueB"))
                 .build();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCriteriaQueryTest.java
@@ -82,7 +82,6 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
             EmbeddedTitusCell.aTitusCell()
                     .withMaster(EmbeddedTitusMasters.basicMaster(SimulatedClouds.basicCloudWithLargeInstances(20)).toBuilder()
                             .withCellName("embeddedCell")
-                            .withProperty("titus.scheduler.globalTaskLaunchingConstraintEvaluatorEnabled", "false")
                             // Set to very high value as we do not want to expire it.
                             .withProperty("titusMaster.jobManager.taskInLaunchedStateTimeoutMs", "30000000")
                             .withProperty("titusMaster.jobManager.batchTaskInStartInitiatedStateTimeoutMs", "30000000")

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCustomConfigurationValidatorTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobCustomConfigurationValidatorTest.java
@@ -67,7 +67,7 @@ public class JobCustomConfigurationValidatorTest extends BaseIntegrationTest {
         client = titusStackResource.getGateway().getV3BlockingGrpcClient();
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testCustomBatchJobSizeValidation() {
         JobDescriptor<BatchJobExt> jobDescriptor = JobFunctions.changeBatchJobSize(
                 oneTaskBatchJobDescriptor().toBuilder()
@@ -87,7 +87,7 @@ public class JobCustomConfigurationValidatorTest extends BaseIntegrationTest {
         }
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testCustomServiceJobSizeValidation() {
         JobDescriptor<ServiceJobExt> jobDescriptor = JobFunctions.changeServiceJobCapacity(
                 oneTaskServiceJobDescriptor().toBuilder()

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobFederationTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobFederationTest.java
@@ -81,7 +81,7 @@ public class JobFederationTest extends BaseIntegrationTest {
         asyncClient.observeJobs(ObserveJobsQuery.newBuilder().build(), eventStreamObserver);
     }
 
-    @Test
+    @Test(timeout = LONG_TEST_TIMEOUT_MS)
     public void testJobCreateRouting() {
         Map<String, Job> jobs = new ConcurrentHashMap<>();
         Map<String, Task> tasks = new ConcurrentHashMap<>();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobLoadSheddingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobLoadSheddingTest.java
@@ -57,7 +57,7 @@ public class JobLoadSheddingTest extends BaseIntegrationTest {
         client = titusMasterResource.getMaster().getV3BlockingGrpcClient();
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testMasterRateLimits() {
         int counter = 0;
         try {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobObserveTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobObserveTest.java
@@ -66,7 +66,7 @@ import static org.junit.Assert.fail;
 @Category(IntegrationTest.class)
 public class JobObserveTest extends BaseIntegrationTest {
 
-    private final TitusStackResource titusStackResource = new TitusStackResource(EmbeddedTitusCells.basicCell(2));
+    private final TitusStackResource titusStackResource = new TitusStackResource(EmbeddedTitusCells.basicCell(4));
 
     private final InstanceGroupsScenarioBuilder instanceGroupsScenarioBuilder = new InstanceGroupsScenarioBuilder(titusStackResource);
 
@@ -80,7 +80,7 @@ public class JobObserveTest extends BaseIntegrationTest {
         instanceGroupsScenarioBuilder.synchronizeWithCloud().template(InstanceGroupScenarioTemplates.basicCloudActivation());
     }
 
-    @Test(timeout = TEST_TIMEOUT_MS)
+    @Test(timeout = LONG_TEST_TIMEOUT_MS)
     public void observeJobs() throws Exception {
         TestStreamObserver<JobChangeNotification> eventObserver = observe(ObserveJobsQuery.newBuilder().build());
 
@@ -111,7 +111,7 @@ public class JobObserveTest extends BaseIntegrationTest {
                 .forEach(n -> CellAssertions.assertCellInfo(n.getJobUpdate().getJob(), EmbeddedTitusMaster.CELL_NAME));
     }
 
-    @Test(timeout = TEST_TIMEOUT_MS)
+    @Test(timeout = LONG_TEST_TIMEOUT_MS)
     public void observeSnapshotWithFilter() throws Exception {
         startAll(
                 batchJobDescriptors().getValue().toBuilder()
@@ -145,7 +145,7 @@ public class JobObserveTest extends BaseIntegrationTest {
         );
     }
 
-    @Test(timeout = TEST_TIMEOUT_MS)
+    @Test(timeout = LONG_TEST_TIMEOUT_MS)
     public void observeByJobDescriptor() throws Exception {
         List<TestStreamObserver<JobChangeNotification>> observers = observeAll(
                 ObserveJobsQuery.newBuilder()
@@ -238,7 +238,7 @@ public class JobObserveTest extends BaseIntegrationTest {
         );
     }
 
-    @Test(timeout = TEST_TIMEOUT_MS)
+    @Test(timeout = LONG_TEST_TIMEOUT_MS)
     public void observeByStates() throws Exception {
         List<TestStreamObserver<JobChangeNotification>> observers = observeAll(
                 ObserveJobsQuery.newBuilder()

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobObserveTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobObserveTest.java
@@ -44,7 +44,7 @@ import com.netflix.titus.master.integration.v3.scenario.ScenarioTemplates;
 import com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCells;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMaster;
 import com.netflix.titus.testkit.grpc.TestStreamObserver;
-import com.netflix.titus.testkit.junit.category.IntegrationTest;
+import com.netflix.titus.testkit.junit.category.IntegrationNotParallelizableTest;
 import com.netflix.titus.testkit.junit.master.TitusStackResource;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +63,7 @@ import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.service
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-@Category(IntegrationTest.class)
+@Category(IntegrationNotParallelizableTest.class)
 public class JobObserveTest extends BaseIntegrationTest {
 
     private final TitusStackResource titusStackResource = new TitusStackResource(EmbeddedTitusCells.basicCell(4));

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
@@ -92,7 +92,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
     /**
      * Verifies that a digest value is properly added to a job descriptor that is using tag.
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobDigestResolution() {
         when(registryClient.getImageDigest(anyString(), anyString())).thenReturn(Mono.just(digest));
 
@@ -115,7 +115,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
     /**
      * Verifies that a NOT_FOUND image produces an invalid argument exception.
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testNonexistentTag() {
         when(registryClient.getImageDigest(anyString(), anyString()))
                 .thenReturn(Mono.error(TitusRegistryException.imageNotFound(repo, tag)));
@@ -142,7 +142,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
     /**
      * Verifies that non-NOT_FOUND errors are suppressed and the original job descriptor is not modified.
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testSuppressedInternalError() {
         when(registryClient.getImageDigest(anyString(), anyString()))
                 .thenReturn(

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
@@ -60,7 +60,7 @@ public class JobScalingTest extends BaseIntegrationTest {
         instanceGroupsScenarioBuilder.synchronizeWithCloud().template(InstanceGroupScenarioTemplates.basicCloudActivation());
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testScaleUpAndDownServiceJob() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
@@ -71,7 +71,7 @@ public class JobScalingTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testScaleUpAndDownServiceJobDesired() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
@@ -82,7 +82,7 @@ public class JobScalingTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testScaleUpAndDownServiceJobMin() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
@@ -92,7 +92,7 @@ public class JobScalingTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testScaleUpAndDownServiceJobMax() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
@@ -102,7 +102,7 @@ public class JobScalingTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testScaleUpAndDownServiceJobDesiredInvalid() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
@@ -112,7 +112,7 @@ public class JobScalingTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTerminateAndShrink() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testTerminateAndShrink"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
@@ -129,7 +129,7 @@ public class JobScalingTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTerminateAndShrinkNotAllowedIfDesiredToLowAndCheckEnabled() {
         try {
             jobsScenarioBuilder.schedule(newJob("testTerminateAndShrinkNotAllowed"), jobScenarioBuilder -> jobScenarioBuilder

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSubmitAndControlNegativeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSubmitAndControlNegativeTest.java
@@ -85,7 +85,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         client = titusStackResource.getGateway().getV3BlockingGrpcClient();
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithNoOwner() throws Exception {
         submitBadJob(
                 client,
@@ -94,13 +94,13 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithNoApplicationName() throws Exception {
         submitBadJob(client, BATCH_JOB_DESCR_BUILDER.setApplicationName("").build(), "applicationName");
         submitBadJob(client, BATCH_JOB_DESCR_BUILDER.setApplicationName("   ").build(), "applicationName");
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithInvalidComputeResources() throws Exception {
         ContainerResources badContainer = ContainerResources.newBuilder()
                 .setGpu(-1)
@@ -115,7 +115,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
     /**
      * TODO GPU is not limited today. We should add GPU to {@link ResourceDimension} model.
      */
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithExcessiveComputeResources() throws Exception {
         ContainerResources badContainer = ContainerResources.newBuilder()
                 .setCpu(100)
@@ -135,7 +135,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithInvalidEfsMounts() throws Exception {
         ContainerResources badEfs = ContainerResources.newBuilder()
                 .addEfsMounts(ContainerResources.EfsMount.getDefaultInstance())
@@ -148,7 +148,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithBadSecurityProfile() throws Exception {
         SecurityProfile securityProfile = SecurityProfile.newBuilder()
                 .addSecurityGroups("not-good-security-group")
@@ -161,7 +161,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithoutImage() throws Exception {
         submitBadJob(
                 client,
@@ -171,12 +171,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
-    @Ignore("Until we support digests")
-    public void testJobWithBothTagAndDigest() throws Exception {
-    }
-
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithInvalidNameAndTag() throws Exception {
         Image badImage = Image.newBuilder().setName("????????").setTag("############").build();
         submitBadJob(
@@ -187,7 +182,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testInvalidSoftAndHardConstraints() throws Exception {
         submitBadJob(
                 client,
@@ -200,7 +195,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testOverlappingSoftAndHardConstraints() throws Exception {
         submitBadJob(
                 client,
@@ -212,7 +207,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testBatchJobWithInvalidSize() throws Exception {
         submitBadJob(
                 client,
@@ -221,7 +216,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTooLargeBatchJob() throws Exception {
         submitBadJob(
                 client,
@@ -230,7 +225,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testBatchJobWithTooLowRuntimeLimit() throws Exception {
         submitBadJob(
                 client,
@@ -239,7 +234,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTooLargeBatchJobRuntimeLimit() throws Exception {
         submitBadJob(
                 client,
@@ -248,7 +243,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testServiceJobInvalidCapacity() throws Exception {
         Capacity badCapacity = Capacity.newBuilder().setMin(-2).setDesired(-3).setMax(-4).build();
         submitBadJob(
@@ -261,7 +256,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTooLargeServiceJob() throws Exception {
         Capacity badCapacity = Capacity.newBuilder().setMin(1).setDesired(100).setMax(10_001).build();
         submitBadJob(
@@ -271,7 +266,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithInvalidImmediateRetryPolicy() throws Exception {
         RetryPolicy badRetryPolicy = RetryPolicy.newBuilder().setImmediate(
                 RetryPolicy.Immediate.newBuilder().setRetries(-1)
@@ -283,7 +278,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithInvalidDelayedRetryPolicy() throws Exception {
         RetryPolicy badRetryPolicy = RetryPolicy.newBuilder().setDelayed(
                 RetryPolicy.Delayed.newBuilder().setRetries(-1).setDelayMs(-1)
@@ -296,7 +291,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobWithInvalidExpBackoffRetryPolicy() throws Exception {
         RetryPolicy badRetryPolicy = RetryPolicy.newBuilder().setExponentialBackOff(
                 RetryPolicy.ExponentialBackOff.newBuilder().setRetries(-1).setInitialDelayMs(-1).setMaxDelayIntervalMs(-1)
@@ -310,7 +305,7 @@ public class JobSubmitAndControlNegativeTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testSubmitJobsWithIdenticalJobGroupIdentity() throws Exception {
         JobDescriptor jobDescriptor = toGrpcJobDescriptor(JobDescriptorGenerator.oneTaskServiceJobDescriptor()
                 .but(jd -> jd.toBuilder().withApplicationName("v3App").build())

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
@@ -25,7 +25,6 @@ import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.master.integration.BaseIntegrationTest;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTemplates;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
-import com.netflix.titus.runtime.endpoint.admission.AdmissionSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.admission.AggregatingValidator;
 import com.netflix.titus.runtime.endpoint.admission.FailJobValidator;
@@ -113,18 +112,6 @@ public class JobValidatorNegativeTest extends BaseIntegrationTest {
                         .build())
                 .withDefaultGateway()
                 .withJobValidator(validator)
-                .build());
-    }
-
-    private static TitusStackResource getTitusStackResource(AdmissionSanitizer<JobDescriptor> jobSanitizer) {
-        SimulatedCloud simulatedCloud = SimulatedClouds.basicCloud(2);
-
-        return new TitusStackResource(EmbeddedTitusCell.aTitusCell()
-                .withMaster(EmbeddedTitusMasters.basicMaster(simulatedCloud).toBuilder()
-                        .withCellName("cell-name")
-                        .build())
-                .withDefaultGateway()
-                .withJobSanitizer(jobSanitizer)
                 .build());
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCriteriaQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCriteriaQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration.v3.job;
+package com.netflix.titus.master.integration.v3.job.query;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCursorArchiveQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCursorArchiveQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration.v3.job;
+package com.netflix.titus.master.integration.v3.job.query;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -31,6 +31,7 @@ import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
 import com.netflix.titus.grpc.protogen.TaskStatus;
+import com.netflix.titus.master.integration.BaseIntegrationTest;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTemplates;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
 import com.netflix.titus.master.integration.v3.scenario.JobScenarioBuilder;
@@ -49,7 +50,7 @@ import static com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCells.basicCe
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(IntegrationTest.class)
-public class JobCursorArchiveQueryTest {
+public class JobCursorArchiveQueryTest extends BaseIntegrationTest {
 
     private static final String ALL_TASK_STATES = StringExt.concatenate(TaskStatus.TaskState.class, ",", s -> s != TaskStatus.TaskState.UNRECOGNIZED);
 
@@ -71,7 +72,7 @@ public class JobCursorArchiveQueryTest {
     private static JobScenarioBuilder jobScenarioBuilder;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         instanceGroupsScenarioBuilder.synchronizeWithCloud().template(InstanceGroupScenarioTemplates.basicCloudActivation());
         client = titusStackResource.getGateway().getV3BlockingGrpcClient();
 
@@ -84,7 +85,7 @@ public class JobCursorArchiveQueryTest {
         jobScenarioBuilder = jobsScenarioBuilder.schedule(jobDescriptor, ScenarioTemplates.startTasksInNewJob()).takeJob(0);
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testArchiveQuery() {
         Evaluators.times(TASKS_PER_JOB, idx -> jobScenarioBuilder.getTaskByIndex(idx).killTask());
         Evaluators.times(TASKS_PER_JOB, idx -> jobScenarioBuilder.getTaskByIndex(idx).expectStateUpdateSkipOther(TaskStatus.TaskState.Finished));

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCursorQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCursorQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration.v3.job;
+package com.netflix.titus.master.integration.v3.job.query;
 
 import java.util.List;
 
@@ -87,7 +87,7 @@ public class JobCursorQueryTest extends BaseIntegrationTest {
         assertThat(allTasksInOrder).hasSize(2 * JOBS_PER_ENGINE * TASKS_PER_JOB);
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobQueryWithCursor() {
         // Page 0
         JobQueryResult result0 = client.findJobs(JobQuery.newBuilder()
@@ -131,12 +131,12 @@ public class JobCursorQueryTest extends BaseIntegrationTest {
                 .isEqualTo(result3.getPagination().getTotalPages());
     }
 
-    @Test(expected = StatusRuntimeException.class)
+    @Test(timeout = TEST_TIMEOUT_MS, expected = StatusRuntimeException.class)
     public void testJobQueryWithBadCursor() {
         client.findJobs(JobQuery.newBuilder().setPage(Page.newBuilder().setPageSize(4).setCursor("bad_cursor_value")).build());
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobQueryWithCursorAndEmptyResult() {
         JobQueryResult result = client.findJobs(JobQuery.newBuilder()
                 .setPage(Page.newBuilder().setPageSize(4))
@@ -149,7 +149,7 @@ public class JobCursorQueryTest extends BaseIntegrationTest {
         assertThat(result.getPagination().getHasMore()).isFalse();
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTaskQueryWithCursor() {
         // Page 0
         TaskQueryResult result0 = client.findTasks(TaskQuery.newBuilder()
@@ -193,12 +193,12 @@ public class JobCursorQueryTest extends BaseIntegrationTest {
                 .isEqualTo(result3.getPagination().getTotalPages());
     }
 
-    @Test(expected = StatusRuntimeException.class)
+    @Test(timeout = TEST_TIMEOUT_MS, expected = StatusRuntimeException.class)
     public void testTaskQueryWithBadCursor() {
         client.findTasks(TaskQuery.newBuilder().setPage(Page.newBuilder().setPageSize(4).setCursor("bad_cursor_value")).build());
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTaskQueryWithCursorAndEmptyResult() {
         TaskQueryResult result = client.findTasks(TaskQuery.newBuilder()
                 .setPage(Page.newBuilder().setPageSize(4))

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCursorQueryWithUpdatesTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCursorQueryWithUpdatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration.v3.job;
+package com.netflix.titus.master.integration.v3.job.query;
 
 import java.util.List;
 
@@ -85,7 +85,7 @@ public class JobCursorQueryWithUpdatesTest extends BaseIntegrationTest {
         assertThat(allTasksInOrder).hasSize(2 * JOBS_PER_ENGINE * TASKS_PER_JOB);
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testJobQueryWithRemovedItems() {
         // Page 0
         JobQueryResult result0 = client.findJobs(JobQuery.newBuilder()
@@ -111,7 +111,7 @@ public class JobCursorQueryWithUpdatesTest extends BaseIntegrationTest {
         assertThat(result2.getItemsList()).isEmpty();
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testTaskQueryWithRemovedItems() {
         // Page 0
         TaskQueryResult result0 = client.findTasks(TaskQuery.newBuilder()

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobDirectQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobDirectQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration.v3.job;
+package com.netflix.titus.master.integration.v3.job.query;
 
 import com.netflix.titus.api.jobmanager.model.job.JobState;
 import com.netflix.titus.grpc.protogen.Job;
@@ -23,6 +23,7 @@ import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskId;
 import com.netflix.titus.master.integration.BaseIntegrationTest;
+import com.netflix.titus.master.integration.v3.job.CellAssertions;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTemplates;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
 import com.netflix.titus.master.integration.v3.scenario.JobsScenarioBuilder;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobObserveTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobObserveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.integration.v3.job;
+package com.netflix.titus.master.integration.v3.job.query;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +33,7 @@ import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskStatus.TaskState;
 import com.netflix.titus.master.integration.BaseIntegrationTest;
+import com.netflix.titus.master.integration.v3.job.CellAssertions;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupScenarioTemplates;
 import com.netflix.titus.master.integration.v3.scenario.InstanceGroupsScenarioBuilder;
 import com.netflix.titus.master.integration.v3.scenario.JobsScenarioBuilder;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/loadbalancer/LoadBalancerGrpcTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/loadbalancer/LoadBalancerGrpcTest.java
@@ -73,19 +73,19 @@ public class LoadBalancerGrpcTest extends BaseIntegrationTest {
         client = titusStackResource.getOperations().getLoadBalancerGrpcClient();
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testPutLoadBalancer() throws Exception {
         LoadBalancerTests.putLoadBalancersPerJob(1, 1, putLoadBalancerWithJobId);
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testGetLoadBalancer() throws Exception {
         String jobId = "Titus-123";
         Set<LoadBalancerId> loadBalancerIds = LoadBalancerTests.getLoadBalancersForJob(jobId, getJobLoadBalancers);
         assertThat(loadBalancerIds.size()).isEqualTo(0);
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testRmLoadBalancer() throws Exception {
         Map<String, Set<LoadBalancerId>> jobIdToLoadBalancersMap = LoadBalancerTests.putLoadBalancersPerJob(10, 50, putLoadBalancerWithJobId);
 
@@ -102,7 +102,7 @@ public class LoadBalancerGrpcTest extends BaseIntegrationTest {
         });
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testGetAllLoadBalancerPages() throws Exception {
         int numJobs = 75;
         int numLbs = 7;
@@ -136,7 +136,7 @@ public class LoadBalancerGrpcTest extends BaseIntegrationTest {
         );
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testGetAllLoadBalancerPagesWithCursor() throws Exception {
         int numJobs = 75;
         int numLbs = 7;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobsScenarioBuilder.java
@@ -113,7 +113,8 @@ public class JobsScenarioBuilder extends ExternalResource {
     public JobsScenarioBuilder schedule(JobDescriptor jobDescriptor,
                                         Function<JobScenarioBuilder, JobScenarioBuilder> jobScenario) {
         TestStreamObserver<JobId> responseObserver = new TestStreamObserver<>();
-        client.createJob(GrpcJobManagementModelConverters.toGrpcJobDescriptor(jobDescriptor), responseObserver);
+        client.withDeadlineAfter(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .createJob(GrpcJobManagementModelConverters.toGrpcJobDescriptor(jobDescriptor), responseObserver);
 
         JobId jobId;
         try {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/supervisor/SupervisorBasicTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/supervisor/SupervisorBasicTest.java
@@ -43,7 +43,7 @@ public class SupervisorBasicTest extends BaseIntegrationTest {
 
     private final SupervisorServiceBlockingStub blockingGrpcClient = titusStackResource.getMaster().getSupervisorBlockingGrpcClient();
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testGetMasterInstances() {
         MasterInstances instances = blockingGrpcClient.getMasterInstances(Empty.getDefaultInstance());
         assertThat(instances.getInstancesList()).hasSize(1);
@@ -53,7 +53,7 @@ public class SupervisorBasicTest extends BaseIntegrationTest {
         assertThat(instance.getStatus().getState()).isEqualTo(MasterStatus.MasterState.LeaderActivated);
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testObserveEvents() {
         Iterator<SupervisorEvent> it = blockingGrpcClient.observeEvents(Empty.getDefaultInstance());
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMasters.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMasters.java
@@ -34,6 +34,11 @@ public final class EmbeddedTitusMasters {
                 .withProperty("titus.agent.synchronizeWithInstanceCacheIntervalMs", "500")
                 .withProperty("titus.master.capacityManagement.availableCapacityUpdateIntervalMs", "10")
 
+                .withProperty("titus.scheduler.exitUponFenzoSchedulingErrorEnabled", "false")
+                // Disable launch guard
+                .withProperty("titus.scheduler.globalTaskLaunchingConstraintEvaluatorEnabled", "false")
+                .withProperty("titus.scheduler.maxLaunchingTasksPerMachine", "96")
+
                 // speed up scheduling during tests
                 .withProperty("titus.scheduler.schedulerIterationIntervalMs", "1")
                 .withProperty("titus.scheduler.schedulerMaxIdleIntervalMs", "5")

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/SimulatedCloud.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/SimulatedCloud.java
@@ -40,6 +40,8 @@ import com.netflix.titus.testkit.embedded.cloud.agent.player.ContainerPlayersMan
 import com.netflix.titus.testkit.embedded.cloud.model.SimulatedAgentGroupDescriptor;
 import com.netflix.titus.testkit.embedded.cloud.resource.ComputeResources;
 import org.apache.mesos.Protos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
@@ -47,6 +49,8 @@ import rx.subjects.SerializedSubject;
 import rx.subjects.Subject;
 
 public class SimulatedCloud {
+
+    private static final Logger logger = LoggerFactory.getLogger(SimulatedCloud.class);
 
     private final ComputeResources computeResources;
 
@@ -190,6 +194,7 @@ public class SimulatedCloud {
     }
 
     public void killTask(String taskId) {
+        logger.info("Task kill request: taskId={}", taskId);
         try {
             getTaskExecutorHolder(taskId).transitionTo(Protos.TaskState.TASK_KILLED);
         } catch (IllegalArgumentException e) {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/TaskExecutorHolder.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/TaskExecutorHolder.java
@@ -33,6 +33,8 @@ import com.netflix.titus.master.mesos.TitusExecutorDetails;
 import com.netflix.titus.testkit.embedded.cloud.agent.player.ContainerPlayersManager;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.TaskState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Observer;
 
@@ -44,6 +46,8 @@ import static com.netflix.titus.common.util.CollectionsExt.asSet;
  * state.
  */
 public class TaskExecutorHolder {
+
+    private static final Logger logger = LoggerFactory.getLogger(TaskExecutorHolder.class);
 
     private static final Map<TaskState, Set<TaskState>> VALID_STATE_TRANSITIONS = CollectionsExt.<TaskState, Set<TaskState>>newHashMap()
             .entry(TaskState.TASK_STAGING, asSet(TaskState.TASK_STARTING, TaskState.TASK_FAILED, TaskState.TASK_KILLING, TaskState.TASK_KILLED))
@@ -199,6 +203,8 @@ public class TaskExecutorHolder {
 
     public TaskState transitionToUnchecked(TaskState nextState, Protos.TaskStatus.Reason reason, String reasonMessage) {
         TaskState oldState = currentTaskStatus.getState();
+
+        logger.info("Changing task state: taskId={}, from={}, to={}", taskId, oldState, nextState);
 
         Protos.TaskStatus.Builder statusBuilder = newTaskStatusBuilder()
                 .setState(nextState)


### PR DESCRIPTION
Also restore the security manager in `BaseIntegrationTest`. There are a few more places where `System.exit` is called, and cannot be easily patched.