### PR TITLE
Pod terminated without a container is not processed by TitusMaster

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
@@ -37,7 +37,6 @@ import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.common.util.CollectionsExt;
-import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.rx.ReactorExt;
 import com.netflix.titus.common.util.tuple.Pair;
@@ -49,10 +48,11 @@ import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeApiServerIn
 import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodDeletedEvent;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodEvent;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodNotFoundEvent;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodPhase;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodUpdatedEvent;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodWrapper;
 import io.kubernetes.client.openapi.models.V1ContainerState;
 import io.kubernetes.client.openapi.models.V1Node;
-import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +64,7 @@ import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_OP
 import static com.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_NORMAL;
 import static com.netflix.titus.api.jobmanager.model.job.TaskStatus.REASON_TASK_KILLED;
 import static com.netflix.titus.common.util.Evaluators.acceptNotNull;
-import static com.netflix.titus.master.mesos.kubeapiserver.KubeConstants.NODE_ANNOTATION_PREFIX;
+import static com.netflix.titus.master.mesos.kubeapiserver.KubeConstants.TITUS_NODE_DOMAIN;
 
 /**
  * TODO Incorporate this into {@link DefaultV3JobOperations} once Fenzo is removed.
@@ -135,7 +135,19 @@ public class KubeNotificationProcessor {
     }
 
     private Mono<Void> handlePodUpdatedEvent(PodEvent event, Job job, Task task) {
-        if (event.getPod() == null || event.getPod().getStatus() == null || CollectionsExt.isNullOrEmpty(event.getPod().getStatus().getContainerStatuses())) {
+        // This is basic sanity check. If it fails, we have a major problem with pod state.
+        if (event.getPod() == null || event.getPod().getStatus() == null || event.getPod().getStatus().getPhase() == null) {
+            logger.warn("Pod notification with pod without status or phase set: taskId={}, pod={}", task.getId(), event.getPod());
+            return Mono.empty();
+        }
+
+        PodWrapper podWrapper = new PodWrapper(event.getPod());
+
+        if (!podWrapper.hasContainers()) {
+            if (podWrapper.getPodPhase() == PodPhase.FAILED || podWrapper.getPodPhase() == PodPhase.SUCCEEDED) {
+                return handleTerminalPodPhaseWithoutContainer(podWrapper, job, task);
+            }
+
             logger.info("Pod notification, but no container info yet: {}", task.getId());
             return Mono.empty();
         }
@@ -159,11 +171,11 @@ public class KubeNotificationProcessor {
             logger.debug("Ignoring 'waiting' state update, as task must stay in the 'Accepted' state here");
         } else if (containerState.getRunning() != null) {
             if (TaskState.isBefore(taskState, TaskState.Started)) {
-                return updateTaskStatus(event.getPod(), task, TaskState.Started, executorDetailsOpt, node);
+                return updateTaskStatus(podWrapper, task, TaskState.Started, executorDetailsOpt, node);
             }
         } else if (containerState.getTerminated() != null) {
             if (taskState != TaskState.Finished) {
-                return updateTaskStatus(event.getPod(), task, TaskState.Finished, executorDetailsOpt, node);
+                return updateTaskStatus(podWrapper, task, TaskState.Finished, executorDetailsOpt, node);
             }
         }
         return Mono.empty();
@@ -192,7 +204,31 @@ public class KubeNotificationProcessor {
         ));
     }
 
-    private Mono<Void> updateTaskStatus(V1Pod pod,
+    /**
+     * This is a special case, where a pod is in a terminal state, but no container was created for it.
+     */
+    private Mono<Void> handleTerminalPodPhaseWithoutContainer(PodWrapper podWrapper, Job job, Task task) {
+        TaskStatus.Builder taskStateBuilder = TaskStatus.newBuilder().withState(TaskState.Finished);
+        if (podWrapper.hasDeletionTimestamp()) {
+            taskStateBuilder
+                    .withReasonCode(TaskStatus.REASON_TASK_KILLED)
+                    .withReasonMessage("Kube pod notification");
+        } else {
+            taskStateBuilder
+                    .withReasonCode(TaskStatus.REASON_UNKNOWN)
+                    .withReasonMessage(podWrapper.getMessage());
+        }
+        Task updatedTask = JobFunctions.changeTaskStatus(task, taskStateBuilder.build());
+        return ReactorExt.toMono(v3JobOperations.updateTask(
+                task.getId(),
+                currentTask -> Optional.of(updatedTask),
+                V3JobOperations.Trigger.Kube,
+                "Kube pod notification",
+                KUBE_CALL_METADATA
+        ));
+    }
+
+    private Mono<Void> updateTaskStatus(PodWrapper pod,
                                         Task task,
                                         TaskState newTaskState,
                                         Optional<TitusExecutorDetails> executorDetailsOpt,
@@ -207,7 +243,7 @@ public class KubeNotificationProcessor {
     }
 
     @VisibleForTesting
-    static Task updateTaskStatus(V1Pod pod,
+    static Task updateTaskStatus(PodWrapper podWrapper,
                                  TaskState newTaskState,
                                  Optional<TitusExecutorDetails> executorDetailsOpt,
                                  Optional<V1Node> node,
@@ -223,15 +259,13 @@ public class KubeNotificationProcessor {
         } else {
             TaskStatus.Builder newStatusBuilder = TaskStatus.newBuilder().withState(TaskState.Finished);
 
-            boolean hasDeletionTimestamp = pod.getMetadata().getDeletionTimestamp() != null;
-
-            if ("failed".equalsIgnoreCase(pod.getStatus().getPhase())) {
+            if (podWrapper.getPodPhase() == PodPhase.FAILED) {
                 newStatusBuilder
-                        .withReasonCode(hasDeletionTimestamp ? REASON_TASK_KILLED : TaskStatus.REASON_FAILED)
-                        .withReasonMessage(Evaluators.getOrDefault(pod.getStatus().getMessage(), "Pod execution failed"));
+                        .withReasonCode(podWrapper.hasDeletionTimestamp() ? REASON_TASK_KILLED : TaskStatus.REASON_FAILED)
+                        .withReasonMessage(podWrapper.getMessage());
             } else {
                 newStatusBuilder
-                        .withReasonCode(hasDeletionTimestamp ? REASON_TASK_KILLED : REASON_NORMAL)
+                        .withReasonCode(podWrapper.hasDeletionTimestamp() ? REASON_TASK_KILLED : REASON_NORMAL)
                         .withReasonMessage("Kube pod notification");
             }
 
@@ -245,10 +279,10 @@ public class KubeNotificationProcessor {
                 .withStatusHistory(newHistory)
                 .build();
 
-        Task fixedTask = fillInMissingStates(pod, updatedTask);
+        Task fixedTask = fillInMissingStates(podWrapper, updatedTask);
         Task taskWithPlacementData = JobManagerUtil.attachPlacementData(fixedTask, executorDetailsOpt);
         Task taskWithNodeMetadata = node.map(n -> attachNodeMetadata(taskWithPlacementData, n)).orElse(taskWithPlacementData);
-        Task taskWithAnnotations = addMissingAttributes(pod, taskWithNodeMetadata);
+        Task taskWithAnnotations = addMissingAttributes(podWrapper, taskWithNodeMetadata);
 
         return taskWithAnnotations;
     }
@@ -261,18 +295,18 @@ public class KubeNotificationProcessor {
 
         Map<String, String> agentAttributes = new HashMap<>();
 
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "ami"), ami -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_AMI, ami));
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "asg"), asg -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_ASG, asg));
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "cluster"), cluster -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_CLUSTER, cluster));
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "id"), id -> {
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "ami"), ami -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_AMI, ami));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "asg"), asg -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_ASG, asg));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "cluster"), cluster -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_CLUSTER, cluster));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "id"), id -> {
             agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID, id);
             agentAttributes.put("agent.id", id);
         });
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "itype"), itype -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_ITYPE, itype));
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "region"), region -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_REGION, region));
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "res"), res -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_RES, res));
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "stack"), stack -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_STACK, stack));
-        acceptNotNull(annotations.get(NODE_ANNOTATION_PREFIX + "zone"), zone -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE, zone));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "itype"), itype -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_ITYPE, itype));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "region"), region -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_REGION, region));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "res"), res -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_RES, res));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "stack"), stack -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_STACK, stack));
+        acceptNotNull(annotations.get(TITUS_NODE_DOMAIN + "zone"), zone -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_AGENT_ZONE, zone));
 
         acceptNotNull(node.getMetadata().getName(), nodeName -> agentAttributes.put(TaskAttributes.TASK_ATTRIBUTES_KUBE_NODE_NAME, nodeName));
 
