### PR TITLE
Instance type federation routing

### DIFF
--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/CellInfoUtil.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/CellInfoUtil.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-class CellInfoUtil {
+public class CellInfoUtil {
     private static final Logger logger = LoggerFactory.getLogger(CellInfoUtil.class);
 
     private static final String CELL_HOST_DELIM = ";";
@@ -46,7 +46,7 @@ class CellInfoUtil {
      *
      * @return {@link Cell cells} indexed by their name
      */
-    static List<Cell> extractCellsFromCellSpecification(String cellsSpecification) {
+    public static List<Cell> extractCellsFromCellSpecification(String cellsSpecification) {
         return Arrays.stream(cellsSpecification.split(CELL_HOST_DELIM))
                 .filter(cellSpec -> cellSpec.contains(CELL_HOST_RULE_DELIM))
                 .map(cellSpec -> cellSpec.split(CELL_HOST_RULE_DELIM))
@@ -60,7 +60,7 @@ class CellInfoUtil {
      * Iteration on the returned {@link Map} will respect the order entries appear in the <tt>cellRoutingSpecification</tt>
      * argument.
      */
-    static Map<Cell, String> extractCellRoutingFromCellSpecification(List<Cell> cells, String cellRoutingSpecification) {
+    public static Map<Cell, String> extractCellRoutingFromCellSpecification(List<Cell> cells, String cellRoutingSpecification) {
         Map<String, Cell> cellsByName = CollectionsExt.indexBy(cells, Cell::getName);
 
         return Arrays.stream(cellRoutingSpecification.split(CELL_ROUTE_DELIM))

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/CellRouter.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/CellRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.federation.service;
+package com.netflix.titus.federation.service.router;
+
+import java.util.Optional;
 
 import com.netflix.titus.api.federation.model.Cell;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
@@ -31,5 +33,5 @@ public interface CellRouter {
      * @param jobDescriptor
      * @return Cell
      */
-    Cell routeKey(JobDescriptor jobDescriptor);
+    Optional<Cell> routeKey(JobDescriptor jobDescriptor);
 }

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/ChainCellRouter.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/ChainCellRouter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service.router;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+
+public class ChainCellRouter implements CellRouter {
+
+    private final List<CellRouter> cellRouters;
+
+    public ChainCellRouter(List<CellRouter> cellRouters) {
+        this.cellRouters = cellRouters;
+    }
+
+    @Override
+    public Optional<Cell> routeKey(JobDescriptor jobDescriptor) {
+        for (CellRouter cellRouter : cellRouters) {
+            Optional<Cell> result = cellRouter.routeKey(jobDescriptor);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/FallbackCellRouter.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/FallbackCellRouter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service.router;
+
+import java.util.Optional;
+
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.federation.service.CellInfoResolver;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+
+public class FallbackCellRouter implements CellRouter {
+
+    private final CellInfoResolver cellInfoResolver;
+
+    public FallbackCellRouter(CellInfoResolver cellInfoResolver) {
+        this.cellInfoResolver = cellInfoResolver;
+    }
+
+    @Override
+    public Optional<Cell> routeKey(JobDescriptor jobDescriptor) {
+        return Optional.of(cellInfoResolver.getDefault());
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/RoutingRuleSelector.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/RoutingRuleSelector.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service.router;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.common.util.Evaluators;
+import com.netflix.titus.federation.service.CellInfoResolver;
+import com.netflix.titus.federation.service.CellInfoUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RoutingRuleSelector {
+
+    private static final Logger logger = LoggerFactory.getLogger(RoutingRuleSelector.class);
+
+    private final Function<String, Map<Cell, Pattern>> compileRoutingPatterns;
+    private final Supplier<String> routingRulesSupplier;
+
+    RoutingRuleSelector(CellInfoResolver cellInfoResolver, Supplier<String> routingRulesSupplier) {
+        compileRoutingPatterns = Evaluators.memoizeLast((spec, lastCompiledPatterns) -> {
+            logger.info("Detected new routing rules, compiling them: {}", spec);
+            try {
+                List<Cell> cells = cellInfoResolver.resolve();
+                Map<Cell, String> cellRoutingRules = CellInfoUtil.extractCellRoutingFromCellSpecification(cells, spec);
+                return CollectionsExt.mapValues(cellRoutingRules, Pattern::compile, LinkedHashMap::new);
+            } catch (RuntimeException e) {
+                logger.error("Bad cell routing spec, ignoring: {}", spec);
+                return lastCompiledPatterns.orElseThrow(() -> e /* there is nothing to do if the first spec is bad */);
+            }
+        });
+        this.routingRulesSupplier = routingRulesSupplier;
+
+        // ensure the initial spec can be compiled or fail fast
+        compileRoutingPatterns.apply(routingRulesSupplier.get());
+    }
+
+    Optional<Cell> select(String routeKey, Predicate<Cell> filter) {
+        Map<Cell, Pattern> cellRoutingPatterns = compileRoutingPatterns.apply(routingRulesSupplier.get());
+
+        return cellRoutingPatterns.entrySet().stream()
+                .filter(entry -> filter.test(entry.getKey()))
+                .filter(entry -> entry.getValue().matcher(routeKey).matches())
+                .findFirst()
+                .map(Map.Entry::getKey);
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/SpecialInstanceTypeRouter.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/router/SpecialInstanceTypeRouter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service.router;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.federation.service.CellInfoResolver;
+import com.netflix.titus.federation.startup.TitusFederationConfiguration;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+
+/**
+ * {@link CellRouter} for special instance types, like GPU instances. With this selector the specialized and expensive
+ * instance types can be centralized in one cell, and all jobs that require these resources can be routed to it
+ * irrespective of to which application they belong to.
+ * <br/>
+ * If a job requires specialized resources, a cell which provides these resources is returned. If a job does not
+ * require specialized resources or none of the cells provide it, the result is {@link Optional#empty()}.
+ */
+public class SpecialInstanceTypeRouter implements CellRouter {
+
+    private static final String REGULAR = "regularInstanceType";
+    private static final String SPECIAL_INSTANCE_GPU = "gpu";
+
+    private final Function<JobDescriptor, String> instanceTypeRouteKeyResolver;
+    private final RoutingRuleSelector selector;
+
+    public SpecialInstanceTypeRouter(CellInfoResolver cellInfoResolver,
+                                     Function<JobDescriptor, String> instanceTypeRouteKeyResolver,
+                                     TitusFederationConfiguration federationConfiguration) {
+        this.instanceTypeRouteKeyResolver = instanceTypeRouteKeyResolver;
+        this.selector = new RoutingRuleSelector(cellInfoResolver, federationConfiguration::getInstanceTypeRoutingRules);
+
+    }
+
+    @Override
+    public Optional<Cell> routeKey(JobDescriptor jobDescriptor) {
+        return selector.select(instanceTypeRouteKeyResolver.apply(jobDescriptor), c -> true);
+    }
+
+    public static SpecialInstanceTypeRouter getGpuInstanceTypeRouter(CellInfoResolver cellInfoResolver,
+                                                                     TitusFederationConfiguration federationConfiguration) {
+        return new SpecialInstanceTypeRouter(
+                cellInfoResolver,
+                jobDescriptor -> jobDescriptor.getContainer().getResources().getGpu() > 0 ? SPECIAL_INSTANCE_GPU : REGULAR,
+                federationConfiguration
+        );
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationConfiguration.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationConfiguration.java
@@ -30,4 +30,7 @@ public interface TitusFederationConfiguration {
 
     @DefaultValue("cell1=(app1.*|app2.*);cell2=(.*)")
     String getRoutingRules();
+
+    @DefaultValue("cell1=(gpu.*)")
+    String getInstanceTypeRoutingRules();
 }

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayTest.java
@@ -39,6 +39,7 @@ import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.time.Clocks;
 import com.netflix.titus.common.util.time.TestClock;
 import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.federation.service.router.ApplicationCellRouter;
 import com.netflix.titus.federation.startup.GrpcConfiguration;
 import com.netflix.titus.federation.startup.TitusFederationConfiguration;
 import com.netflix.titus.grpc.protogen.Capacity;
@@ -123,7 +124,7 @@ public class AggregatingJobServiceGatewayTest {
         when(titusFederationConfiguration.getRoutingRules()).thenReturn("one=(app1.*|app2.*);two=(app3.*)");
 
         CellInfoResolver cellInfoResolver = new DefaultCellInfoResolver(titusFederationConfiguration);
-        DefaultCellRouter cellRouter = new DefaultCellRouter(cellInfoResolver, titusFederationConfiguration);
+        ApplicationCellRouter cellRouter = new ApplicationCellRouter(cellInfoResolver, titusFederationConfiguration);
         cells = cellInfoResolver.resolve();
         cellToServiceMap = ImmutableMap.of(
                 cells.get(0), cellOne,

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayWithSingleCellTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingJobServiceGatewayWithSingleCellTest.java
@@ -30,6 +30,7 @@ import com.netflix.titus.api.federation.model.Cell;
 import com.netflix.titus.api.model.Page;
 import com.netflix.titus.common.util.time.Clocks;
 import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.federation.service.router.ApplicationCellRouter;
 import com.netflix.titus.federation.startup.GrpcConfiguration;
 import com.netflix.titus.federation.startup.TitusFederationConfiguration;
 import com.netflix.titus.grpc.protogen.Job;
@@ -81,7 +82,7 @@ public class AggregatingJobServiceGatewayWithSingleCellTest {
         when(titusFederationConfiguration.getRoutingRules()).thenReturn("one=(app1.*|app2.*);two=(app3.*)");
 
         CellInfoResolver cellInfoResolver = new DefaultCellInfoResolver(titusFederationConfiguration);
-        DefaultCellRouter cellRouter = new DefaultCellRouter(cellInfoResolver, titusFederationConfiguration);
+        ApplicationCellRouter cellRouter = new ApplicationCellRouter(cellInfoResolver, titusFederationConfiguration);
         List<Cell> cells = cellInfoResolver.resolve();
         cellToServiceMap = ImmutableMap.of(cells.get(0), cell);
 

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/router/ChainCellRouterTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/router/ChainCellRouterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service.router;
+
+import java.util.Optional;
+
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class ChainCellRouterTest {
+
+    private static final Cell CELL_1 = new Cell("cell1", "cell.1");
+    private static final Cell CELL_2 = new Cell("cell2", "cell.2");
+
+    @Test
+    public void testChaining() {
+        CellRouter first = Mockito.mock(CellRouter.class);
+        CellRouter second = Mockito.mock(CellRouter.class);
+        ChainCellRouter chain = new ChainCellRouter(asList(first, second));
+
+        // Nothing matches
+        when(first.routeKey(any())).thenReturn(Optional.empty());
+        when(second.routeKey(any())).thenReturn(Optional.empty());
+        assertThat(chain.routeKey(JobDescriptor.getDefaultInstance())).isEmpty();
+
+        // First cell matches
+        when(first.routeKey(any())).thenReturn(Optional.of(CELL_1));
+        when(second.routeKey(any())).thenReturn(Optional.of(CELL_2));
+        assertThat(chain.routeKey(JobDescriptor.getDefaultInstance())).contains(CELL_1);
+
+        // Second cell matches
+        when(first.routeKey(any())).thenReturn(Optional.empty());
+        when(second.routeKey(any())).thenReturn(Optional.of(CELL_2));
+        assertThat(chain.routeKey(JobDescriptor.getDefaultInstance())).contains(CELL_2);
+    }
+}

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/router/RoutingRuleSelectorTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/router/RoutingRuleSelectorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service.router;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.federation.service.CellInfoResolver;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RoutingRuleSelectorTest {
+
+    private static final Cell CELL_1 = new Cell("cell1", "cell.1");
+    private static final Cell CELL_2 = new Cell("cell2", "cell.2");
+
+    private final CellInfoResolver cellInfoResolver = mock(CellInfoResolver.class);
+
+    @Before
+    public void setUp() {
+        when(cellInfoResolver.resolve()).thenReturn(asList(CELL_1, CELL_2));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testFailFast() {
+        new RoutingRuleSelector(cellInfoResolver, () -> null);
+    }
+
+    @Test
+    public void testParser() {
+        RoutingRuleSelector selector = new RoutingRuleSelector(cellInfoResolver, () -> "cell1=(app1.*);cell2=(app2.*)");
+        assertThat(selector.select("app1", cell -> true)).contains(CELL_1);
+        assertThat(selector.select("app2", cell -> true)).contains(CELL_2);
+    }
+
+    @Test
+    public void testReload() {
+        AtomicReference<String> rules = new AtomicReference<>("cell1=(app1.*);cell2=(app2.*)");
+        RoutingRuleSelector selector = new RoutingRuleSelector(cellInfoResolver, rules::get);
+        assertThat(selector.select("app1", cell -> true)).contains(CELL_1);
+        rules.set("cell1=(app2.*);cell2=(app1.*)");
+        assertThat(selector.select("app1", cell -> true)).contains(CELL_2);
+    }
+
+    @Test
+    public void testReloadFailure() {
+        AtomicReference<String> rules = new AtomicReference<>("cell1=(app1.*);cell2=(app2.*)");
+        RoutingRuleSelector selector = new RoutingRuleSelector(cellInfoResolver, rules::get);
+        assertThat(selector.select("app1", cell -> true)).contains(CELL_1);
+
+        rules.set(null);
+        assertThat(selector.select("app1", cell -> true)).contains(CELL_1);
+
+        rules.set("cell1=(app2.*);cell2=(app1.*)");
+        assertThat(selector.select("app1", cell -> true)).contains(CELL_2);
+    }
+}

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/router/SpecialInstanceTypeRouterTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/router/SpecialInstanceTypeRouterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.federation.service.router;
+
+import com.netflix.titus.api.federation.model.Cell;
+import com.netflix.titus.federation.service.CellInfoResolver;
+import com.netflix.titus.federation.startup.TitusFederationConfiguration;
+import com.netflix.titus.grpc.protogen.Container;
+import com.netflix.titus.grpc.protogen.ContainerResources;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SpecialInstanceTypeRouterTest {
+
+    private static final Cell CELL_1 = new Cell("cell1", "cell.1");
+    private static final Cell CELL_2 = new Cell("cell2", "cell.2");
+
+    private final CellInfoResolver cellInfoResolver = mock(CellInfoResolver.class);
+
+    private final TitusFederationConfiguration titusFederationConfiguration = mock(TitusFederationConfiguration.class);
+
+    private CellRouter router;
+
+    @Before
+    public void setUp() {
+        when(cellInfoResolver.resolve()).thenReturn(asList(CELL_1, CELL_2));
+        when(titusFederationConfiguration.getInstanceTypeRoutingRules()).thenReturn("cell2=(gpu.*)");
+        router = SpecialInstanceTypeRouter.getGpuInstanceTypeRouter(cellInfoResolver, titusFederationConfiguration);
+    }
+
+    @Test
+    public void testGpuCellIsSelectedForGpuJob() {
+        JobDescriptor gpuJobDescriptor = JobDescriptor.newBuilder()
+                .setContainer(Container.newBuilder()
+                        .setResources(ContainerResources.newBuilder()
+                                .setGpu(5)
+                        )
+                )
+                .build();
+        assertThat(router.routeKey(gpuJobDescriptor)).contains(CELL_2);
+    }
+
+    @Test
+    public void testNoCellIsSelectedForNonGpuJob() {
+        assertThat(router.routeKey(JobDescriptor.getDefaultInstance())).isEmpty();
+    }
+}


### PR DESCRIPTION
The primary goal for this PR is the ability to centralize special instances (GPU) in one cell, and route all jobs that need the special resources to that cell, irrespective of the application level routing rules.
