### PR TITLE
handle Pod opportunistic scheduling annotations

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosConfiguration.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
-import com.netflix.titus.master.mesos.kubeapiserver.direct.KubeConstants;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeConstants;
 
 @Configuration(prefix = "titus.mesos")
 public interface MesosConfiguration {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -455,8 +455,9 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         Protos.TaskInfo taskInfo = taskInfoRequest.getTaskInfo();
         String taskId = taskInfo.getName();
         String nodeName = taskInfo.getSlaveId().getValue();
-        Map<String, String> annotations = KubeUtil.createPodAnnotations(taskInfoRequest.getJob(), taskInfo.getData().toByteArray(),
-                taskInfoRequest.getPassthroughAttributes(), mesosConfiguration.isJobDescriptorAnnotationEnabled());
+        Map<String, String> annotations = KubeUtil.createPodAnnotations(taskInfoRequest.getJob(), taskInfoRequest.getTask(),
+                taskInfo.getData().toByteArray(), taskInfoRequest.getPassthroughAttributes(),
+                mesosConfiguration.isJobDescriptorAnnotationEnabled());
 
         V1ObjectMeta metadata = new V1ObjectMeta()
                 .name(taskId)

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeConstants.java
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.mesos.kubeapiserver.direct;
+package com.netflix.titus.master.mesos.kubeapiserver;
 
 /**
  * Miscellaneous Kube constants.
  */
-public class KubeConstants {
+public final class KubeConstants {
+    private KubeConstants() {
+    }
 
     /*
      * Standard node labels.
      */
+
+    /**
+     * Prefix used for legacy node attributes
+     *
+     * <em>Deprecated</em>: use a prefix that is a valid DNS name (rather than using Java package conventions)
+     */
+    @Deprecated
+    public static final String NODE_ANNOTATION_PREFIX = "com.netflix.titus.agent.attribute/";
 
     public static final String NODE_LABEL_REGION = "failure-domain.beta.kubernetes.io/region";
 
@@ -85,4 +95,24 @@ public class KubeConstants {
      * Taint added to each GPU instance.
      */
     public static final String TAINT_GPU_INSTANCE = TITUS_TAINT_DOMAIN + "gpu";
+
+    /*
+     * Opportunistic scheduling annotations
+     */
+
+    /**
+     * Predicted runtime for a Job in a format compatible with Go's <tt>time.Duration</tt>, e.g. <tt>10s</tt>.
+     * <p>
+     * See <a href="https://godoc.org/time#ParseDuration"><tt>time.ParseDuration</tt></a> for more details on the format.
+     */
+    public static final String JOB_RUNTIME_PREDICTION = "predictions.scheduler.titus.netflix.com/runtime";
+    /**
+     * Opportunistic CPUs allocated to Pods (uint) during scheduling
+     */
+    public static final String OPPORTUNISTIC_CPU_COUNT = "opportunistic.scheduler.titus.netflix.com/cpu";
+    /**
+     * Opportunistic resource CRD used when allocating opportunistic resources to a Pod during scheduling
+     */
+    public static final String OPPORTUNISTIC_ID = "opportunistic.scheduler.titus.netflix.com/id";
+
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultPodAffinityFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultPodAffinityFactory.java
@@ -26,6 +26,7 @@ import com.netflix.titus.api.jobmanager.JobConstraints;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeConstants;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1LabelSelectorRequirement;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
@@ -47,6 +47,7 @@ import com.netflix.titus.api.model.EfsMount;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeConstants;
 import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.taint.TaintTolerationFactory;
 import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobManagementModelConverters;
@@ -115,7 +116,7 @@ public class DefaultTaskToPodConverter implements TaskToPodConverter {
     public V1Pod apply(Job<?> job, Task task) {
         String taskId = task.getId();
         TitanProtos.ContainerInfo containerInfo = buildContainerInfo(job, task);
-        Map<String, String> annotations = KubeUtil.createPodAnnotations(job, containerInfo.toByteArray(),
+        Map<String, String> annotations = KubeUtil.createPodAnnotations(job, task, containerInfo.toByteArray(),
                 containerInfo.getPassthroughAttributesMap(), configuration.isJobDescriptorAnnotationEnabled());
 
         V1ObjectMeta metadata = new V1ObjectMeta()

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/Tolerations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/Tolerations.java
@@ -18,7 +18,7 @@ package com.netflix.titus.master.mesos.kubeapiserver.direct.taint;
 
 import java.util.function.Function;
 
-import com.netflix.titus.master.mesos.kubeapiserver.direct.KubeConstants;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeConstants;
 import io.kubernetes.client.openapi.models.V1Toleration;
 
 public final class Tolerations {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.jobmanager.service;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import com.netflix.titus.api.jobmanager.TaskAttributes;
+import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.master.mesos.ContainerEvent;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeConstants;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeJobManagementReconciler;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeApiServerIntegrator;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodEvent;
+import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1ContainerStateRunning;
+import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
+import io.kubernetes.client.openapi.models.V1ContainerStatus;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import rx.Completable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class KubeNotificationProcessorTest {
+    private DirectProcessor<PodEvent> podEvents;
+    private DirectProcessor<PodEvent> reconcilerPodEvents;
+    private DirectProcessor<ContainerEvent> reconcilerContainerEvents;
+    private KubeNotificationProcessor processor;
+
+    @Mock
+    private V3JobOperations jobOperations;
+    @Captor
+    private ArgumentCaptor<Function<Task, Optional<Task>>> changeFunctionCaptor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        podEvents = DirectProcessor.create();
+        reconcilerPodEvents = DirectProcessor.create();
+        reconcilerContainerEvents = DirectProcessor.create();
+        processor = new KubeNotificationProcessor(mock(JobManagerConfiguration.class), new FakeDirectKube(), new FakeReconciler(), jobOperations);
+        processor.enterActiveMode();
+    }
+
+    @After
+    public void tearDown() {
+        reconcilerPodEvents.onComplete();
+        reconcilerContainerEvents.onComplete();
+        podEvents.onComplete();
+        processor.shutdown();
+    }
+
+    @Test
+    public void opportunisticAnnotationsArePropagatedToTasks() {
+        String jobId = UUID.randomUUID().toString();
+        String taskId = UUID.randomUUID().toString();
+        Job<JobDescriptor.JobDescriptorExt> job = Job.newBuilder().withId(jobId).build();
+        BatchJobTask task = BatchJobTask.newBuilder()
+                .withId(taskId)
+                .withTaskContext(CollectionsExt.asMap(TaskAttributes.TASK_ATTRIBUTES_OWNED_BY_KUBE_SCHEDULER, "true"))
+                .withStatus(TaskStatus.newBuilder().withState(TaskState.Accepted).build())
+                .build();
+        when(jobOperations.findTaskById(eq(taskId))).thenReturn(Optional.of(Pair.of(job, task)));
+        when(jobOperations.updateTask(eq(taskId), any(), any(), anyString(), any())).thenReturn(Completable.complete());
+
+        V1Pod oldPod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(taskId))
+                .status(new V1PodStatus()
+                        .addContainerStatusesItem(new V1ContainerStatus()
+                                .containerID(taskId)
+                                .state(new V1ContainerState().waiting(new V1ContainerStateWaiting()))
+                        )
+                );
+        V1Pod updatedPod = new V1Pod()
+                .metadata(new V1ObjectMeta()
+                        .name(taskId)
+                        .putAnnotationsItem(KubeConstants.OPPORTUNISTIC_CPU_COUNT, "5")
+                        .putAnnotationsItem(KubeConstants.OPPORTUNISTIC_ID, "opportunistic-resource-1234")
+                )
+                .status(new V1PodStatus()
+                        .addContainerStatusesItem(new V1ContainerStatus()
+                                .containerID(taskId)
+                                .state(new V1ContainerState().running(new V1ContainerStateRunning()))
+                        )
+                        .addContainerStatusesItem(new V1ContainerStatus()
+                                .containerID(taskId)
+                                .state(new V1ContainerState().waiting(new V1ContainerStateWaiting()))
+                        )
+                );
+        podEvents.onNext(PodEvent.onUpdate(oldPod, updatedPod, Optional.empty()));
+
+        verify(jobOperations, after(5000)).updateTask(eq(taskId), changeFunctionCaptor.capture(), eq(V3JobOperations.Trigger.Kube),
+                eq("Kube pod notification"), any());
+
+        Function<Task, Optional<Task>> changeFunction = changeFunctionCaptor.getValue();
+        assertThat(changeFunction).isNotNull();
+        Optional<Task> updated = changeFunction.apply(task);
+        assertThat(updated).isPresent();
+        assertThat(updated.get().getTaskContext())
+                .containsEntry(TaskAttributes.TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, "5")
+                .containsEntry(TaskAttributes.TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, "opportunistic-resource-1234");
+    }
+
+    private class FakeDirectKube implements DirectKubeApiServerIntegrator {
+        @Override
+        public Flux<PodEvent> events() {
+            return podEvents;
+        }
+
+        @Override
+        public Map<String, V1Pod> getPods() {
+            throw new UnsupportedOperationException("not needed");
+        }
+
+        @Override
+        public Mono<V1Pod> launchTask(Job job, Task task) {
+            throw new UnsupportedOperationException("not needed");
+        }
+
+        @Override
+        public Mono<Void> terminateTask(Task task) {
+            throw new UnsupportedOperationException("not needed");
+        }
+    }
+
+    private class FakeReconciler implements KubeJobManagementReconciler {
+        @Override
+        public Flux<ContainerEvent> getV3ContainerEventSource() {
+            return reconcilerContainerEvents;
+        }
+
+        @Override
+        public Flux<PodEvent> getPodEventSource() {
+            return reconcilerPodEvents;
+        }
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtilTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtilTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import com.netflix.titus.master.mesos.kubeapiserver.direct.KubeConstants;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1NodeSpec;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactoryTest.java
@@ -23,7 +23,7 @@ import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeConfiguration;
-import com.netflix.titus.master.mesos.kubeapiserver.direct.KubeConstants;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeConstants;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.testkit.model.job.JobGenerator;
 import io.kubernetes.client.openapi.models.V1Toleration;


### PR DESCRIPTION
1. Add job runtime predictions as annotations on Pods (when present).
2. For pods handled by Fenzo, propagate opportunistic allocations to agents via Pod annotations (in addition to encoded into `ContainerInfo`).
3. for pods handled by kube-scheduler (which will take care of filling pod annotations), update tasks (context) with opportunistic scheduling allocations so the Titus API reflects opportunistic allocations on Pods.

cc @gabrielhartmann this will start adding opportunistic CPU allocations as a Pod annotation: `pod.metadata.annotations['opportunistic.scheduler.titus.netflix.com/cpu']`