### PR TITLE
More routing options for Fenzo/Kube scheduler

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/feature/FeatureGuards.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/feature/FeatureGuards.java
@@ -23,6 +23,14 @@ import com.netflix.titus.common.util.feature.FeatureGuard.FeatureGuardResult;
 
 public class FeatureGuards {
 
+    private static final FeatureGuard ALWAYS_APPROVED = value -> FeatureGuardResult.Approved;
+    private static final FeatureGuard ALWAYS_DENIED = value -> FeatureGuardResult.Denied;
+    private static final FeatureGuard ALWAYS_UNDECIDED = value -> FeatureGuardResult.Undecided;
+
+    /**
+     * If multiple feature guards are give, they are evaluated in order until one returns result {@link FeatureGuardResult#Approved}
+     * or {@link FeatureGuardResult#Denied}. If all of them return {@link FeatureGuardResult#Undecided}, the result is false.
+     */
     public static <T> Predicate<T> toPredicate(FeatureGuard<T>... featureGuard) {
         if (featureGuard.length == 0) {
             return value -> false;
@@ -59,5 +67,17 @@ public class FeatureGuards {
 
     public static <T> FeatureGuard<T> fromField(Function<T, String> accessor, FeatureGuard<String> delegate) {
         return new FeatureGuardForField<>(accessor, delegate);
+    }
+
+    public static <T> FeatureGuard<T> alwaysApproved() {
+        return ALWAYS_APPROVED;
+    }
+
+    public static <T> FeatureGuard<T> alwaysDenied() {
+        return ALWAYS_DENIED;
+    }
+
+    public static <T> FeatureGuard<T> alwaysUndecided() {
+        return ALWAYS_UNDECIDED;
     }
 }

--- a/titus-common/src/test/java/com/netflix/titus/common/util/feature/FeatureGuardsTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/feature/FeatureGuardsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.util.feature;
+
+import org.junit.Test;
+
+import static com.netflix.titus.common.util.feature.FeatureGuards.alwaysApproved;
+import static com.netflix.titus.common.util.feature.FeatureGuards.alwaysDenied;
+import static com.netflix.titus.common.util.feature.FeatureGuards.alwaysUndecided;
+import static com.netflix.titus.common.util.feature.FeatureGuards.toPredicate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FeatureGuardsTest {
+
+    @Test
+    public void testPredicates() {
+        assertThat(toPredicate().test("anything")).isFalse();
+
+        assertThat(toPredicate(alwaysApproved()).test("anything")).isTrue();
+        assertThat(toPredicate(alwaysDenied()).test("anything")).isFalse();
+        assertThat(toPredicate(alwaysUndecided()).test("anything")).isFalse();
+
+        assertThat(toPredicate(alwaysUndecided(), alwaysUndecided()).test("anything")).isFalse();
+        assertThat(toPredicate(alwaysUndecided(), alwaysApproved()).test("anything")).isTrue();
+        assertThat(toPredicate(alwaysUndecided(), alwaysDenied()).test("anything")).isFalse();
+        assertThat(toPredicate(alwaysApproved(), alwaysDenied()).test("anything")).isTrue();
+        assertThat(toPredicate(alwaysDenied(), alwaysApproved()).test("anything")).isFalse();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -95,6 +95,13 @@ public final class JobManagerUtil {
         return Pair.of(applicationSLA.getTier(), capacityGroup);
     }
 
+    public static ApplicationSLA getCapacityGroupDescriptor(JobDescriptor<?> jobDescriptor, ApplicationSlaManagementService capacityGroupService) {
+        String capacityGroup = jobDescriptor.getCapacityGroup();
+
+        ApplicationSLA applicationSLA = capacityGroupService.getApplicationSLA(capacityGroup);
+        return applicationSLA == null ? capacityGroupService.getApplicationSLA(ApplicationSlaManagementService.DEFAULT_APPLICATION) : applicationSLA;
+    }
+
     public static Function<Task, Optional<Task>> newMesosTaskStateUpdater(TaskStatus newTaskStatus, Optional<TitusExecutorDetails> detailsOpt, TitusRuntime titusRuntime) {
         return oldTask -> {
             TaskState oldState = oldTask.getStatus().getState();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/batch/BatchDifferenceResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/batch/BatchDifferenceResolver.java
@@ -44,6 +44,7 @@ import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.api.jobmanager.store.JobStore;
+import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.common.framework.reconciler.ChangeAction;
 import com.netflix.titus.common.framework.reconciler.EntityHolder;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
@@ -89,7 +90,7 @@ public class BatchDifferenceResolver implements ReconciliationEngine.DifferenceR
     private final JobManagerConfiguration configuration;
     private final FeatureActivationConfiguration featureConfiguration;
     private final DirectKubeConfiguration kubeConfiguration;
-    private final Predicate<JobDescriptor> kubeSchedulerPredicate;
+    private final Predicate<Pair<JobDescriptor, ApplicationSLA>> kubeSchedulerPredicate;
     private final ApplicationSlaManagementService capacityGroupService;
     private final SchedulingService<? extends TaskRequest> schedulingService;
     private final VirtualMachineMasterService vmService;
@@ -110,7 +111,7 @@ public class BatchDifferenceResolver implements ReconciliationEngine.DifferenceR
             JobManagerConfiguration configuration,
             FeatureActivationConfiguration featureConfiguration,
             DirectKubeConfiguration kubeConfiguration,
-            @Named(FeatureRolloutPlans.KUBE_SCHEDULER_FEATURE) Predicate<JobDescriptor> kubeSchedulerPredicate,
+            @Named(FeatureRolloutPlans.KUBE_SCHEDULER_FEATURE) Predicate<Pair<JobDescriptor, ApplicationSLA>> kubeSchedulerPredicate,
             ApplicationSlaManagementService capacityGroupService,
             SchedulingService<? extends TaskRequest> schedulingService,
             VirtualMachineMasterService vmService,
@@ -130,7 +131,7 @@ public class BatchDifferenceResolver implements ReconciliationEngine.DifferenceR
             JobManagerConfiguration configuration,
             FeatureActivationConfiguration featureConfiguration,
             DirectKubeConfiguration kubeConfiguration,
-            @Named(FeatureRolloutPlans.KUBE_SCHEDULER_FEATURE) Predicate<JobDescriptor> kubeSchedulerPredicate,
+            @Named(FeatureRolloutPlans.KUBE_SCHEDULER_FEATURE) Predicate<Pair<JobDescriptor, ApplicationSLA>> kubeSchedulerPredicate,
             ApplicationSlaManagementService capacityGroupService,
             SchedulingService<? extends TaskRequest> schedulingService,
             VirtualMachineMasterService vmService,
@@ -244,7 +245,11 @@ public class BatchDifferenceResolver implements ReconciliationEngine.DifferenceR
         }
 
         Map<String, String> taskContext = getTaskContext(previousTask, unassignedIpAllocations);
-        if (KubeUtil.findFarzoneId(kubeConfiguration, refJobView.getJob()).isPresent() || kubeSchedulerPredicate.test(refJobView.getJob().getJobDescriptor())) {
+
+        JobDescriptor jobDescriptor = refJobView.getJob().getJobDescriptor();
+        ApplicationSLA capacityGroupDescriptor = JobManagerUtil.getCapacityGroupDescriptor(jobDescriptor, capacityGroupService);
+        if (KubeUtil.findFarzoneId(kubeConfiguration, refJobView.getJob()).isPresent()
+                || kubeSchedulerPredicate.test(Pair.of(jobDescriptor, capacityGroupDescriptor))) {
             taskContext = CollectionsExt.copyAndAdd(taskContext, TaskAttributes.TASK_ATTRIBUTES_OWNED_BY_KUBE_SCHEDULER, "true");
         }
 


### PR DESCRIPTION
With this PR, we can route using an application name, capacity group, tier or job type.