### PR TITLE
An update to the original Archaius2/Spring dynamic proxy implementation

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/archaius2/Archaius2Ext.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/archaius2/Archaius2Ext.java
@@ -34,6 +34,7 @@ import com.netflix.archaius.api.PropertyRepository;
 import com.netflix.archaius.config.MapConfig;
 import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.common.util.closeable.CloseableReference;
 import org.springframework.core.env.Environment;
 import reactor.core.publisher.Flux;
 
@@ -153,6 +154,31 @@ public final class Archaius2Ext {
                 selectorFieldAccessor,
                 configType,
                 defaultConfig
+        );
+    }
+
+    /**
+     * See {@link #newObjectConfigurationResolver(Config, Function, Class, Object)}. As Spring environment does not support
+     * configuration change callbacks, so we have to make an explicit periodic updates.
+     *
+     * @param updateTrigger on each emitted item from this {@link Flux} instance, a configuration update is made
+     * @return resolver instance with a closable reference. Calling {@link CloseableReference#close()}, terminates
+     * configuration update subscription.
+     */
+    public static <OBJECT, CONFIG> CloseableReference<ObjectConfigurationResolver<OBJECT, CONFIG>> newObjectConfigurationResolver(
+            String prefix,
+            Environment environment,
+            Function<OBJECT, String> selectorFieldAccessor,
+            Class<CONFIG> configType,
+            CONFIG defaultConfig,
+            Flux<Long> updateTrigger) {
+        String formattedPrefix = SpringConfig.formatPrefix(prefix);
+        return PeriodicallyRefreshingObjectConfigurationResolver.newInstance(
+                new SpringConfig(formattedPrefix, environment),
+                selectorFieldAccessor,
+                root -> newConfiguration(configType, formattedPrefix + root, environment),
+                defaultConfig,
+                updateTrigger
         );
     }
 

