### PR TITLE
Increase the JVM heap on circleci for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   java:
     docker:
-      - image: circleci/openjdk:8-stretch-node-browsers-legacy
+      - image: circleci/openjdk:8-jdk-stretch
 jobs:
   build:
     executor: java
@@ -11,15 +11,17 @@ jobs:
       - run:
           environment:
             DEBIAN_FRONTEND: noninteractive
+            _JAVA_OPTIONS: "-Xms2g -Xmx12g"
+            GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=8"
           command: |
             sudo apt update
             sudo apt install -qy ca-certificates git
       - checkout
       - restore_cache:
           keys:
-            - v2-gradle-cache
+            - v3-gradle-cache
       - run:
-          command: ./gradlew testAll --no-daemon --max-workers 2 --stacktrace
+          command: ./gradlew testAll --parallel --stacktrace
           no_output_timeout: 20m
       - run:
           name: Save test results
@@ -35,6 +37,6 @@ jobs:
           paths:
             - ~/.gradle/caches
             - ~/.gradle/wrapper
-          key: v2-gradle-cache
+          key: v3-gradle-cache
           when: on_success
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
           environment:
             DEBIAN_FRONTEND: noninteractive
             _JAVA_OPTIONS: "-Xms2g -Xmx12g"
-            GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4"
           command: |
             sudo apt update
             sudo apt install -qy ca-certificates git
@@ -21,7 +20,7 @@ jobs:
           keys:
             - v3-gradle-cache
       - run:
-          command: ./gradlew testAll --parallel --stacktrace
+          command: ./gradlew testAll --no-daemon --max-workers 4 --parallel --stacktrace
           no_output_timeout: 20m
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           environment:
             DEBIAN_FRONTEND: noninteractive
             _JAVA_OPTIONS: "-Xms2g -Xmx12g"
-            GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=8"
+            GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4"
           command: |
             sudo apt update
             sudo apt install -qy ca-certificates git

--- a/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassStoreHelperTest.java
+++ b/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassStoreHelperTest.java
@@ -23,10 +23,12 @@ import java.util.concurrent.TimeUnit;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import com.netflix.titus.testkit.junit.category.IntegrationNotParallelizableTest;
 import org.cassandraunit.CassandraCQLUnit;
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
@@ -35,6 +37,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(IntegrationNotParallelizableTest.class)
 public class CassStoreHelperTest {
 
     private static final long STARTUP_TIMEOUT = 60_000L;


### PR DESCRIPTION
Execution of all tests (on a single box) down to 11min on Circle CI, and hopefully less flaky.