### PR TITLE
Refactoring/spring mvc

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
@@ -18,7 +18,6 @@ package com.netflix.titus.api.json;
 
 import java.util.Collection;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -161,15 +160,6 @@ public class ObjectMappers {
 
     private static final ObjectMapper STORE = createStoreMapper();
     private static final ObjectMapper APP_SCALE_STORE = createAppScalePolicyMapper();
-
-    /**
-     * A helper marker class for use with {@link JsonView} annotation.
-     */
-    public static final class PublicView {
-    }
-
-    public static final class DebugView {
-    }
 
     public static ObjectMapper storeMapper() {
         return STORE;

--- a/titus-common-grpc-api/src/main/proto/netflix/titus/testing/sample_grpc_service.proto
+++ b/titus-common-grpc-api/src/main/proto/netflix/titus/testing/sample_grpc_service.proto
@@ -14,6 +14,17 @@ message SampleContainer {
     string stringValue = 1;
 }
 
+message SampleComplexMessage {
+
+    message SampleInternalMessage {
+        string intervalValue = 1;
+    }
+
+    map<string, string> mapValue = 1;
+
+    SampleInternalMessage internalMessage = 2;
+}
+
 // ----------------------------------------------------------------------------
 // Service
 

--- a/titus-common-server/build.gradle
+++ b/titus-common-server/build.gradle
@@ -32,5 +32,7 @@ dependencies {
     compile "io.grpc:grpc-services:${grpcVersion}"
 
     testCompile "io.grpc:grpc-testing:${grpcVersion}"
+    testCompile "org.springframework:spring-test:${springVersion}"
+    testCompile "org.springframework.boot:spring-boot-test-autoconfigure:${springBootVersion}"
     testCompile project(':titus-common-testkit')
 }

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/CommonExceptionHandlers.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/CommonExceptionHandlers.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.rest;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+@ControllerAdvice
+public class CommonExceptionHandlers {
+
+    @ExceptionHandler(value = {Exception.class})
+    public ResponseEntity<ErrorResponse> handleException(Exception e, WebRequest request) {
+        int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+
+        Throwable cause = e.getCause() == null ? e : e.getCause();
+
+        ErrorResponse errorResponse = ErrorResponse.newError(status, cause.getMessage())
+                .clientRequest(request)
+                .serverContext()
+                .exceptionContext(cause)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(errorResponse);
+    }
+}

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/ErrorResponse.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.endpoint.common.rest;
+package com.netflix.titus.runtime.endpoint.rest;
 
 import java.util.Collections;
 import java.util.Map;

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/ErrorResponses.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/ErrorResponses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.endpoint.common.rest;
+package com.netflix.titus.runtime.endpoint.rest;
 
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/RestAddOnsComponent.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/RestAddOnsComponent.java
@@ -16,36 +16,14 @@
 
 package com.netflix.titus.runtime.endpoint.rest;
 
-import com.netflix.titus.common.runtime.TitusRuntime;
-import com.netflix.titus.runtime.endpoint.metadata.SimpleHttpCallMetadataResolver;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import({
+        TitusProtobufHttpMessageConverter.class,
+        LocalSchedulerSpringResource.class,
+        FitSpringResource.class,
+})
 public class RestAddOnsComponent {
-
-    @Bean
-    public LocalSchedulerSpringResource getLocalSchedulerSpringResource(TitusRuntime titusRuntime) {
-        return new LocalSchedulerSpringResource(titusRuntime);
-    }
-
-    @Bean
-    public FitSpringResource getFitSpringResource(TitusRuntime titusRuntime) {
-        return new FitSpringResource(titusRuntime);
-    }
-
-    @Bean
-    public FilterRegistrationBean<SimpleHttpCallMetadataResolver.CallMetadataInterceptorFilter> CallMetadataInterceptorFilter(SimpleHttpCallMetadataResolver resolver) {
-        FilterRegistrationBean<SimpleHttpCallMetadataResolver.CallMetadataInterceptorFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new SimpleHttpCallMetadataResolver.CallMetadataInterceptorFilter(resolver));
-        registrationBean.addUrlPatterns("/*");
-        return registrationBean;
-    }
-
-    @Bean
-    public ProtobufHttpMessageConverter protobufHttpMessageConverter() {
-        return new ProtobufHttpMessageConverter();
-    }
 }

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/RestAddOnsComponent.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/RestAddOnsComponent.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @Import({
+        CommonExceptionHandlers.class,
         TitusProtobufHttpMessageConverter.class,
         LocalSchedulerSpringResource.class,
         FitSpringResource.class,

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/TitusProtobufHttpMessageConverter.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/TitusProtobufHttpMessageConverter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.rest;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.protobuf.Message;
+import com.netflix.titus.common.util.ProtobufExt;
+import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.common.util.jackson.CommonObjectMappers;
+import io.grpc.reflection.v1alpha.ErrorResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Controller
+public class TitusProtobufHttpMessageConverter implements HttpMessageConverter<Message> {
+
+    /**
+     * If 'debug' parameter is included in query, include error context when printing {@link ErrorResponse}.
+     */
+    static final String DEBUG_PARAM = "debug";
+
+    /**
+     * if 'fields' parameter is included in a query, only the requested field values are returned.
+     */
+    static final String FIELDS_PARAM = "fields";
+
+    private static final ObjectMapper MAPPER = CommonObjectMappers.protobufMapper();
+
+    private static final ObjectWriter COMPACT_ERROR_WRITER = MAPPER.writer().withView(CommonObjectMappers.PublicView.class);
+
+    private final HttpMessageConverter<Message> delegate;
+
+    @Inject
+    public TitusProtobufHttpMessageConverter() {
+        this.delegate = new ProtobufHttpMessageConverter();
+    }
+
+    @Override
+    public boolean canRead(Class<?> clazz, MediaType mediaType) {
+        return Message.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return Message.class.isAssignableFrom(clazz) && MediaType.APPLICATION_JSON.equals(mediaType);
+    }
+
+    @Override
+    public List<MediaType> getSupportedMediaTypes() {
+        return Collections.singletonList(MediaType.APPLICATION_JSON);
+    }
+
+    @Override
+    public Message read(Class<? extends Message> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+        return delegate.read(clazz, inputMessage);
+    }
+
+    @Override
+    public void write(Message entity, MediaType contentType, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+        HttpServletRequest httpServletRequest = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        outputMessage.getHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        // Unless 'debug' flag is set, do not write error context
+        if (entity instanceof ErrorResponse) {
+            String debug = httpServletRequest.getParameter(DEBUG_PARAM);
+            if (debug == null || debug.equalsIgnoreCase("false")) {
+                COMPACT_ERROR_WRITER.writeValue(outputMessage.getBody(), entity);
+                return;
+            }
+        }
+
+        List<String> fields = StringExt.splitByComma(httpServletRequest.getParameter(FIELDS_PARAM));
+        if (fields.isEmpty()) {
+            MAPPER.writeValue(outputMessage.getBody(), entity);
+        } else {
+            Message filteredEntity = ProtobufExt.copy(entity, new HashSet<>(fields));
+            MAPPER.writeValue(outputMessage.getBody(), filteredEntity);
+        }
+    }
+}

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/TitusProtobufHttpMessageConverter.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/rest/TitusProtobufHttpMessageConverter.java
@@ -92,15 +92,6 @@ public class TitusProtobufHttpMessageConverter implements HttpMessageConverter<M
 
         outputMessage.getHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
 
-        // Unless 'debug' flag is set, do not write error context
-        if (entity instanceof ErrorResponse) {
-            String debug = httpServletRequest.getParameter(DEBUG_PARAM);
-            if (debug == null || debug.equalsIgnoreCase("false")) {
-                COMPACT_ERROR_WRITER.writeValue(outputMessage.getBody(), entity);
-                return;
-            }
-        }
-
         List<String> fields = StringExt.splitByComma(httpServletRequest.getParameter(FIELDS_PARAM));
         if (fields.isEmpty()) {
             MAPPER.writeValue(outputMessage.getBody(), entity);

--- a/titus-common-server/src/test/java/com/netflix/titus/runtime/endpoint/rest/ErrorResponsesTest.java
+++ b/titus-common-server/src/test/java/com/netflix/titus/runtime/endpoint/rest/ErrorResponsesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.endpoint.common.rest;
+package com.netflix.titus.runtime.endpoint.rest;
 
 import java.io.IOException;
 import java.util.Enumeration;
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.PropertyBindingException;
-import com.netflix.titus.api.endpoint.v2.rest.representation.TitusJobType;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.containsString;
@@ -42,13 +41,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
+ *
  */
 public class ErrorResponsesTest {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    public void testBuildOfHttpRequest() throws Exception {
+    public void testBuildOfHttpRequest() {
         HttpServletRequest httpRequest = mock(HttpServletRequest.class);
         when(httpRequest.getServletPath()).thenReturn("/servletPath");
         when(httpRequest.getPathInfo()).thenReturn("/pathInfo");
@@ -60,13 +60,13 @@ public class ErrorResponsesTest {
     }
 
     @Test
-    public void testBuildOfServerContext() throws Exception {
+    public void testBuildOfServerContext() {
         Map<String, Object> serverContext = ErrorResponses.buildServerContext();
         assertThat(serverContext.isEmpty(), is(false));
     }
 
     @Test
-    public void testBuildOfGenericException() throws Exception {
+    public void testBuildOfGenericException() {
         List<ErrorResponses.StackTraceRepresentation> mappedError;
         try {
             throw new IOException("simulated I/O error");
@@ -78,7 +78,7 @@ public class ErrorResponsesTest {
 
     @Test
     public void testBuildOfJacksonWithInvalidType() throws Exception {
-        String badDocument = "{\"type\":\"myServiceType\"}";
+        String badDocument = "{\"value\":\"notANumber\"}";
 
         List<ErrorResponses.StackTraceRepresentation> mappedError = null;
         try {
@@ -91,10 +91,10 @@ public class ErrorResponsesTest {
         Map<String, Object> details = mappedError.get(0).getDetails();
         assertThat(details, is(notNullValue()));
 
-        assertThat(details.get("pathReference"), is(equalTo(this.getClass().getName() + "$MyService[\"type\"]")));
-        assertThat(details.get("targetType"), is(equalTo(TitusJobType.class.getName())));
+        assertThat(details.get("pathReference"), is(equalTo(this.getClass().getName() + "$MyService[\"value\"]")));
+        assertThat(details.get("targetType"), is(equalTo("int")));
         assertThat((String) details.get("errorLocation"), containsString("line: 1"));
-        assertThat(details.get("document"), is(equalTo("{\"type\":\"myServiceType\"}")));
+        assertThat(details.get("document"), is(equalTo("{\"value\":\"notANumber\"}")));
     }
 
     @Test
@@ -142,11 +142,12 @@ public class ErrorResponsesTest {
     }
 
     static class MyService {
-        private TitusJobType type;
+
+        private int value;
 
         @JsonCreator()
-        MyService(@JsonProperty("type") TitusJobType type) {
-            this.type = type;
+        MyService(@JsonProperty("value") int value) {
+            this.value = value;
         }
     }
 }

--- a/titus-common-server/src/test/java/com/netflix/titus/runtime/endpoint/rest/SampleSpringResource.java
+++ b/titus-common-server/src/test/java/com/netflix/titus/runtime/endpoint/rest/SampleSpringResource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.rest;
+
+import com.google.common.base.Preconditions;
+import com.netflix.titus.testing.SampleGrpcService.SampleComplexMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/test", produces = "application/json")
+public class SampleSpringResource {
+
+    private volatile SampleComplexMessage lastValue;
+
+    @GetMapping
+    public SampleComplexMessage getLast() {
+        return Preconditions.checkNotNull(lastValue);
+    }
+
+    @GetMapping(path = "/error")
+    public SampleComplexMessage getError() {
+        throw new IllegalStateException("simulated error");
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> postLast(@RequestBody SampleComplexMessage body) {
+        lastValue = body;
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/titus-common-server/src/test/java/com/netflix/titus/runtime/endpoint/rest/TitusProtobufHttpMessageConverterTest.java
+++ b/titus-common-server/src/test/java/com/netflix/titus/runtime/endpoint/rest/TitusProtobufHttpMessageConverterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.rest;
+
+import com.google.protobuf.util.JsonFormat;
+import com.netflix.titus.testing.SampleGrpcService.SampleComplexMessage;
+import com.netflix.titus.testing.SampleGrpcService.SampleComplexMessage.SampleInternalMessage;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest()
+@ContextConfiguration(classes = {SampleSpringResource.class, TitusProtobufHttpMessageConverter.class})
+public class TitusProtobufHttpMessageConverterTest {
+
+    private static final SampleComplexMessage SAMPLE_BASE = SampleComplexMessage.newBuilder()
+            .putMapValue("keyA", "valueA")
+            .setInternalMessage(SampleInternalMessage.newBuilder()
+                    .setIntervalValue("internaValue123")
+                    .build()
+            )
+            .build();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testSerializer() throws Exception {
+        doPost(SAMPLE_BASE);
+        SampleComplexMessage result = doGet("/test");
+        assertThat(result).isEqualTo(SAMPLE_BASE);
+    }
+
+    /**
+     * This is something protobuf {@link JsonFormat} does not do, but Jackson does, and some existing clients
+     * depend on it.
+     */
+    @Test
+    public void testEmptyMapsAreSerialized() throws Exception {
+        doPost(SampleComplexMessage.getDefaultInstance());
+        String result = doGetString("/test");
+        assertThat(result).contains("mapValue");
+    }
+
+    @Test
+    public void testFieldFilter() throws Exception {
+        doPost(SAMPLE_BASE);
+        SampleComplexMessage result = doGet("/test?fields=mapValue");
+        assertThat(result.getMapValueMap()).isEqualTo(SAMPLE_BASE.getMapValueMap());
+        assertThat(result.getInternalMessage()).isEqualTo(SampleInternalMessage.getDefaultInstance());
+    }
+
+    /**
+     * TODO Move ErrorResponse to titus-common-server submodule.
+     */
+    @Test
+    @Ignore
+    public void testErrors() throws Exception {
+        doGet("/error");
+    }
+
+    /**
+     * TODO Move ErrorResponse to titus-common-server submodule.
+     */
+    @Test
+    @Ignore
+    public void testDebug() throws Exception {
+        doGet("/error?debug=true");
+    }
+
+    private String doGetString(String baseUri) throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(baseUri);
+        MvcResult mvcResult = mockMvc.perform(requestBuilder)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn();
+
+        return mvcResult.getResponse().getContentAsString();
+    }
+
+    private SampleComplexMessage doGet(String baseUri) throws Exception {
+        SampleComplexMessage.Builder resultBuilder = SampleComplexMessage.newBuilder();
+        JsonFormat.parser().merge(doGetString(baseUri), resultBuilder);
+        return resultBuilder.build();
+    }
+
+    private void doPost(SampleComplexMessage sample) throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/test")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(JsonFormat.printer().print(sample));
+
+        mockMvc.perform(requestBuilder)
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andReturn();
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/util/jackson/CommonObjectMappers.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/jackson/CommonObjectMappers.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonStreamContext;
@@ -58,6 +59,15 @@ import rx.exceptions.Exceptions;
  * {@link ObjectMapper} with different configuration options.
  */
 public class CommonObjectMappers {
+
+    /**
+     * A helper marker class for use with {@link JsonView} annotation.
+     */
+    public static final class PublicView {
+    }
+
+    public static final class DebugView {
+    }
 
     private static final ObjectMapper JACKSON_DEFAULT = new ObjectMapper();
     private static final ObjectMapper DEFAULT = createDefaultMapper();

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/FederationRestComponent.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/endpoint/rest/FederationRestComponent.java
@@ -16,7 +16,7 @@
 
 package com.netflix.titus.federation.endpoint.rest;
 
-import com.netflix.titus.runtime.endpoint.common.rest.TitusExceptionHandler;
+import com.netflix.titus.runtime.endpoint.common.rest.TitusExceptionHandlers;
 import com.netflix.titus.runtime.endpoint.v3.rest.AutoScalingSpringResource;
 import com.netflix.titus.runtime.endpoint.v3.rest.HealthSpringResource;
 import com.netflix.titus.runtime.endpoint.v3.rest.JobManagementSpringResource;
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @Import({
-        TitusExceptionHandler.class,
+        TitusExceptionHandlers.class,
 
         HealthSpringResource.class,
         FederationSchedulerSpringResource.class,

--- a/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ApplicationSlaManagementResourceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ApplicationSlaManagementResourceTest.java
@@ -28,7 +28,7 @@ import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.common.util.archaius2.Archaius2Ext;
 import com.netflix.titus.master.config.MasterConfiguration;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
-import com.netflix.titus.runtime.endpoint.common.rest.ErrorResponse;
+import com.netflix.titus.runtime.endpoint.rest.ErrorResponse;
 import com.netflix.titus.runtime.endpoint.common.rest.JsonMessageReaderWriter;
 import com.netflix.titus.runtime.endpoint.common.rest.TitusExceptionMapper;
 import com.netflix.titus.testkit.data.core.ApplicationSlaSample;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/ErrorResponse.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/ErrorResponse.java
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
-import com.netflix.titus.api.json.ObjectMappers;
+import com.netflix.titus.common.util.jackson.CommonObjectMappers;
 import org.springframework.web.context.request.WebRequest;
 
 /**
@@ -37,16 +37,16 @@ public class ErrorResponse {
     public static final String SERVER_CONTEXT = "serverContext";
     public static final String EXCEPTION_CONTEXT = "exception";
 
-    @JsonView(ObjectMappers.PublicView.class)
+    @JsonView(CommonObjectMappers.PublicView.class)
     private final int statusCode;
 
-    @JsonView(ObjectMappers.PublicView.class)
+    @JsonView(CommonObjectMappers.PublicView.class)
     private final String message;
 
-    @JsonView(ObjectMappers.PublicView.class)
+    @JsonView(CommonObjectMappers.PublicView.class)
     private final Object errorDetails;
 
-    @JsonView(ObjectMappers.DebugView.class)
+    @JsonView(CommonObjectMappers.DebugView.class)
     private final Map<String, Object> errorContext;
 
     @JsonCreator

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriter.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriter.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.netflix.titus.api.json.ObjectMappers;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.jackson.CommonObjectMappers;
+import com.netflix.titus.runtime.endpoint.rest.ErrorResponse;
 
 @Provider
 @Produces(MediaType.APPLICATION_JSON)

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriter.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriter.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.netflix.titus.api.json.ObjectMappers;
 import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.common.util.jackson.CommonObjectMappers;
 
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
@@ -56,9 +57,9 @@ public class JsonMessageReaderWriter implements MessageBodyReader<Object>, Messa
      */
     static final String FIELDS_PARAM = "fields";
 
-    private static final ObjectMapper MAPPER = ObjectMappers.protobufMapper();
+    private static final ObjectMapper MAPPER = CommonObjectMappers.protobufMapper();
 
-    private static final ObjectWriter COMPACT_ERROR_WRITER = MAPPER.writer().withView(ObjectMappers.PublicView.class);
+    private static final ObjectWriter COMPACT_ERROR_WRITER = MAPPER.writer().withView(CommonObjectMappers.PublicView.class);
 
     private static final Validator VALIDATION = Validation.buildDefaultValidatorFactory().getValidator();
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/TitusExceptionHandlers.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/TitusExceptionHandlers.java
@@ -25,31 +25,16 @@ import com.netflix.titus.api.scheduler.service.SchedulerException;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.model.sanitizer.EntitySanitizerUtil;
 import com.netflix.titus.common.util.CollectionsExt;
-import org.springframework.http.HttpStatus;
+import com.netflix.titus.runtime.endpoint.rest.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 
 @ControllerAdvice
-public class TitusExceptionHandler {
+public class TitusExceptionHandlers {
 
     private static final int TOO_MANY_REQUESTS = 429;
-
-    @ExceptionHandler(value = {Exception.class})
-    protected ResponseEntity<ErrorResponse> handleException(Exception e, WebRequest request) {
-        int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-
-        Throwable cause = e.getCause() == null ? e : e.getCause();
-
-        ErrorResponse errorResponse = ErrorResponse.newError(status, cause.getMessage())
-                .clientRequest(request)
-                .serverContext()
-                .exceptionContext(cause)
-                .build();
-
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
-    }
 
     @ExceptionHandler(value = {TitusServiceException.class})
     protected ResponseEntity<ErrorResponse> handleException(TitusServiceException e, WebRequest request) {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/TitusExceptionMapper.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/common/rest/TitusExceptionMapper.java
@@ -36,6 +36,7 @@ import com.netflix.titus.api.scheduler.service.SchedulerException;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.model.sanitizer.EntitySanitizerUtil;
 import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.runtime.endpoint.rest.ErrorResponse;
 import com.sun.jersey.api.NotFoundException;
 import com.sun.jersey.api.ParamException;
 

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriterTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriterTest.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.netflix.titus.api.endpoint.v2.rest.representation.ApplicationSlaRepresentation;
 import com.netflix.titus.api.endpoint.v2.rest.representation.TierRepresentation;
+import com.netflix.titus.runtime.endpoint.rest.ErrorResponse;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Use the same protobuf -> JSON serialization mechanism as in the previous implementation, to minimize a risk of braking existing clients.