--- a/titus-common/src/main/java/com/netflix/titus/common/util/archaius2/PeriodicallyRefreshingObjectConfigurationResolver.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/archaius2/PeriodicallyRefreshingObjectConfigurationResolver.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.util.archaius2;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.titus.common.util.closeable.CloseableReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Spring Environment does not provide change callbacks. In this integration we refresh the data periodically using the
+ * provided update trigger.
+ */
+class PeriodicallyRefreshingObjectConfigurationResolver<OBJECT, CONFIG> implements ObjectConfigurationResolver<OBJECT, CONFIG> {
+
+    private static final Logger logger = LoggerFactory.getLogger(PeriodicallyRefreshingObjectConfigurationResolver.class);
+
+    private static final Duration RETRY_INTERVAL = Duration.ofSeconds(5);
+
+    private final Config configuration;
+    private final Archaius2ObjectConfigurationResolver<OBJECT, CONFIG> delegate;
+
+    PeriodicallyRefreshingObjectConfigurationResolver(Config configuration,
+                                                      Function<OBJECT, String> selectorFieldAccessor,
+                                                      Function<String, CONFIG> dynamicProxyFactory,
+                                                      CONFIG defaultConfig) {
+        this.configuration = configuration;
+        this.delegate = new Archaius2ObjectConfigurationResolver<>(
+                configuration,
+                selectorFieldAccessor,
+                dynamicProxyFactory,
+                defaultConfig
+        );
+    }
+
+    @Override
+    public CONFIG resolve(OBJECT object) {
+        return delegate.resolve(object);
+    }
+
+    void refresh() {
+        try {
+            delegate.onConfigUpdated(configuration);
+        } catch (Exception e) {
+            logger.warn("Refresh error: {}", e.getMessage());
+            logger.debug("Stack trace", e);
+        }
+    }
+
+    static <OBJECT, CONFIG> CloseableReference<ObjectConfigurationResolver<OBJECT, CONFIG>> newInstance(Config configuration,
+                                                                                                        Function<OBJECT, String> selectorFieldAccessor,
+                                                                                                        Function<String, CONFIG> dynamicProxyFactory,
+                                                                                                        CONFIG defaultConfig,
+                                                                                                        Flux<Long> updateTrigger) {
+        PeriodicallyRefreshingObjectConfigurationResolver<OBJECT, CONFIG> resolver = new PeriodicallyRefreshingObjectConfigurationResolver<>(
+                configuration, selectorFieldAccessor, dynamicProxyFactory, defaultConfig
+        );
+
+        Disposable disposable = updateTrigger
+                .retryBackoff(Long.MAX_VALUE, RETRY_INTERVAL)
+                .subscribe(tick -> resolver.refresh());
+
+        return CloseableReference.<ObjectConfigurationResolver<OBJECT, CONFIG>>newBuilder()
+                .withResource(resolver)
+                .withCloseAction(disposable::dispose)
+                .withSwallowException(true)
+                .build();
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/util/archaius2/SpringConfig.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/archaius2/SpringConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.util.archaius2;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.netflix.archaius.api.Config;
+import com.netflix.archaius.config.AbstractConfig;
+import com.netflix.titus.common.util.StringExt;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+
+public class SpringConfig extends AbstractConfig {
+
+    private final String prefix;
+    private final Environment environment;
+
+    public SpringConfig(String prefix, Environment environment) {
+        this.prefix = formatPrefix(prefix);
+        this.environment = environment;
+    }
+
+    @Override
+    public Object getRawProperty(String key) {
+        return environment.getProperty(fullKey(key));
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return environment.containsProperty(fullKey(key));
+    }
+
+    @Override
+    public Iterator<String> getKeys() {
+        return getAllProperties().keySet().iterator();
+    }
+
+    @Override
+    public Config getPrefixedView(String prefix) {
+        return new SpringConfig(this.prefix + prefix, environment);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getAllProperties().isEmpty();
+    }
+
+    private String fullKey(String key) {
+        return prefix.isEmpty() ? key : prefix + key;
+    }
+
+    /**
+     * Based on the following recommendation: https://github.com/spring-projects/spring-framework/issues/14874
+     */
+    private Map<String, Object> getAllProperties() {
+        Map<String, Object> all = new HashMap<>();
+        if (environment instanceof ConfigurableEnvironment) {
+            for (PropertySource<?> propertySource : ((ConfigurableEnvironment) environment).getPropertySources()) {
+                if (propertySource instanceof EnumerablePropertySource) {
+                    for (String key : ((EnumerablePropertySource) propertySource).getPropertyNames()) {
+                        if (key.startsWith(prefix)) {
+                            all.put(key.substring(prefix.length()), propertySource.getProperty(key));
+                        }
+                    }
+                }
+            }
+        }
+        return all;
+    }
+
+    static String formatPrefix(String prefix) {
+        return StringExt.isEmpty(prefix) ? "" : (prefix.endsWith(".") ? prefix : prefix + '.');
+    }
+}

--- a/titus-common/src/test/java/com/netflix/titus/common/util/archaius2/PeriodicallyRefreshingObjectConfigurationResolverTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/archaius2/PeriodicallyRefreshingObjectConfigurationResolverTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.util.archaius2;
+
+import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.titus.common.util.closeable.CloseableReference;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+import reactor.core.publisher.DirectProcessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeriodicallyRefreshingObjectConfigurationResolverTest {
+
+    private final MockEnvironment configuration = new MockEnvironment();
+
+    private final DirectProcessor<Long> updateTrigger = DirectProcessor.create();
+
+    private final CloseableReference<ObjectConfigurationResolver<MyObject, MyObjectConfig>> resolverRef = Archaius2Ext.newObjectConfigurationResolver(
+            "object",
+            configuration,
+            MyObject::getName,
+            MyObjectConfig.class,
+            Archaius2Ext.newConfiguration(MyObjectConfig.class, "default", configuration),
+            updateTrigger
+    );
+
+    private final ObjectConfigurationResolver<MyObject, MyObjectConfig> resolver = resolverRef.get();
+
+    @After
+    public void tearDown() {
+        resolverRef.close();
+    }
+
+    @Test
+    public void testDefaultObjectConfiguration() {
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(100);
+    }
+
+    @Test
+    public void testDefaultOverrides() {
+        update("default.limit", "200");
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(200);
+    }
+
+    @Test
+    public void testObjectOverrides() {
+        update("object.a.pattern", "a",
+                "object.a.limit", "200",
+                "object.b.pattern", "b",
+                "object.b.limit", "300"
+        );
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(200);
+        assertThat(resolver.resolve(new MyObject("b")).getLimit()).isEqualTo(300);
+        assertThat(resolver.resolve(new MyObject("x")).getLimit()).isEqualTo(100);
+    }
+
+    @Test
+    public void testDynamicUpdates() {
+        update("object.a.pattern", "a",
+                "object.a.limit", "200"
+        );
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(200);
+
+        update("object.a.limit", "300");
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(300);
+
+        update("object.a.pattern", "not_a_anymore");
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(100);
+    }
+
+    @Test
+    public void testBadPattern() {
+        update("object.a.pattern", "a",
+                "object.a.limit", "200"
+        );
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(200);
+
+        update("object.a.pattern", "*"); // bad regexp
+        assertThat(resolver.resolve(new MyObject("a")).getLimit()).isEqualTo(200);
+    }
+
+    private void update(String... keyValuePairs) {
+        for (int i = 0; i < keyValuePairs.length; i += 2) {
+            configuration.setProperty(keyValuePairs[i], keyValuePairs[i + 1]);
+        }
+        updateTrigger.onNext(System.currentTimeMillis());
+    }
+
+    private static class MyObject {
+
+        private final String name;
+
+        MyObject(String name) {
+            this.name = name;
+        }
+
+        String getName() {
+            return name;
+        }
+    }
+
+    private interface MyObjectConfig {
+        @DefaultValue("100")
+        int getLimit();
+    }
+}

--- a/titus-common/src/test/java/com/netflix/titus/common/util/archaius2/SpringConfigTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/archaius2/SpringConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.util.archaius2;
+
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringConfigTest {
+
+    private final MockEnvironment environment = new MockEnvironment();
+
+    @Test
+    public void testGetProperty() {
+        environment.setProperty("number", "123");
+        SpringConfig config = new SpringConfig(null, environment);
+        assertThat(config.getString("number")).isEqualTo("123");
+        assertThat(config.getLong("number")).isEqualTo(123L);
+    }
+
+    @Test
+    public void testPrefixedView() {
+        environment.setProperty("myPrefix.number", "123");
+        SpringConfig config = new SpringConfig("myPrefix", environment);
+        assertThat(config.getString("number")).isEqualTo("123");
+        assertThat(config.getLong("number")).isEqualTo(123L);
+    }
+
+    @Test
+    public void testUpdates() {
+        environment.setProperty("number", "123");
+        SpringConfig config = new SpringConfig(null, environment);
+        assertThat(config.getString("number")).isEqualTo("123");
+        assertThat(config.getLong("number")).isEqualTo(123L);
+
+        environment.setProperty("number", "456");
+        assertThat(config.getString("number")).isEqualTo("456");
+        assertThat(config.getLong("number")).isEqualTo(456L);
+    }
+}

--- a/titus-common/src/test/java/com/netflix/titus/common/util/archaius2/SpringProxyInvocationHandlerTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/archaius2/SpringProxyInvocationHandlerTest.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.common.util.archaius2;
 
 import java.util.List;
+import java.util.Set;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
@@ -83,10 +84,27 @@ public class SpringProxyInvocationHandlerTest {
     }
 
     @Test
+    public void testEmptyList() {
+        assertThat(configuration.getEmptyList()).isEmpty();
+    }
+
+    @Test
     public void testSet() {
         assertThat(configuration.getSet()).containsExactly("d", "e", "f");
         environment.setProperty("annotationPrefix.set", "D,E,F");
         assertThat(configuration.getSet()).containsExactly("D", "E", "F");
+    }
+
+    @Test
+    public void testEmptySet() {
+        assertThat(configuration.getEmptySet()).isEmpty();
+    }
+
+    @Test
+    public void testNullValue() {
+        assertThat(configuration.getInteger()).isNull();
+        environment.setProperty("annotationPrefix.integer", "1");
+        assertThat(configuration.getInteger()).isEqualTo(1);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -122,6 +140,8 @@ public class SpringProxyInvocationHandlerTest {
         @DefaultValue("1")
         int getInt();
 
+        Integer getInteger();
+
         int getIntWithNoDefault();
 
         @DefaultValue("2")
@@ -139,8 +159,12 @@ public class SpringProxyInvocationHandlerTest {
         @DefaultValue("a,b,c")
         List<String> getList();
 
+        List<String> getEmptyList();
+
         @DefaultValue("d,e,f")
         List<String> getSet();
+
+        Set<String> getEmptySet();
 
         default long getNumber(boolean returnLong) {
             return returnLong ? getLong() : getInt();


### PR DESCRIPTION
It fixies two oversights:
1. it is ok to return null for non-primitive types
2. List and Set getters return empty collections if property not set
