### PR TITLE
Change task dependency rules to avoid issues caused by the recent gradle upgrade

### DIFF
--- a/titus-common-grpc-api/build.gradle
+++ b/titus-common-grpc-api/build.gradle
@@ -22,13 +22,11 @@ dependencies {
 }
 
 if (project.hasProperty("idlLocal")) {
-    task extractProto {
-        doLast {
-            copy {
-                from '../../titus-api-definitions/src/main/proto'
-                into new File(buildDir, "extracted-protos/main")
-            }
-        }
+    tasks.register('copyProtos', Exec) {
+        commandLine "/bin/bash", "-c", "cp -R " + new File(buildDir, '../../../titus-api-definitions/src/main/proto/netflix')  + " " + new File(buildDir, "extracted-protos/main")
+    }
+    afterEvaluate {
+        tasks.findByName('extractProto').finalizedBy tasks.copyProtos
     }
 }
 

--- a/titus-grpc-api/build.gradle
+++ b/titus-grpc-api/build.gradle
@@ -20,13 +20,11 @@ dependencies {
 }
 
 if (project.hasProperty("idlLocal")) {
-    task extractProto {
-        doLast {
-            copy {
-                from '../../titus-api-definitions/src/main/proto'
-                into new File(buildDir, "extracted-protos/main")
-            }
-        }
+    tasks.register('copyProtos', Exec) {
+        commandLine "/bin/bash", "-c", "cp -R " + new File(buildDir, '../../../titus-api-definitions/src/main/proto/netflix')  + " " + new File(buildDir, "extracted-protos/main")
+    }
+    afterEvaluate {
+        tasks.findByName('extractProto').finalizedBy tasks.copyProtos
     }
 }
 


### PR DESCRIPTION
protobuf tasks are now created lazily which broke the previous override rule setup