### PR TITLE
Read archived data from active job/task tables if not found in the archive tables

### DIFF
--- a/titus-ext/cassandra/src/main/java/com/netflix/titus/ext/cassandra/store/CassandraJobStore.java
+++ b/titus-ext/cassandra/src/main/java/com/netflix/titus/ext/cassandra/store/CassandraJobStore.java
@@ -606,43 +606,62 @@ public class CassandraJobStore implements JobStore {
 
     @Override
     public Observable<Job<?>> retrieveArchivedJob(String jobId) {
-        return Observable.fromCallable((Callable<Statement>) () -> retrieveArchivedJobStatement.bind(jobId)).flatMap(statement -> execute(statement)
-                .map(resultSet -> {
-                    Row row = resultSet.one();
-                    if (row == null) {
-                        throw JobStoreException.jobDoesNotExist(jobId);
-                    }
-                    String value = row.getString(0);
-                    return (Job<?>) ObjectMappers.readValue(mapper, value, Job.class);
-                }));
+        Observable<Job> action = retrieveEntityById(jobId, Job.class, retrieveArchivedJobStatement)
+                .switchIfEmpty(retrieveEntityById(jobId, Job.class, retrieveActiveJobStatement))
+                .switchIfEmpty(Observable.error(JobStoreException.jobDoesNotExist(jobId)));
+        return (Observable) action;
     }
 
     @Override
     public Observable<Task> retrieveArchivedTasksForJob(String jobId) {
-        return Observable.fromCallable(() -> retrieveArchivedTaskIdsForJobStatement.bind(jobId).setFetchSize(Integer.MAX_VALUE))
-                .flatMap(retrieveActiveTaskIdsForJob -> execute(retrieveActiveTaskIdsForJob).flatMap(taskIdsResultSet -> {
-                    List<String> taskIds = taskIdsResultSet.all().stream().map(row -> row.getString(0)).collect(Collectors.toList());
-                    List<Observable<ResultSet>> observables = taskIds.stream().map(retrieveArchivedTaskStatement::bind).map(this::execute).collect(Collectors.toList());
-                    return Observable.merge(observables, getConcurrencyLimit()).flatMapIterable(tasksResultSet -> tasksResultSet.all().stream()
-                            .map(row -> row.getString(0))
-                            .map(value -> deserializeTask(value))
-                            .collect(Collectors.toList()));
-                }));
+        return retrieveArchivedTasksForJob(jobId, retrieveArchivedTaskIdsForJobStatement, retrieveArchivedTaskStatement)
+                .switchIfEmpty(retrieveArchivedTasksForJob(jobId, retrieveActiveTaskIdsForJobStatement, retrieveActiveTaskStatement));
+    }
+
+    private Observable<Task> retrieveArchivedTasksForJob(String jobId, PreparedStatement taskIdStatement, PreparedStatement taskStatement) {
+        return Observable.fromCallable(() -> taskIdStatement.bind(jobId).setFetchSize(Integer.MAX_VALUE))
+                .flatMap(retrieveActiveTaskIdsForJob ->
+                        execute(retrieveActiveTaskIdsForJob).flatMap(taskIdsResultSet -> {
+                            List<String> taskIds = taskIdsResultSet.all().stream().map(row -> row.getString(0)).collect(Collectors.toList());
+                            if (taskIds.isEmpty()) {
+                                return Observable.empty();
+                            }
+                            List<Observable<ResultSet>> observables = taskIds.stream()
+                                    .map(taskStatement::bind)
+                                    .map(this::execute)
+                                    .collect(Collectors.toList());
+                            return Observable.merge(observables, getConcurrencyLimit()).flatMapIterable(tasksResultSet -> tasksResultSet.all().stream()
+                                    .map(row -> row.getString(0))
+                                    .map(this::deserializeTask)
+                                    .collect(Collectors.toList()));
+                        }));
     }
 
     @Override
     public Observable<Task> retrieveArchivedTask(String taskId) {
-        return Observable.fromCallable((Callable<Statement>) () -> retrieveArchivedTaskStatement.bind(taskId))
-                .flatMap(statement -> execute(statement).flatMap(resultSet -> {
+        return retrieveEntityById(taskId, Task.class, retrieveArchivedTaskStatement)
+                .switchIfEmpty(retrieveEntityById(taskId, Task.class, retrieveActiveTaskStatement))
+                .switchIfEmpty(Observable.error(JobStoreException.taskDoesNotExist(taskId)));
+    }
+
+    private <T> Observable<T> retrieveEntityById(String id, Class<T> type, PreparedStatement preparedStatement) {
+        return Observable.fromCallable((Callable<Statement>) () -> preparedStatement.bind(id))
+                .flatMap(this::execute)
+                .flatMap(resultSet -> {
                     Row row = resultSet.one();
-                    if (row != null) {
-                        String value = row.getString(0);
-                        Task task = deserializeTask(value);
-                        return Observable.just(task);
-                    } else {
-                        return Observable.error(JobStoreException.taskDoesNotExist(taskId));
+                    if (row == null) {
+                        return Observable.empty();
                     }
-                }));
+                    try {
+                        String value = row.getString(0);
+                        if (type.isAssignableFrom(Task.class)) {
+                            return Observable.just((T) deserializeTask(value));
+                        }
+                        return Observable.just(ObjectMappers.readValue(mapper, value, type));
+                    } catch (Exception e) {
+                        return Observable.error(e);
+                    }
+                });
     }
 
     private Task deserializeTask(String value) {

--- a/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
+++ b/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
@@ -302,17 +302,37 @@ public class CassandraJobStoreTest {
 
     @Test
     public void testRetrieveArchivedJob() {
+        testRetrieveArchivedJob(true);
+    }
+
+    @Test
+    public void testRetrieveArchivedJobFromActiveTable() {
+        testRetrieveArchivedJob(false);
+    }
+
+    private void testRetrieveArchivedJob(boolean archive) {
         JobStore store = getJobStore();
         Job<BatchJobExt> job = createBatchJobObject();
         store.init().await();
         store.storeJob(job).await();
-        store.deleteJob(job).await();
+        if (archive) {
+            store.deleteJob(job).await();
+        }
         Job archivedJob = store.retrieveArchivedJob(job.getId()).toBlocking().first();
         assertThat(archivedJob).isEqualTo(job);
     }
 
     @Test
     public void testRetrieveArchivedTasksForJob() {
+        testRetrieveArchivedTasksForJob(true);
+    }
+
+    @Test
+    public void testRetrieveArchivedTasksForJobFromActiveTable() {
+        testRetrieveArchivedTasksForJob(false);
+    }
+
+    private void testRetrieveArchivedTasksForJob(boolean archive) {
         JobStore store = getJobStore();
         Job<BatchJobExt> job = createBatchJobObject();
         store.init().await();
@@ -321,13 +341,24 @@ public class CassandraJobStoreTest {
         assertThat(jobsAndErrors.getLeft().get(0)).isEqualTo(job);
         Task task = createTaskObject(job);
         store.storeTask(task).await();
-        store.deleteTask(task).await();
+        if (archive) {
+            store.deleteTask(task).await();
+        }
         Task archivedTask = store.retrieveArchivedTasksForJob(job.getId()).toBlocking().first();
         assertThat(archivedTask).isEqualTo(task);
     }
 
     @Test
     public void testRetrieveArchivedTask() {
+        testRetrieveArchivedTask(true);
+    }
+
+    @Test
+    public void testRetrieveArchivedTaskFromActiveTable() {
+        testRetrieveArchivedTask(false);
+    }
+
+    private void testRetrieveArchivedTask(boolean archive) {
         JobStore store = getJobStore();
         Job<BatchJobExt> job = createBatchJobObject();
         store.init().await();
@@ -336,7 +367,9 @@ public class CassandraJobStoreTest {
         assertThat(jobsAndErrors.getLeft().get(0)).isEqualTo(job);
         Task task = createTaskObject(job);
         store.storeTask(task).await();
-        store.deleteTask(task).await();
+        if (archive) {
+            store.deleteTask(task).await();
+        }
         Task archivedTask = store.retrieveArchivedTask(task.getId()).toBlocking().first();
         assertThat(archivedTask).isEqualTo(task);
     }


### PR DESCRIPTION
It is possible that finished jobs/tasks are not moved after they are finished to
the archive tables. This may happen during failover which happens
immediately after a job completes, but is not archived yet. To read such
abandoned items (which are ignored when loading active data into memory), we
have to make a fallback query in case the primary archive table does not contain
an entry.