### PR TITLE
Register copy proto task after evaluation of project

### DIFF
--- a/titus-common-grpc-api/build.gradle
+++ b/titus-common-grpc-api/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 }
 
 if (project.hasProperty("idlLocal")) {
-    task extractProto {
+    tasks.register('copyProtos', Copy) {
         doLast {
             copy {
                 from '../../titus-api-definitions/src/main/proto'
@@ -30,7 +30,11 @@ if (project.hasProperty("idlLocal")) {
             }
         }
     }
+    afterEvaluate {
+        tasks.findByName('extractProto').finalizedBy tasks.copyProtos
+    }
 }
+
 
 idea {
     module {

--- a/titus-grpc-api/build.gradle
+++ b/titus-grpc-api/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.google.protobuf" version "0.8.11"
+    id "com.google.protobuf" version "0.8.12"
 }
 
 configurations {
@@ -20,13 +20,16 @@ dependencies {
 }
 
 if (project.hasProperty("idlLocal")) {
-    task extractProto {
+    tasks.register('copyProtos', Copy) {
         doLast {
             copy {
                 from '../../titus-api-definitions/src/main/proto'
                 into new File(buildDir, "extracted-protos/main")
             }
         }
+    }
+    afterEvaluate {
+        tasks.findByName('extractProto').finalizedBy tasks.copyProtos
     }
 }
 


### PR DESCRIPTION
It seems like protobuf plugin could change the way task are register so they are only available when invoked. In this cases, gradle might not be able to configure task dependencies accordingly

This change is to create a copy task for the protos and after the project is evaluated, add a task dependency to extractProto

this is how task execution will look like

```
:titus-common-grpc-api:extractIncludeProto SKIPPED
:titus-common-grpc-api:extractProto SKIPPED
:titus-common-grpc-api:copyProtos SKIPPED
:titus-common-grpc-api:generateProto SKIPPED
:titus-common-grpc-api:compileJava SKIPPED
:titus-common-grpc-api:processResources SKIPPED
:titus-common-grpc-api:classes SKIPPED
:titus-common-grpc-api:createPropertiesFileForJar SKIPPED
:titus-common-grpc-api:writeManifestProperties SKIPPED
:titus-common-grpc-api:jar SKIPPED
:titus-common-runtime:compileJava SKIPPED
:titus-common-runtime:processResources SKIPPED
:titus-common-runtime:classes SKIPPED
:titus-common-runtime:createPropertiesFileForJar SKIPPED
:titus-common-runtime:writeManifestProperties SKIPPED
:titus-common-runtime:jar SKIPPED
:titus-grpc-api:extractIncludeProto SKIPPED
:titus-grpc-api:extractProto SKIPPED
:titus-grpc-api:copyProtos SKIPPED
:titus-grpc-api:generateProto SKIPPED
:titus-grpc-api:compileJava SKIPPED
:titus-grpc-api:processResources SKIPPED
:titus-grpc-api:classes SKIPPED
:titus-grpc-api:createPropertiesFileForJar SKIPPED
:titus-grpc-api:writeManifestProperties SKIPPED
:titus-grpc-api:jar SKIPPED
``` 