@@ -285,13 +319,13 @@ public class KubeNotificationProcessor {
                 .build();
     }
 
-    private static Task fillInMissingStates(V1Pod pod, Task task) {
+    private static Task fillInMissingStates(PodWrapper podWrapper, Task task) {
         TaskState currentState = task.getStatus().getState();
         if (currentState != TaskState.Started && currentState != TaskState.Finished) {
             return task;
         }
 
-        V1ContainerState containerState = KubeUtil.findContainerState(pod).orElse(null);
+        V1ContainerState containerState = podWrapper.findContainerState().orElse(null);
         if (containerState == null) {
             return task;
         }
@@ -305,7 +339,7 @@ public class KubeNotificationProcessor {
         } else { // TaskState.Finished
             if (containerState.getTerminated() == null || containerState.getTerminated().getStartedAt() == null) {
                 // It must be the case where the container setup failed.
-                return fillInMissingStatesForContainerSetupFailure(pod, task);
+                return fillInMissingStatesForContainerSetupFailure(podWrapper, task);
             }
             startAtTimestamp = containerState.getTerminated().getStartedAt().getMillis();
         }
@@ -336,19 +370,13 @@ public class KubeNotificationProcessor {
      * The {@link V1PodStatus#getPhase()} is failed, and the {@link V1PodStatus#getMessage()} contains details on
      * the nature of failure. There should be no launched state, so we add it to mark the container start attempt.
      */
-    private static Task fillInMissingStatesForContainerSetupFailure(V1Pod pod, Task task) {
+    private static Task fillInMissingStatesForContainerSetupFailure(PodWrapper podWrapper, Task task) {
         // Sanity check. Should never be true.
         if (JobFunctions.findTaskStatus(task, TaskState.Launched).isPresent()) {
             return task;
         }
 
-        long startAtTimestamp;
-        V1ContainerState containerState = KubeUtil.findContainerState(pod).orElse(null);
-        if (containerState != null && containerState.getTerminated() != null && containerState.getTerminated().getFinishedAt() != null) {
-            startAtTimestamp = containerState.getTerminated().getFinishedAt().getMillis();
-        } else {
-            startAtTimestamp = task.getStatus().getTimestamp();
-        }
+        long startAtTimestamp = podWrapper.findFinishedAt().orElse(task.getStatus().getTimestamp());
 
         List<TaskStatus> newStatusHistory = new ArrayList<>(task.getStatusHistory());
         newStatusHistory.add(TaskStatus.newBuilder()
@@ -372,13 +400,13 @@ public class KubeNotificationProcessor {
         return Optional.empty();
     }
 
-    private static Task addMissingAttributes(V1Pod pod, Task updatedTask) {
+    private static Task addMissingAttributes(PodWrapper podWrapper, Task updatedTask) {
         Map<String, String> taskContext = updatedTask.getTaskContext();
 
-        Optional<String> updatedCpus = getPodAnnotation(pod, KubeConstants.OPPORTUNISTIC_CPU_COUNT)
+        Optional<String> updatedCpus = podWrapper.findPodAnnotation(KubeConstants.OPPORTUNISTIC_CPU_COUNT)
                 .filter(cpus -> !cpus.equals(taskContext.get(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT)));
 
-        Optional<String> updatedAllocation = getPodAnnotation(pod, KubeConstants.OPPORTUNISTIC_ID)
+        Optional<String> updatedAllocation = podWrapper.findPodAnnotation(KubeConstants.OPPORTUNISTIC_ID)
                 .filter(id -> !id.equals(taskContext.get(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION)));
 
         if (!updatedCpus.isPresent() && !updatedAllocation.isPresent()) {
@@ -389,11 +417,5 @@ public class KubeNotificationProcessor {
         updatedCpus.ifPresent(cpus -> builder.addToTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_COUNT, cpus));
         updatedAllocation.ifPresent(id -> builder.addToTaskContext(TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION, id));
         return builder.build();
-    }
-
-    private static Optional<String> getPodAnnotation(V1Pod pod, String key) {
-        return Optional.ofNullable(pod.getMetadata())
-                .flatMap(meta -> Optional.ofNullable(meta.getAnnotations()))
-                .flatMap(annotations -> Optional.ofNullable(annotations.get(key)));
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeConstants.java
@@ -20,20 +20,13 @@ package com.netflix.titus.master.mesos.kubeapiserver;
  * Miscellaneous Kube constants.
  */
 public final class KubeConstants {
+
     private KubeConstants() {
     }
 
     /*
      * Standard node labels.
      */
-
-    /**
-     * Prefix used for legacy node attributes
-     *
-     * <em>Deprecated</em>: use a prefix that is a valid DNS name (rather than using Java package conventions)
-     */
-    @Deprecated
-    public static final String NODE_ANNOTATION_PREFIX = "com.netflix.titus.agent.attribute/";
 
     public static final String NODE_LABEL_REGION = "failure-domain.beta.kubernetes.io/region";
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodPhase.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodPhase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.model;
+
+import com.netflix.titus.common.util.ExceptionExt;
+import com.netflix.titus.common.util.StringExt;
+
+public enum PodPhase {
+
+    PENDING("Pending"),
+
+    RUNNING("Running"),
+
+    SUCCEEDED("Succeeded"),
+
+    FAILED("Failed"),
+
+    UNKNOWN("Unknown");
+
+    private final String phaseName;
+
+    PodPhase(String phaseName) {
+        this.phaseName = phaseName;
+    }
+
+    public String getPhaseName() {
+        return phaseName;
+    }
+
+    public static PodPhase parse(String phaseName) {
+        return ExceptionExt.doTry(() -> StringExt.parseEnumIgnoreCase(phaseName, PodPhase.class)).orElse(UNKNOWN);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodWrapper.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/model/PodWrapper.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.model;
+
+import java.util.Optional;
+
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import io.kubernetes.client.openapi.models.V1ContainerState;
+import io.kubernetes.client.openapi.models.V1Pod;
+
+/**
+ * A helper object for processing pod state. This implementation assumes that it is always at most one container
+ * in a pod.
+ */
+public class PodWrapper {
+
+    private final V1Pod v1Pod;
+
+    private volatile PodPhase podPhase;
+
+    public PodWrapper(V1Pod v1Pod) {
+        this.v1Pod = v1Pod;
+    }
+
+    public V1Pod getV1Pod() {
+        return v1Pod;
+    }
+
+    public PodPhase getPodPhase() {
+        if (podPhase == null) {
+            podPhase = v1Pod.getStatus() != null && v1Pod.getStatus().getPhase() != null
+                    ? PodPhase.parse(v1Pod.getStatus().getPhase())
+                    : PodPhase.UNKNOWN;
+        }
+        return podPhase;
+    }
+
+    public String getMessage() {
+        return v1Pod.getStatus() != null && v1Pod.getStatus().getMessage() != null
+                ? v1Pod.getStatus().getMessage()
+                : "<no message>";
+    }
+
+    public Optional<V1ContainerState> findContainerState() {
+        return KubeUtil.findContainerState(v1Pod);
+    }
+
+    public Optional<Long> findFinishedAt() {
+        V1ContainerState containerState = findContainerState().orElse(null);
+        if (containerState != null && containerState.getTerminated() != null && containerState.getTerminated().getFinishedAt() != null) {
+            return Optional.of(containerState.getTerminated().getFinishedAt().getMillis());
+        }
+        return Optional.empty();
+    }
+
+    public Optional<String> findPodAnnotation(String key) {
+        if (v1Pod.getMetadata() == null || v1Pod.getMetadata().getAnnotations() == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(v1Pod.getMetadata().getAnnotations().get(key));
+    }
+
+    public boolean hasContainers() {
+        return v1Pod.getStatus() != null && !CollectionsExt.isNullOrEmpty(v1Pod.getStatus().getContainerStatuses());
+    }
+
+    public boolean hasDeletionTimestamp() {
+        return v1Pod.getMetadata() != null && v1Pod.getMetadata().getDeletionTimestamp() != null;
+
+    }
+}


### PR DESCRIPTION
Instead, TitusMaster waits indefinitely for it to complete. Such pods
are not GCed, as they stay in the Accepted state in TitusMaster.
