### PR TITLE
Custom bucket path is an optional parameter

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/LogStorageInfos.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/LogStorageInfos.java
@@ -111,17 +111,12 @@ public final class LogStorageInfos {
     public static Optional<S3Bucket> findCustomS3Bucket(JobDescriptor<?> jobDescriptor) {
         Map<String, String> attributes = jobDescriptor.getContainer().getAttributes();
         String bucketName = attributes.get(JobAttributes.JOB_CONTAINER_ATTRIBUTE_S3_BUCKET_NAME);
-        String pathPrefix = attributes.get(JobAttributes.JOB_CONTAINER_ATTRIBUTE_S3_PATH_PREFIX);
-        if (StringExt.isEmpty(bucketName) || StringExt.isEmpty(pathPrefix)) {
-            return Optional.empty();
-        }
-        return Optional.of(new S3Bucket(bucketName));
+        return StringExt.isEmpty(bucketName) ? Optional.empty() : Optional.of(new S3Bucket(bucketName));
     }
 
     public static Optional<S3Bucket> findCustomS3Bucket(Task task) {
         Map<String, String> attributes = task.getTaskContext();
         String bucketName = attributes.get(TaskAttributes.TASK_ATTRIBUTE_S3_BUCKET_NAME);
-
         return StringExt.isEmpty(bucketName) ? Optional.empty() : Optional.of(new S3Bucket(bucketName));
     }
 

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/LogStorageInfosTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/LogStorageInfosTest.java
@@ -59,13 +59,14 @@ public class LogStorageInfosTest {
         // Empty context
         assertThat(LogStorageInfos.findCustomS3Bucket(JobGenerator.oneBatchJob())).isEmpty();
 
-        // Non empty context
-        Job customizedJob = newJob("bucketA", "pathB");
-        S3Bucket s3Bucket = LogStorageInfos.findCustomS3Bucket(customizedJob).orElse(null);
-        assertThat(s3Bucket.getBucketName()).isEqualTo("bucketA");
+        // Bucket only
+        Job bucketOnlyJob = newJob("bucketA", null);
+        assertThat(LogStorageInfos.findCustomS3Bucket(bucketOnlyJob)).contains(new S3Bucket("bucketA"));
 
-        String customPathPrefix = LogStorageInfos.findCustomPathPrefix(customizedJob.getJobDescriptor()).orElse(null);
-        assertThat(customPathPrefix).isEqualTo("pathB");
+        // Bucket and path
+        Job customizedJob = newJob("bucketA", "pathB");
+        assertThat(LogStorageInfos.findCustomS3Bucket(customizedJob)).contains(new S3Bucket("bucketA"));
+        assertThat(LogStorageInfos.findCustomPathPrefix(customizedJob.getJobDescriptor())).contains("pathB");
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue, where a custom S3 bucket validation logic would not run
when only a bucket, but not path is set.
