### PR TITLE
Support CallMetadata in Spring/REST

### DIFF
--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/metadata/spring/SpringCallMetadataInterceptor.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/metadata/spring/SpringCallMetadataInterceptor.java
@@ -43,6 +43,11 @@ public class SpringCallMetadataInterceptor extends HandlerInterceptorAdapter {
 
     @Override
     public boolean preHandle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler) throws Exception {
+        Authentication delegate = SecurityContextHolder.getContext().getAuthentication();
+        if (delegate == null) {
+            return super.preHandle(httpServletRequest, httpServletResponse, handler);
+        }
+
         String callReason = httpServletRequest.getHeader(CallMetadataHeaders.CALL_REASON_HEADER);
         String debugQueryParameter = httpServletRequest.getParameter(DEBUG_QUERY_PARAM);
         boolean debug = debugQueryParameter == null
@@ -50,7 +55,6 @@ public class SpringCallMetadataInterceptor extends HandlerInterceptorAdapter {
                 : Boolean.parseBoolean(debugQueryParameter);
 
         String originalCallerId = httpServletRequest.getHeader(CallMetadataHeaders.CALLER_ID_HEADER);
-        Authentication delegate = SecurityContextHolder.getContext().getAuthentication();
 
         Caller directCaller = getDirectCaller(httpServletRequest, delegate);
 

--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AppAutoScalingCallbackService.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AppAutoScalingCallbackService.java
@@ -15,10 +15,13 @@
  */
 package com.netflix.titus.ext.aws.appscale;
 
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import rx.Observable;
 
 public interface AppAutoScalingCallbackService {
-    Observable<ScalableTargetResourceInfo> getScalableTargetResourceInfo(String jobId);
+    Observable<ScalableTargetResourceInfo> getScalableTargetResourceInfo(String jobId, CallMetadata callMetadata);
 
-    Observable<ScalableTargetResourceInfo> setScalableTargetResourceInfo(String jobId, ScalableTargetResourceInfo scalableTargetResourceInfo);
+    Observable<ScalableTargetResourceInfo> setScalableTargetResourceInfo(String jobId,
+                                                                         ScalableTargetResourceInfo scalableTargetResourceInfo,
+                                                                         CallMetadata callMetadata);
 }

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingHealthService.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingHealthService.java
@@ -26,6 +26,7 @@ import com.netflix.titus.grpc.protogen.HealthCheckResponse;
 import com.netflix.titus.grpc.protogen.HealthCheckResponse.ServingStatus;
 import com.netflix.titus.grpc.protogen.HealthCheckResponse.Unknown;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.service.HealthService;
 import io.grpc.Status;
@@ -98,7 +99,7 @@ public class AggregatingHealthService implements HealthService {
     }
 
     private <STUB extends AbstractStub<STUB>> STUB wrap(STUB stub) {
-        return createWrappedStub(stub, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
+        return GrpcUtil.createWrappedStubWithResolver(stub, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
     }
 
     private interface ClientCall<T> extends BiConsumer<HealthGrpc.HealthStub, StreamObserver<T>> {

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingReactorMachineServiceStub.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingReactorMachineServiceStub.java
@@ -29,6 +29,7 @@ import com.netflix.titus.grpc.protogen.v4.MachineServiceGrpc;
 import com.netflix.titus.grpc.protogen.v4.MachineServiceGrpc.MachineServiceStub;
 import com.netflix.titus.grpc.protogen.v4.QueryRequest;
 import com.netflix.titus.runtime.connector.machine.ReactorMachineServiceStub;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import io.grpc.stub.StreamObserver;
 import reactor.core.publisher.Mono;
@@ -89,7 +90,7 @@ public class AggregatingReactorMachineServiceStub implements ReactorMachineServi
     }
 
     private MachineServiceStub wrap(MachineServiceStub client) {
-        return createWrappedStub(client, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
+        return GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
     }
 
     private interface ClientCall<T> extends BiConsumer<MachineServiceStub, StreamObserver<T>> {

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultAggregatingSchedulerService.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultAggregatingSchedulerService.java
@@ -25,6 +25,7 @@ import com.netflix.titus.federation.startup.GrpcConfiguration;
 import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.grpc.protogen.SchedulingResultEvent;
 import com.netflix.titus.grpc.protogen.SchedulingResultRequest;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import io.grpc.stub.StreamObserver;
 import reactor.core.publisher.Mono;
@@ -69,7 +70,7 @@ public class DefaultAggregatingSchedulerService implements AggregatingSchedulerS
     }
 
     private SchedulerServiceGrpc.SchedulerServiceStub wrap(SchedulerServiceGrpc.SchedulerServiceStub client) {
-        return createWrappedStub(client, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
+        return GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, grpcConfiguration.getRequestTimeoutMs());
     }
 
     private interface ClientCall<T> extends BiConsumer<SchedulerServiceGrpc.SchedulerServiceStub, StreamObserver<T>> {

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingAutoScalingTestBase.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AggregatingAutoScalingTestBase.java
@@ -59,11 +59,10 @@ public class AggregatingAutoScalingTestBase {
 
         GrpcConfiguration grpcConfiguration = mock(GrpcConfiguration.class);
         when(grpcConfiguration.getRequestTimeoutMs()).thenReturn(1000L);
-        final AnonymousCallMetadataResolver anonymousCallMetadataResolver = new AnonymousCallMetadataResolver();
         final AggregatingCellClient aggregatingCellClient = new AggregatingCellClient(connector);
 
-        service = new AggregatingAutoScalingService(connector, anonymousCallMetadataResolver, grpcConfiguration,
-                new AggregatingJobManagementServiceHelper(aggregatingCellClient, grpcConfiguration, anonymousCallMetadataResolver),
+        service = new AggregatingAutoScalingService(connector, grpcConfiguration,
+                new AggregatingJobManagementServiceHelper(aggregatingCellClient, grpcConfiguration),
                 aggregatingCellClient);
     }
 

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AutoScalingResourceTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/AutoScalingResourceTest.java
@@ -29,6 +29,8 @@ import com.netflix.titus.grpc.protogen.ScalingPolicyResult;
 import com.netflix.titus.grpc.protogen.TargetTrackingPolicyDescriptor;
 import com.netflix.titus.grpc.protogen.UpdatePolicyRequest;
 import com.netflix.titus.runtime.endpoint.common.rest.RestException;
+import com.netflix.titus.runtime.endpoint.metadata.AnonymousCallMetadataResolver;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.v3.rest.AutoScalingResource;
 import io.grpc.Status;
 import org.assertj.core.api.Assertions;
@@ -38,6 +40,8 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 
 public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
+
+    private final CallMetadataResolver callMetadataResolver = new AnonymousCallMetadataResolver();
 
     @Test
     public void getPoliciesFromTwoCells() {
@@ -54,7 +58,7 @@ public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
         cellOne.getServiceRegistry().addService(cellOneService);
         cellTwo.getServiceRegistry().addService(cellTwoService);
 
-        final AutoScalingResource autoScalingResource = new AutoScalingResource(service);
+        final AutoScalingResource autoScalingResource = new AutoScalingResource(service, callMetadataResolver);
         final GetPolicyResult allScalingPolicies = autoScalingResource.getAllScalingPolicies();
         assertThat(allScalingPolicies).isNotNull();
         assertThat(allScalingPolicies.getItemsCount()).isEqualTo(2);
@@ -73,7 +77,7 @@ public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
         cellOne.getServiceRegistry().addService(cellOneService);
         cellTwo.getServiceRegistry().addService(badCell);
 
-        final AutoScalingResource autoScalingResource = new AutoScalingResource(service);
+        final AutoScalingResource autoScalingResource = new AutoScalingResource(service, callMetadataResolver);
         autoScalingResource.getAllScalingPolicies();
         assertThat(false).isTrue();
     }
@@ -92,7 +96,7 @@ public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
         cellOne.getServiceRegistry().addService(cellOneService);
         cellTwo.getServiceRegistry().addService(cellTwoService);
 
-        final AutoScalingResource autoScalingResource = new AutoScalingResource(service);
+        final AutoScalingResource autoScalingResource = new AutoScalingResource(service, callMetadataResolver);
         final GetPolicyResult scalingPolicyForJob = autoScalingResource.getScalingPolicyForJob(JOB_2);
         assertThat(scalingPolicyForJob).isNotNull();
         assertThat(scalingPolicyForJob.getItemsCount()).isEqualTo(1);
@@ -113,7 +117,7 @@ public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
         cellOne.getServiceRegistry().addService(cellOneService);
         cellTwo.getServiceRegistry().addService(cellTwoService);
 
-        final AutoScalingResource autoScalingResource = new AutoScalingResource(service);
+        final AutoScalingResource autoScalingResource = new AutoScalingResource(service, callMetadataResolver);
         final GetPolicyResult scalingPolicy = autoScalingResource.getScalingPolicy(POLICY_2);
         assertThat(scalingPolicy.getItemsCount()).isEqualTo(1);
         assertThat(scalingPolicy.getItems(0).getId().getId()).isEqualTo(POLICY_2);
@@ -142,7 +146,7 @@ public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
         cellTwo.getServiceRegistry().addService(cellTwoService);
         cellTwo.getServiceRegistry().addService(cellTwoJobsService);
 
-        final AutoScalingResource autoScalingResource = new AutoScalingResource(service);
+        final AutoScalingResource autoScalingResource = new AutoScalingResource(service, callMetadataResolver);
         final ScalingPolicyID scalingPolicyID = autoScalingResource.setScalingPolicy(PutPolicyRequest.newBuilder().setJobId(JOB_2).build());
 
         assertThat(scalingPolicyID).isNotNull();
@@ -190,7 +194,7 @@ public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
         cellTwo.getServiceRegistry().addService(cellTwoService);
         cellTwo.getServiceRegistry().addService(cellTwoJobsService);
 
-        final AutoScalingResource autoScalingResource = new AutoScalingResource(service);
+        final AutoScalingResource autoScalingResource = new AutoScalingResource(service, callMetadataResolver);
         final ScalingPolicyID scalingPolicyId = autoScalingResource.setScalingPolicy(PutPolicyRequest.newBuilder().setJobId(JOB_2).build());
 
         assertThat(scalingPolicyId).isNotNull();
@@ -210,6 +214,4 @@ public class AutoScalingResourceTest extends AggregatingAutoScalingTestBase {
         assertThat(scalingPolicyForJobResult.getItemsCount()).isEqualTo(1);
         assertThat(scalingPolicyForJobResult.getItems(0).getJobId()).isEqualTo(JOB_2);
     }
-
-
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultAutoScalingService.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultAutoScalingService.java
@@ -21,10 +21,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.google.protobuf.Empty;
-import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
-import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
-import com.netflix.titus.runtime.service.AutoScalingService;
-import com.netflix.titus.runtime.connector.GrpcClientConfiguration;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc.AutoScalingServiceStub;
 import com.netflix.titus.grpc.protogen.DeletePolicyRequest;
 import com.netflix.titus.grpc.protogen.GetPolicyResult;
@@ -32,6 +29,9 @@ import com.netflix.titus.grpc.protogen.JobId;
 import com.netflix.titus.grpc.protogen.PutPolicyRequest;
 import com.netflix.titus.grpc.protogen.ScalingPolicyID;
 import com.netflix.titus.grpc.protogen.UpdatePolicyRequest;
+import com.netflix.titus.runtime.connector.GrpcClientConfiguration;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
+import com.netflix.titus.runtime.service.AutoScalingService;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,64 +50,60 @@ public class DefaultAutoScalingService implements AutoScalingService {
 
     private final GrpcClientConfiguration configuration;
     private AutoScalingServiceStub client;
-    private final CallMetadataResolver callMetadataResolver;
 
     @Inject
-    public DefaultAutoScalingService(GrpcClientConfiguration configuration,
-                                     AutoScalingServiceStub client,
-                                     CallMetadataResolver callMetadataResolver) {
+    public DefaultAutoScalingService(GrpcClientConfiguration configuration, AutoScalingServiceStub client) {
         this.configuration = configuration;
         this.client = client;
-        this.callMetadataResolver = callMetadataResolver;
     }
 
     @Override
-    public Observable<GetPolicyResult> getJobScalingPolicies(JobId request) {
+    public Observable<GetPolicyResult> getJobScalingPolicies(JobId request, CallMetadata callMetadata) {
         logger.info("Getting policy for JobId {}", request);
         return createRequestObservable(emitter -> {
             StreamObserver<GetPolicyResult> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).getJobScalingPolicies(request, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeout()).getJobScalingPolicies(request, streamObserver);
         }, configuration.getRequestTimeout());
     }
 
     @Override
-    public Observable<ScalingPolicyID> setAutoScalingPolicy(PutPolicyRequest request) {
+    public Observable<ScalingPolicyID> setAutoScalingPolicy(PutPolicyRequest request, CallMetadata callMetadata) {
         logger.info("Setting policy request {}", request);
         return createRequestObservable(emitter -> {
             StreamObserver<ScalingPolicyID> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).setAutoScalingPolicy(request, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeout()).setAutoScalingPolicy(request, streamObserver);
         }, configuration.getRequestTimeout());
     }
 
     @Override
-    public Observable<GetPolicyResult> getScalingPolicy(ScalingPolicyID request) {
+    public Observable<GetPolicyResult> getScalingPolicy(ScalingPolicyID request, CallMetadata callMetadata) {
         return createRequestObservable(emitter -> {
             StreamObserver<GetPolicyResult> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).getScalingPolicy(request, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeout()).getScalingPolicy(request, streamObserver);
         }, configuration.getRequestTimeout());
     }
 
     @Override
-    public Observable<GetPolicyResult> getAllScalingPolicies() {
+    public Observable<GetPolicyResult> getAllScalingPolicies(CallMetadata callMetadata) {
         return createRequestObservable(emitter -> {
             StreamObserver<GetPolicyResult> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).getAllScalingPolicies(Empty.getDefaultInstance(), streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeout()).getAllScalingPolicies(Empty.getDefaultInstance(), streamObserver);
         }, configuration.getRequestTimeout());
     }
 
     @Override
-    public Completable deleteAutoScalingPolicy(DeletePolicyRequest request) {
+    public Completable deleteAutoScalingPolicy(DeletePolicyRequest request, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).deleteAutoScalingPolicy(request, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeout()).deleteAutoScalingPolicy(request, streamObserver);
         }, configuration.getRequestTimeout());
     }
 
     @Override
-    public Completable updateAutoScalingPolicy(UpdatePolicyRequest request) {
+    public Completable updateAutoScalingPolicy(UpdatePolicyRequest request, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).updateAutoScalingPolicy(request, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeout()).updateAutoScalingPolicy(request, streamObserver);
         }, configuration.getRequestTimeout());
     }
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultHealthService.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultHealthService.java
@@ -23,6 +23,7 @@ import com.netflix.titus.grpc.protogen.HealthCheckRequest;
 import com.netflix.titus.grpc.protogen.HealthCheckResponse;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
 import com.netflix.titus.runtime.connector.GrpcClientConfiguration;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.service.HealthService;
 import io.grpc.stub.StreamObserver;
@@ -49,7 +50,7 @@ public class DefaultHealthService implements HealthService {
     public Observable<HealthCheckResponse> check(HealthCheckRequest request) {
         return createRequestObservable(emitter -> {
             StreamObserver<HealthCheckResponse> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).check(request, streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).check(request, streamObserver);
         }, configuration.getRequestTimeout());
     }
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultSchedulerService.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/DefaultSchedulerService.java
@@ -34,6 +34,7 @@ import com.netflix.titus.grpc.protogen.SystemSelector;
 import com.netflix.titus.grpc.protogen.SystemSelectorId;
 import com.netflix.titus.grpc.protogen.SystemSelectorUpdate;
 import com.netflix.titus.grpc.protogen.SystemSelectors;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcSchedulerModelConverters;
 import io.grpc.stub.StreamObserver;
@@ -69,7 +70,7 @@ public class DefaultSchedulerService implements SchedulerService {
     public Observable<SystemSelectors> getSystemSelectors() {
         return createRequestObservable(emitter -> {
             StreamObserver<SystemSelectors> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).getSystemSelectors(Empty.getDefaultInstance(), streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).getSystemSelectors(Empty.getDefaultInstance(), streamObserver);
         }, configuration.getRequestTimeout());
     }
 
@@ -77,7 +78,7 @@ public class DefaultSchedulerService implements SchedulerService {
     public Observable<SystemSelector> getSystemSelector(String id) {
         return createRequestObservable(emitter -> {
             StreamObserver<SystemSelector> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).getSystemSelector(SystemSelectorId.newBuilder().setId(id).build(), streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).getSystemSelector(SystemSelectorId.newBuilder().setId(id).build(), streamObserver);
         }, configuration.getRequestTimeout());
     }
 
@@ -91,7 +92,7 @@ public class DefaultSchedulerService implements SchedulerService {
 
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).createSystemSelector(systemSelector, streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).createSystemSelector(systemSelector, streamObserver);
         }, configuration.getRequestTimeout());
     }
 
@@ -106,7 +107,7 @@ public class DefaultSchedulerService implements SchedulerService {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = createEmptyClientResponseObserver(emitter);
             SystemSelectorUpdate systemSelectorUpdate = SystemSelectorUpdate.newBuilder().setId(id).setSystemSelector(systemSelector).build();
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).updateSystemSelector(systemSelectorUpdate, streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).updateSystemSelector(systemSelectorUpdate, streamObserver);
         }, configuration.getRequestTimeout());
     }
 
@@ -114,7 +115,7 @@ public class DefaultSchedulerService implements SchedulerService {
     public Completable deleteSystemSelector(String id) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).deleteSystemSelector(SystemSelectorId.newBuilder().setId(id).build(), streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).deleteSystemSelector(SystemSelectorId.newBuilder().setId(id).build(), streamObserver);
         }, configuration.getRequestTimeout());
     }
 
@@ -122,7 +123,7 @@ public class DefaultSchedulerService implements SchedulerService {
     public Observable<SchedulingResultEvent> findLastSchedulingResult(String taskId) {
         return createRequestObservable(emitter -> {
             StreamObserver<SchedulingResultEvent> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).getSchedulingResult(SchedulingResultRequest.newBuilder().setTaskId(taskId).build(), streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).getSchedulingResult(SchedulingResultRequest.newBuilder().setTaskId(taskId).build(), streamObserver);
         }, configuration.getRequestTimeout());
     }
 
@@ -130,7 +131,7 @@ public class DefaultSchedulerService implements SchedulerService {
     public Observable<SchedulingResultEvent> observeSchedulingResults(String taskId) {
         return createRequestObservable(emitter -> {
             StreamObserver<SchedulingResultEvent> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver).observeSchedulingResults(SchedulingResultRequest.newBuilder().setTaskId(taskId).build(), streamObserver);
+            GrpcUtil.createWrappedStubWithResolver(client, callMetadataResolver).observeSchedulingResults(SchedulingResultRequest.newBuilder().setTaskId(taskId).build(), streamObserver);
         });
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/supervisor/client/GrpcSupervisorClient.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/supervisor/client/GrpcSupervisorClient.java
@@ -55,7 +55,7 @@ public class GrpcSupervisorClient implements SupervisorClient {
     public Observable<MasterInstances> getMasterInstances() {
         return createRequestObservable(emitter -> {
             StreamObserver<MasterInstances> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).getMasterInstances(Empty.getDefaultInstance(), streamObserver);
+            createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).getMasterInstances(Empty.getDefaultInstance(), streamObserver);
         }, configuration.getRequestTimeout());
     }
 
@@ -63,7 +63,7 @@ public class GrpcSupervisorClient implements SupervisorClient {
     public Observable<MasterInstance> getMasterInstance(String instanceId) {
         return createRequestObservable(emitter -> {
             StreamObserver<MasterInstance> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout())
+            createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout())
                     .getMasterInstance(MasterInstanceId.newBuilder().setInstanceId(instanceId).build(), streamObserver);
         }, configuration.getRequestTimeout());
     }
@@ -72,7 +72,7 @@ public class GrpcSupervisorClient implements SupervisorClient {
     public Observable<SupervisorEvent> observeEvents() {
         return createRequestObservable(emitter -> {
             StreamObserver<SupervisorEvent> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver).observeEvents(Empty.getDefaultInstance(), streamObserver);
+            createWrappedStubWithResolver(client, callMetadataResolver).observeEvents(Empty.getDefaultInstance(), streamObserver);
         });
     }
 
@@ -80,7 +80,7 @@ public class GrpcSupervisorClient implements SupervisorClient {
     public Completable stopBeingLeader() {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeout()).stopBeingLeader(Empty.getDefaultInstance(), streamObserver);
+            createWrappedStubWithResolver(client, callMetadataResolver, configuration.getRequestTimeout()).stopBeingLeader(Empty.getDefaultInstance(), streamObserver);
         }, configuration.getRequestTimeout());
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/TitusPaginationUtils.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/TitusPaginationUtils.java
@@ -20,13 +20,11 @@ import java.util.Collections;
 
 import com.google.common.collect.ImmutableMap;
 import com.netflix.titus.api.model.callmetadata.CallMetadata;
-import com.netflix.titus.api.model.callmetadata.CallMetadataConstants;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.runtime.SystemLogEvent;
 import com.netflix.titus.common.runtime.SystemLogService;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.grpc.protogen.Page;
-import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import io.grpc.stub.StreamObserver;
 
 /**
@@ -47,18 +45,6 @@ public class TitusPaginationUtils {
             return false;
         }
         return true;
-    }
-
-    public static void logPageNumberUsage(SystemLogService systemLog,
-                                          CallMetadataResolver metadataResolver,
-                                          String component,
-                                          String apiName,
-                                          Page page) {
-        if (page.getPageNumber() == 0 || StringExt.isNotEmpty(page.getCursor())) {
-            return;
-        }
-        CallMetadata callMetadata = metadataResolver.resolve().orElse(CallMetadataConstants.UNDEFINED_CALL_METADATA);
-        logPageNumberUsage(systemLog, callMetadata, component, apiName, page);
     }
 
     public static void logPageNumberUsage(SystemLogService systemLog,

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementSpringResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementSpringResource.java
@@ -92,51 +92,68 @@ public class JobManagementSpringResource {
     @ApiOperation("Update an existing job's capacity")
     @PutMapping(path = "/jobs/{jobId}/instances")
     public ResponseEntity<Void> setInstances(@PathVariable("jobId") String jobId,
-                                             @RequestBody Capacity capacity) {
+                                             @RequestBody Capacity capacity,
+                                             CallMetadataAuthentication authentication) {
         JobCapacityUpdate jobCapacityUpdate = JobCapacityUpdate.newBuilder()
                 .setJobId(jobId)
                 .setCapacity(capacity)
                 .build();
-        return Responses.fromCompletable(jobServiceGateway.updateJobCapacity(jobCapacityUpdate), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(
+                jobServiceGateway.updateJobCapacity(jobCapacityUpdate, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Update an existing job's capacity. Optional attributes min / max / desired are supported.")
     @PutMapping(path = "/jobs/{jobId}/capacityAttributes")
     public ResponseEntity<Void> setCapacityWithOptionalAttributes(@PathVariable("jobId") String jobId,
-                                                                  @RequestBody JobCapacityWithOptionalAttributes capacity) {
+                                                                  @RequestBody JobCapacityWithOptionalAttributes capacity,
+                                                                  CallMetadataAuthentication authentication) {
         JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes = JobCapacityUpdateWithOptionalAttributes.newBuilder()
                 .setJobId(jobId)
                 .setJobCapacityWithOptionalAttributes(capacity)
                 .build();
-        return Responses.fromCompletable(jobServiceGateway.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(
+                jobServiceGateway.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Update an existing job's processes")
     @PutMapping(path = "/jobs/{jobId}/jobprocesses")
     public ResponseEntity<Void> setJobProcesses(@PathVariable("jobId") String jobId,
-                                                @RequestBody ServiceJobSpec.ServiceJobProcesses jobProcesses) {
+                                                @RequestBody ServiceJobSpec.ServiceJobProcesses jobProcesses,
+                                                CallMetadataAuthentication authentication) {
         JobProcessesUpdate jobProcessesUpdate = JobProcessesUpdate.newBuilder()
                 .setJobId(jobId)
                 .setServiceJobProcesses(jobProcesses)
                 .build();
-        return Responses.fromCompletable(jobServiceGateway.updateJobProcesses(jobProcessesUpdate), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(
+                jobServiceGateway.updateJobProcesses(jobProcessesUpdate, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Update job's disruption budget")
     @PutMapping(path = "/jobs/{jobId}/disruptionBudget")
     public ResponseEntity<Void> setJobDisruptionBudget(@PathVariable("jobId") String jobId,
-                                                       @RequestBody JobDisruptionBudget jobDisruptionBudget) {
+                                                       @RequestBody JobDisruptionBudget jobDisruptionBudget,
+                                                       CallMetadataAuthentication authentication) {
         JobDisruptionBudgetUpdate request = JobDisruptionBudgetUpdate.newBuilder()
                 .setJobId(jobId)
                 .setDisruptionBudget(jobDisruptionBudget)
                 .build();
-        return Responses.fromVoidMono(jobServiceGateway.updateJobDisruptionBudget(request), HttpStatus.NO_CONTENT);
+        return Responses.fromVoidMono(
+                jobServiceGateway.updateJobDisruptionBudget(request, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Update attributes of a job")
     @PutMapping(path = "/jobs/{jobId}/attributes")
     public ResponseEntity<Void> updateJobAttributes(@PathVariable("jobId") String jobId,
-                                                    @RequestBody JobAttributesUpdate request) {
+                                                    @RequestBody JobAttributesUpdate request,
+                                                    CallMetadataAuthentication authentication) {
         JobAttributesUpdate sanitizedRequest;
         if (request.getJobId().isEmpty()) {
             sanitizedRequest = request.toBuilder().setJobId(jobId).build();
@@ -146,12 +163,17 @@ public class JobManagementSpringResource {
             }
             sanitizedRequest = request;
         }
-        return Responses.fromVoidMono(jobServiceGateway.updateJobAttributes(sanitizedRequest), HttpStatus.NO_CONTENT);
+        return Responses.fromVoidMono(
+                jobServiceGateway.updateJobAttributes(sanitizedRequest, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Delete attributes of a job with the specified key names")
     @DeleteMapping(path = "/jobs/{jobId}/attributes")
-    public ResponseEntity<Void> deleteJobAttributes(@PathVariable("jobId") String jobId, @RequestParam("keys") String delimitedKeys) {
+    public ResponseEntity<Void> deleteJobAttributes(@PathVariable("jobId") String jobId,
+                                                    @RequestParam("keys") String delimitedKeys,
+                                                    CallMetadataAuthentication authentication) {
         if (Strings.isNullOrEmpty(delimitedKeys)) {
             throw TitusServiceException.invalidArgument("Path parameter 'keys' cannot be empty");
         }
@@ -165,33 +187,42 @@ public class JobManagementSpringResource {
                 .setJobId(jobId)
                 .addAllKeys(keys)
                 .build();
-        return Responses.fromVoidMono(jobServiceGateway.deleteJobAttributes(request), HttpStatus.NO_CONTENT);
+        return Responses.fromVoidMono(
+                jobServiceGateway.deleteJobAttributes(request, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Update an existing job's status")
     @PostMapping(path = "/jobs/{jobId}/enable")
-    public ResponseEntity<Void> enableJob(@PathVariable("jobId") String jobId) {
+    public ResponseEntity<Void> enableJob(@PathVariable("jobId") String jobId, CallMetadataAuthentication authentication) {
         JobStatusUpdate jobStatusUpdate = JobStatusUpdate.newBuilder()
                 .setId(jobId)
                 .setEnableStatus(true)
                 .build();
-        return Responses.fromCompletable(jobServiceGateway.updateJobStatus(jobStatusUpdate), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(
+                jobServiceGateway.updateJobStatus(jobStatusUpdate, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Update an existing job's status")
     @PostMapping(path = "/jobs/{jobId}/disable")
-    public ResponseEntity<Void> disableJob(@PathVariable("jobId") String jobId) {
+    public ResponseEntity<Void> disableJob(@PathVariable("jobId") String jobId, CallMetadataAuthentication authentication) {
         JobStatusUpdate jobStatusUpdate = JobStatusUpdate.newBuilder()
                 .setId(jobId)
                 .setEnableStatus(false)
                 .build();
-        return Responses.fromCompletable(jobServiceGateway.updateJobStatus(jobStatusUpdate), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(
+                jobServiceGateway.updateJobStatus(jobStatusUpdate, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Find the job with the specified ID")
     @GetMapping(path = "/jobs/{jobId}", produces = org.springframework.http.MediaType.APPLICATION_JSON_VALUE)
-    public Job findJob(@PathVariable("jobId") String jobId) {
-        return Responses.fromSingleValueObservable(jobServiceGateway.findJob(jobId));
+    public Job findJob(@PathVariable("jobId") String jobId, CallMetadataAuthentication authentication) {
+        return Responses.fromSingleValueObservable(jobServiceGateway.findJob(jobId, authentication.getCallMetadata()));
     }
 
     @ApiOperation("Find jobs")
@@ -203,19 +234,19 @@ public class JobManagementSpringResource {
         queryBuilder.setPage(page);
         queryBuilder.putAllFilteringCriteria(RestUtil.getFilteringCriteria(queryParameters));
         queryBuilder.addAllFields(RestUtil.getFieldsParameter(queryParameters));
-        return Responses.fromSingleValueObservable(jobServiceGateway.findJobs(queryBuilder.build()));
+        return Responses.fromSingleValueObservable(jobServiceGateway.findJobs(queryBuilder.build(), authentication.getCallMetadata()));
     }
 
     @ApiOperation("Kill a job")
     @DeleteMapping(path = "/jobs/{jobId}")
-    public ResponseEntity<Void> killJob(@PathVariable("jobId") String jobId) {
-        return Responses.fromCompletable(jobServiceGateway.killJob(jobId), HttpStatus.NO_CONTENT);
+    public ResponseEntity<Void> killJob(@PathVariable("jobId") String jobId, CallMetadataAuthentication authentication) {
+        return Responses.fromCompletable(jobServiceGateway.killJob(jobId, authentication.getCallMetadata()), HttpStatus.NO_CONTENT);
     }
 
     @ApiOperation("Find the task with the specified ID")
     @GetMapping(path = "/tasks/{taskId}")
-    public Task findTask(@PathVariable("taskId") String taskId) {
-        return Responses.fromSingleValueObservable(jobServiceGateway.findTask(taskId));
+    public Task findTask(@PathVariable("taskId") String taskId, CallMetadataAuthentication authentication) {
+        return Responses.fromSingleValueObservable(jobServiceGateway.findTask(taskId, authentication.getCallMetadata()));
     }
 
     @ApiOperation("Find tasks")
@@ -227,7 +258,7 @@ public class JobManagementSpringResource {
         queryBuilder.setPage(page);
         queryBuilder.putAllFilteringCriteria(RestUtil.getFilteringCriteria(queryParameters));
         queryBuilder.addAllFields(RestUtil.getFieldsParameter(queryParameters));
-        return Responses.fromSingleValueObservable(jobServiceGateway.findTasks(queryBuilder.build()));
+        return Responses.fromSingleValueObservable(jobServiceGateway.findTasks(queryBuilder.build(), authentication.getCallMetadata()));
     }
 
     @ApiOperation("Kill task")
@@ -235,20 +266,22 @@ public class JobManagementSpringResource {
     public ResponseEntity<Void> killTask(
             @PathVariable("taskId") String taskId,
             @RequestParam(name = "shrink", defaultValue = "false") boolean shrink,
-            @RequestParam(name = "preventMinSizeUpdate", defaultValue = "false") boolean preventMinSizeUpdate
+            @RequestParam(name = "preventMinSizeUpdate", defaultValue = "false") boolean preventMinSizeUpdate,
+            CallMetadataAuthentication authentication
     ) {
         TaskKillRequest taskKillRequest = TaskKillRequest.newBuilder()
                 .setTaskId(taskId)
                 .setShrink(shrink)
                 .setPreventMinSizeUpdate(preventMinSizeUpdate)
                 .build();
-        return Responses.fromCompletable(jobServiceGateway.killTask(taskKillRequest), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(jobServiceGateway.killTask(taskKillRequest, authentication.getCallMetadata()), HttpStatus.NO_CONTENT);
     }
 
     @ApiOperation("Update attributes of a task")
     @PutMapping(path = "/tasks/{taskId}/attributes")
     public ResponseEntity<Void> updateTaskAttributes(@PathVariable("taskId") String taskId,
-                                                     @RequestBody TaskAttributesUpdate request) {
+                                                     @RequestBody TaskAttributesUpdate request,
+                                                     CallMetadataAuthentication authentication) {
         TaskAttributesUpdate sanitizedRequest;
         if (request.getTaskId().isEmpty()) {
             sanitizedRequest = request.toBuilder().setTaskId(taskId).build();
@@ -258,12 +291,17 @@ public class JobManagementSpringResource {
             }
             sanitizedRequest = request;
         }
-        return Responses.fromCompletable(jobServiceGateway.updateTaskAttributes(sanitizedRequest), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(
+                jobServiceGateway.updateTaskAttributes(sanitizedRequest, authentication.getCallMetadata()),
+                HttpStatus.NO_CONTENT
+        );
     }
 
     @ApiOperation("Delete attributes of a task with the specified key names")
     @DeleteMapping(path = "/tasks/{taskId}/attributes")
-    public ResponseEntity<Void> deleteTaskAttributes(@PathVariable("taskId") String taskId, @RequestParam("keys") String delimitedKeys) {
+    public ResponseEntity<Void> deleteTaskAttributes(@PathVariable("taskId") String taskId,
+                                                     @RequestParam("keys") String delimitedKeys,
+                                                     CallMetadataAuthentication authentication) {
         if (Strings.isNullOrEmpty(delimitedKeys)) {
             throw TitusServiceException.invalidArgument("Path parameter 'keys' cannot be empty");
         }
@@ -277,12 +315,12 @@ public class JobManagementSpringResource {
                 .setTaskId(taskId)
                 .addAllKeys(keys)
                 .build();
-        return Responses.fromCompletable(jobServiceGateway.deleteTaskAttributes(request), HttpStatus.NO_CONTENT);
+        return Responses.fromCompletable(jobServiceGateway.deleteTaskAttributes(request, authentication.getCallMetadata()), HttpStatus.NO_CONTENT);
     }
 
     @ApiOperation("Move task to another job")
     @PostMapping(path = "/tasks/move")
-    public ResponseEntity<Void> moveTask(@RequestBody TaskMoveRequest taskMoveRequest) {
-        return Responses.fromCompletable(jobServiceGateway.moveTask(taskMoveRequest), HttpStatus.NO_CONTENT);
+    public ResponseEntity<Void> moveTask(@RequestBody TaskMoveRequest taskMoveRequest, CallMetadataAuthentication authentication) {
+        return Responses.fromCompletable(jobServiceGateway.moveTask(taskMoveRequest, authentication.getCallMetadata()), HttpStatus.NO_CONTENT);
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerSpringResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerSpringResource.java
@@ -62,11 +62,11 @@ public class LoadBalancerSpringResource {
 
     @ApiOperation("Find the load balancer(s) with the specified ID")
     @GetMapping(path = "/{jobId}")
-    public GetJobLoadBalancersResult getJobLoadBalancers(@PathVariable("jobId") String jobId) {
+    public GetJobLoadBalancersResult getJobLoadBalancers(@PathVariable("jobId") String jobId, CallMetadataAuthentication authentication) {
         return Responses.fromSingleValueObservable(loadBalancerService.getLoadBalancers(
-                JobId.newBuilder()
-                        .setId(jobId)
-                        .build()));
+                JobId.newBuilder().setId(jobId).build(),
+                authentication.getCallMetadata()
+        ));
     }
 
     @ApiOperation("Get all load balancers")
@@ -75,23 +75,25 @@ public class LoadBalancerSpringResource {
                                                          CallMetadataAuthentication authentication) {
         Page page = RestUtil.createPage(queryParameters);
         logPageNumberUsage(systemLog, authentication.getCallMetadata(), getClass().getSimpleName(), "getAllLoadBalancers", page);
-        return Responses.fromSingleValueObservable(
-                loadBalancerService.getAllLoadBalancers(GetAllLoadBalancersRequest.newBuilder()
-                        .setPage(page)
-                        .build()));
+        return Responses.fromSingleValueObservable(loadBalancerService.getAllLoadBalancers(
+                GetAllLoadBalancersRequest.newBuilder().setPage(page).build(),
+                authentication.getCallMetadata()
+        ));
     }
 
     @ApiOperation("Add a load balancer")
     @PostMapping
     public ResponseEntity<Void> addLoadBalancer(
             @RequestParam("jobId") String jobId,
-            @RequestParam("loadBalancerId") String loadBalancerId) {
+            @RequestParam("loadBalancerId") String loadBalancerId,
+            CallMetadataAuthentication authentication) {
         return Responses.fromCompletable(
                 loadBalancerService.addLoadBalancer(
                         AddLoadBalancerRequest.newBuilder()
                                 .setJobId(jobId)
                                 .setLoadBalancerId(LoadBalancerId.newBuilder().setId(loadBalancerId).build())
-                                .build()
+                                .build(),
+                        authentication.getCallMetadata()
                 ),
                 HttpStatus.NO_CONTENT
         );
@@ -101,13 +103,15 @@ public class LoadBalancerSpringResource {
     @DeleteMapping
     public ResponseEntity<Void> removeLoadBalancer(
             @RequestParam("jobId") String jobId,
-            @RequestParam("loadBalancerId") String loadBalancerId) {
+            @RequestParam("loadBalancerId") String loadBalancerId,
+            CallMetadataAuthentication authentication) {
         return Responses.fromCompletable(
                 loadBalancerService.removeLoadBalancer(
                         RemoveLoadBalancerRequest.newBuilder()
                                 .setJobId(jobId)
                                 .setLoadBalancerId(LoadBalancerId.newBuilder().setId(loadBalancerId).build())
-                                .build()
+                                .build(),
+                        authentication.getCallMetadata()
                 ),
                 HttpStatus.NO_CONTENT
         );

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/GrpcJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/GrpcJobServiceGateway.java
@@ -46,7 +46,6 @@ import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
 import com.netflix.titus.runtime.connector.GrpcRequestConfiguration;
 import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
-import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
 import io.grpc.stub.StreamObserver;
 import reactor.core.publisher.Mono;
@@ -66,15 +65,12 @@ import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrap
 public class GrpcJobServiceGateway implements JobServiceGateway {
 
     private final JobManagementServiceGrpc.JobManagementServiceStub client;
-    private final CallMetadataResolver callMetadataResolver;
     private final GrpcRequestConfiguration configuration;
 
     @Inject
     public GrpcJobServiceGateway(JobManagementServiceGrpc.JobManagementServiceStub client,
-                                 CallMetadataResolver callMetadataResolver,
                                  GrpcRequestConfiguration configuration) {
         this.client = client;
-        this.callMetadataResolver = callMetadataResolver;
         this.configuration = configuration;
     }
 
@@ -94,158 +90,159 @@ public class GrpcJobServiceGateway implements JobServiceGateway {
     }
 
     @Override
-    public Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate) {
+    public Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobCapacity(jobCapacityUpdate, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).updateJobCapacity(jobCapacityUpdate, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes) {
+    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes,
+                                                               CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Completable updateJobProcesses(JobProcessesUpdate jobProcessesUpdate) {
+    public Completable updateJobProcesses(JobProcessesUpdate jobProcessesUpdate, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobProcesses(jobProcessesUpdate, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).updateJobProcesses(jobProcessesUpdate, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Completable updateJobStatus(JobStatusUpdate statusUpdate) {
+    public Completable updateJobStatus(JobStatusUpdate statusUpdate, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobStatus(statusUpdate, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).updateJobStatus(statusUpdate, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Mono<Void> updateJobDisruptionBudget(JobDisruptionBudgetUpdate request) {
+    public Mono<Void> updateJobDisruptionBudget(JobDisruptionBudgetUpdate request, CallMetadata callMetadata) {
         return createMonoVoidRequest(
                 emitter -> {
                     StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientMonoResponse(emitter);
-                    createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobDisruptionBudget(request, streamObserver);
+                    createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).updateJobDisruptionBudget(request, streamObserver);
                 },
                 configuration.getRequestTimeoutMs()
         ).ignoreElement().cast(Void.class);
     }
 
     @Override
-    public Mono<Void> updateJobAttributes(JobAttributesUpdate request) {
+    public Mono<Void> updateJobAttributes(JobAttributesUpdate request, CallMetadata callMetadata) {
         return createMonoVoidRequest(
                 emitter -> {
                     StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientMonoResponse(emitter);
-                    createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateJobAttributes(request, streamObserver);
+                    createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).updateJobAttributes(request, streamObserver);
                 },
                 configuration.getRequestTimeoutMs()
         ).ignoreElement().cast(Void.class);
     }
 
     @Override
-    public Mono<Void> deleteJobAttributes(JobAttributesDeleteRequest request) {
+    public Mono<Void> deleteJobAttributes(JobAttributesDeleteRequest request, CallMetadata callMetadata) {
         return createMonoVoidRequest(
                 emitter -> {
                     StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientMonoResponse(emitter);
-                    createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).deleteJobAttributes(request, streamObserver);
+                    createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).deleteJobAttributes(request, streamObserver);
                 },
                 configuration.getRequestTimeoutMs()
         ).ignoreElement().cast(Void.class);
     }
 
     @Override
-    public Observable<Job> findJob(String jobId) {
+    public Observable<Job> findJob(String jobId, CallMetadata callMetadata) {
         Observable<Job> observable = createRequestObservable(emitter -> {
             StreamObserver<Job> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).findJob(JobId.newBuilder().setId(jobId).build(), streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).findJob(JobId.newBuilder().setId(jobId).build(), streamObserver);
         }, configuration.getRequestTimeoutMs());
         return observable.timeout(configuration.getRequestTimeoutMs(), TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public Observable<JobQueryResult> findJobs(JobQuery jobQuery) {
+    public Observable<JobQueryResult> findJobs(JobQuery jobQuery, CallMetadata callMetadata) {
         return createRequestObservable(emitter -> {
             StreamObserver<JobQueryResult> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).findJobs(jobQuery, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).findJobs(jobQuery, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Observable<JobChangeNotification> observeJob(String jobId) {
+    public Observable<JobChangeNotification> observeJob(String jobId, CallMetadata callMetadata) {
         return createRequestObservable(emitter -> {
             StreamObserver<JobChangeNotification> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver).observeJob(JobId.newBuilder().setId(jobId).build(), streamObserver);
+            createWrappedStub(client, callMetadata).observeJob(JobId.newBuilder().setId(jobId).build(), streamObserver);
         });
     }
 
     @Override
-    public Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query) {
+    public Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query, CallMetadata callMetadata) {
         return createRequestObservable(emitter -> {
             StreamObserver<JobChangeNotification> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver).observeJobs(query, streamObserver);
+            createWrappedStub(client, callMetadata).observeJobs(query, streamObserver);
         });
     }
 
     @Override
-    public Completable killJob(String jobId) {
+    public Completable killJob(String jobId, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).killJob(JobId.newBuilder().setId(jobId).build(), streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).killJob(JobId.newBuilder().setId(jobId).build(), streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Observable<com.netflix.titus.grpc.protogen.Task> findTask(String taskId) {
+    public Observable<com.netflix.titus.grpc.protogen.Task> findTask(String taskId, CallMetadata callMetadata) {
         Observable<com.netflix.titus.grpc.protogen.Task> observable = createRequestObservable(emitter -> {
             StreamObserver<com.netflix.titus.grpc.protogen.Task> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).findTask(TaskId.newBuilder().setId(taskId).build(), streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).findTask(TaskId.newBuilder().setId(taskId).build(), streamObserver);
         }, configuration.getRequestTimeoutMs());
         return observable.timeout(configuration.getRequestTimeoutMs(), TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public Observable<TaskQueryResult> findTasks(TaskQuery taskQuery) {
+    public Observable<TaskQueryResult> findTasks(TaskQuery taskQuery, CallMetadata callMetadata) {
         Observable<TaskQueryResult> observable = createRequestObservable(emitter -> {
             StreamObserver<TaskQueryResult> streamObserver = createSimpleClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).findTasks(taskQuery, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).findTasks(taskQuery, streamObserver);
         }, configuration.getRequestTimeoutMs());
         return observable.timeout(configuration.getRequestTimeoutMs(), TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public Completable killTask(TaskKillRequest taskKillRequest) {
+    public Completable killTask(TaskKillRequest taskKillRequest, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).killTask(taskKillRequest, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).killTask(taskKillRequest, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Completable updateTaskAttributes(TaskAttributesUpdate attributesUpdate) {
+    public Completable updateTaskAttributes(TaskAttributesUpdate attributesUpdate, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).updateTaskAttributes(attributesUpdate, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).updateTaskAttributes(attributesUpdate, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Completable deleteTaskAttributes(TaskAttributesDeleteRequest deleteRequest) {
+    public Completable deleteTaskAttributes(TaskAttributesDeleteRequest deleteRequest, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).deleteTaskAttributes(deleteRequest, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).deleteTaskAttributes(deleteRequest, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 
     @Override
-    public Completable moveTask(TaskMoveRequest taskMoveRequest) {
+    public Completable moveTask(TaskMoveRequest taskMoveRequest, CallMetadata callMetadata) {
         return createRequestCompletable(emitter -> {
             StreamObserver<Empty> streamObserver = GrpcUtil.createEmptyClientResponseObserver(emitter);
-            createWrappedStub(client, callMetadataResolver, configuration.getRequestTimeoutMs()).moveTask(taskMoveRequest, streamObserver);
+            createWrappedStub(client, callMetadata, configuration.getRequestTimeoutMs()).moveTask(taskMoveRequest, streamObserver);
         }, configuration.getRequestTimeoutMs());
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGateway.java
@@ -56,39 +56,40 @@ public interface JobServiceGateway {
 
     Observable<String> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata);
 
-    Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate);
+    Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate, CallMetadata callMetadata);
 
-    Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes);
+    Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes,
+                                                        CallMetadata callMetadata);
 
-    Completable updateJobProcesses(JobProcessesUpdate jobProcessesUpdate);
+    Completable updateJobProcesses(JobProcessesUpdate jobProcessesUpdate, CallMetadata callMetadata);
 
-    Completable updateJobStatus(JobStatusUpdate statusUpdate);
+    Completable updateJobStatus(JobStatusUpdate statusUpdate, CallMetadata callMetadata);
 
-    Mono<Void> updateJobDisruptionBudget(JobDisruptionBudgetUpdate request);
+    Mono<Void> updateJobDisruptionBudget(JobDisruptionBudgetUpdate request, CallMetadata callMetadata);
 
-    Mono<Void> updateJobAttributes(JobAttributesUpdate request);
+    Mono<Void> updateJobAttributes(JobAttributesUpdate request, CallMetadata callMetadata);
 
-    Mono<Void> deleteJobAttributes(JobAttributesDeleteRequest request);
+    Mono<Void> deleteJobAttributes(JobAttributesDeleteRequest request, CallMetadata callMetadata);
 
-    Observable<Job> findJob(String jobId);
+    Observable<Job> findJob(String jobId, CallMetadata callMetadata);
 
-    Observable<JobQueryResult> findJobs(JobQuery jobQuery);
+    Observable<JobQueryResult> findJobs(JobQuery jobQuery, CallMetadata callMetadata);
 
-    Observable<JobChangeNotification> observeJob(String jobId);
+    Observable<JobChangeNotification> observeJob(String jobId, CallMetadata callMetadata);
 
-    Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query);
+    Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query, CallMetadata callMetadata);
 
-    Completable killJob(String jobId);
+    Completable killJob(String jobId, CallMetadata callMetadata);
 
-    Observable<Task> findTask(String taskId);
+    Observable<Task> findTask(String taskId, CallMetadata callMetadata);
 
-    Observable<TaskQueryResult> findTasks(TaskQuery taskQuery);
+    Observable<TaskQueryResult> findTasks(TaskQuery taskQuery, CallMetadata callMetadata);
 
-    Completable killTask(TaskKillRequest taskKillRequest);
+    Completable killTask(TaskKillRequest taskKillRequest, CallMetadata callMetadata);
 
-    Completable updateTaskAttributes(TaskAttributesUpdate request);
+    Completable updateTaskAttributes(TaskAttributesUpdate request, CallMetadata callMetadata);
 
-    Completable deleteTaskAttributes(TaskAttributesDeleteRequest request);
+    Completable deleteTaskAttributes(TaskAttributesDeleteRequest request, CallMetadata callMetadata);
 
-    Completable moveTask(TaskMoveRequest taskMoveRequest);
+    Completable moveTask(TaskMoveRequest taskMoveRequest, CallMetadata callMetadata);
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGatewayDelegate.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/JobServiceGatewayDelegate.java
@@ -55,92 +55,93 @@ public class JobServiceGatewayDelegate implements JobServiceGateway {
     }
 
     @Override
-    public Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate) {
-        return delegate.updateJobCapacity(jobCapacityUpdate);
+    public Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate, CallMetadata callMetadata) {
+        return delegate.updateJobCapacity(jobCapacityUpdate, callMetadata);
     }
 
     @Override
-    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes) {
-        return delegate.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes);
+    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes,
+                                                               CallMetadata callMetadata) {
+        return delegate.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes, callMetadata);
     }
 
     @Override
-    public Completable updateJobProcesses(JobProcessesUpdate jobProcessesUpdate) {
-        return delegate.updateJobProcesses(jobProcessesUpdate);
+    public Completable updateJobProcesses(JobProcessesUpdate jobProcessesUpdate, CallMetadata callMetadata) {
+        return delegate.updateJobProcesses(jobProcessesUpdate, callMetadata);
     }
 
     @Override
-    public Completable updateJobStatus(JobStatusUpdate statusUpdate) {
-        return delegate.updateJobStatus(statusUpdate);
+    public Completable updateJobStatus(JobStatusUpdate statusUpdate, CallMetadata callMetadata) {
+        return delegate.updateJobStatus(statusUpdate, callMetadata);
     }
 
     @Override
-    public Mono<Void> updateJobDisruptionBudget(JobDisruptionBudgetUpdate request) {
-        return delegate.updateJobDisruptionBudget(request);
+    public Mono<Void> updateJobDisruptionBudget(JobDisruptionBudgetUpdate request, CallMetadata callMetadata) {
+        return delegate.updateJobDisruptionBudget(request, callMetadata);
     }
 
     @Override
-    public Mono<Void> updateJobAttributes(JobAttributesUpdate request) {
-        return delegate.updateJobAttributes(request);
+    public Mono<Void> updateJobAttributes(JobAttributesUpdate request, CallMetadata callMetadata) {
+        return delegate.updateJobAttributes(request, callMetadata);
     }
 
     @Override
-    public Mono<Void> deleteJobAttributes(JobAttributesDeleteRequest request) {
-        return delegate.deleteJobAttributes(request);
+    public Mono<Void> deleteJobAttributes(JobAttributesDeleteRequest request, CallMetadata callMetadata) {
+        return delegate.deleteJobAttributes(request, callMetadata);
     }
 
     @Override
-    public Observable<Job> findJob(String jobId) {
-        return delegate.findJob(jobId);
+    public Observable<Job> findJob(String jobId, CallMetadata callMetadata) {
+        return delegate.findJob(jobId, callMetadata);
     }
 
     @Override
-    public Observable<JobQueryResult> findJobs(JobQuery jobQuery) {
-        return delegate.findJobs(jobQuery);
+    public Observable<JobQueryResult> findJobs(JobQuery jobQuery, CallMetadata callMetadata) {
+        return delegate.findJobs(jobQuery, callMetadata);
     }
 
     @Override
-    public Observable<JobChangeNotification> observeJob(String jobId) {
-        return delegate.observeJob(jobId);
+    public Observable<JobChangeNotification> observeJob(String jobId, CallMetadata callMetadata) {
+        return delegate.observeJob(jobId, callMetadata);
     }
 
     @Override
-    public Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query) {
-        return delegate.observeJobs(query);
+    public Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query, CallMetadata callMetadata) {
+        return delegate.observeJobs(query, callMetadata);
     }
 
     @Override
-    public Completable killJob(String jobId) {
-        return delegate.killJob(jobId);
+    public Completable killJob(String jobId, CallMetadata callMetadata) {
+        return delegate.killJob(jobId, callMetadata);
     }
 
     @Override
-    public Observable<Task> findTask(String taskId) {
-        return delegate.findTask(taskId);
+    public Observable<Task> findTask(String taskId, CallMetadata callMetadata) {
+        return delegate.findTask(taskId, callMetadata);
     }
 
     @Override
-    public Observable<TaskQueryResult> findTasks(TaskQuery taskQuery) {
-        return delegate.findTasks(taskQuery);
+    public Observable<TaskQueryResult> findTasks(TaskQuery taskQuery, CallMetadata callMetadata) {
+        return delegate.findTasks(taskQuery, callMetadata);
     }
 
     @Override
-    public Completable killTask(TaskKillRequest taskKillRequest) {
-        return delegate.killTask(taskKillRequest);
+    public Completable killTask(TaskKillRequest taskKillRequest, CallMetadata callMetadata) {
+        return delegate.killTask(taskKillRequest, callMetadata);
     }
 
     @Override
-    public Completable updateTaskAttributes(TaskAttributesUpdate attributesUpdate) {
-        return delegate.updateTaskAttributes(attributesUpdate);
+    public Completable updateTaskAttributes(TaskAttributesUpdate attributesUpdate, CallMetadata callMetadata) {
+        return delegate.updateTaskAttributes(attributesUpdate, callMetadata);
     }
 
     @Override
-    public Completable deleteTaskAttributes(TaskAttributesDeleteRequest deleteRequest) {
-        return delegate.deleteTaskAttributes(deleteRequest);
+    public Completable deleteTaskAttributes(TaskAttributesDeleteRequest deleteRequest, CallMetadata callMetadata) {
+        return delegate.deleteTaskAttributes(deleteRequest, callMetadata);
     }
 
     @Override
-    public Completable moveTask(TaskMoveRequest taskMoveRequest) {
-        return delegate.moveTask(taskMoveRequest);
+    public Completable moveTask(TaskMoveRequest taskMoveRequest, CallMetadata callMetadata) {
+        return delegate.moveTask(taskMoveRequest, callMetadata);
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
@@ -24,14 +24,14 @@ import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.service.TitusServiceException;
+import com.netflix.titus.common.model.admission.AdmissionSanitizer;
+import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdate;
 import com.netflix.titus.grpc.protogen.JobCapacityUpdateWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobCapacityWithOptionalAttributes;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
-import com.netflix.titus.common.model.admission.AdmissionSanitizer;
-import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobManagementModelConverters;
 import reactor.core.publisher.Mono;
 import rx.Completable;
@@ -94,23 +94,24 @@ public class SanitizingJobServiceGateway extends JobServiceGatewayDelegate {
     }
 
     @Override
-    public Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate) {
+    public Completable updateJobCapacity(JobCapacityUpdate jobCapacityUpdate, CallMetadata callMetadata) {
         Capacity newCapacity = GrpcJobManagementModelConverters.toCoreCapacity(jobCapacityUpdate.getCapacity());
         Set<ValidationError> violations = entitySanitizer.validate(newCapacity);
         if (!violations.isEmpty()) {
             return Completable.error(TitusServiceException.invalidArgument(violations));
         }
-        return delegate.updateJobCapacity(jobCapacityUpdate);
+        return delegate.updateJobCapacity(jobCapacityUpdate, callMetadata);
     }
 
     @Override
-    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes) {
+    public Completable updateJobCapacityWithOptionalAttributes(JobCapacityUpdateWithOptionalAttributes jobCapacityUpdateWithOptionalAttributes,
+                                                               CallMetadata callMetadata) {
         final JobCapacityWithOptionalAttributes jobCapacityWithOptionalAttributes = jobCapacityUpdateWithOptionalAttributes.getJobCapacityWithOptionalAttributes();
         CapacityAttributes capacityAttributes = GrpcJobManagementModelConverters.toCoreCapacityAttributes(jobCapacityWithOptionalAttributes);
         Set<ValidationError> violations = entitySanitizer.validate(capacityAttributes);
         if (!violations.isEmpty()) {
             return Completable.error(TitusServiceException.invalidArgument(violations));
         }
-        return delegate.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes);
+        return delegate.updateJobCapacityWithOptionalAttributes(jobCapacityUpdateWithOptionalAttributes, callMetadata);
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/AutoScalingService.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/AutoScalingService.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.runtime.service;
 
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.grpc.protogen.DeletePolicyRequest;
 import com.netflix.titus.grpc.protogen.GetPolicyResult;
 import com.netflix.titus.grpc.protogen.JobId;
@@ -27,15 +28,15 @@ import rx.Observable;
 
 public interface AutoScalingService {
 
-    Observable<GetPolicyResult> getJobScalingPolicies(JobId jobId);
+    Observable<GetPolicyResult> getJobScalingPolicies(JobId jobId, CallMetadata callMetadata);
 
-    Observable<ScalingPolicyID> setAutoScalingPolicy(PutPolicyRequest request);
+    Observable<ScalingPolicyID> setAutoScalingPolicy(PutPolicyRequest request, CallMetadata callMetadata);
 
-    Observable<GetPolicyResult> getScalingPolicy(ScalingPolicyID request);
+    Observable<GetPolicyResult> getScalingPolicy(ScalingPolicyID request, CallMetadata callMetadata);
 
-    Observable<GetPolicyResult> getAllScalingPolicies();
+    Observable<GetPolicyResult> getAllScalingPolicies(CallMetadata callMetadata);
 
-    Completable deleteAutoScalingPolicy(DeletePolicyRequest request);
+    Completable deleteAutoScalingPolicy(DeletePolicyRequest request, CallMetadata callMetadata);
 
-    Completable updateAutoScalingPolicy(UpdatePolicyRequest request);
+    Completable updateAutoScalingPolicy(UpdatePolicyRequest request, CallMetadata callMetadata);
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/LoadBalancerService.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/service/LoadBalancerService.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.runtime.service;
 
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.grpc.protogen.AddLoadBalancerRequest;
 import com.netflix.titus.grpc.protogen.GetAllLoadBalancersRequest;
 import com.netflix.titus.grpc.protogen.GetAllLoadBalancersResult;
@@ -26,11 +27,11 @@ import rx.Completable;
 import rx.Observable;
 
 public interface LoadBalancerService {
-    Observable<GetJobLoadBalancersResult> getLoadBalancers(JobId jobId);
+    Observable<GetJobLoadBalancersResult> getLoadBalancers(JobId jobId, CallMetadata callMetadata);
 
-    Observable<GetAllLoadBalancersResult> getAllLoadBalancers(GetAllLoadBalancersRequest request);
+    Observable<GetAllLoadBalancersResult> getAllLoadBalancers(GetAllLoadBalancersRequest request, CallMetadata callMetadata);
 
-    Completable addLoadBalancer(AddLoadBalancerRequest request);
+    Completable addLoadBalancer(AddLoadBalancerRequest request, CallMetadata callMetadata);
 
-    Completable removeLoadBalancer(RemoveLoadBalancerRequest removeLoadBalancerRequest);
+    Completable removeLoadBalancer(RemoveLoadBalancerRequest removeLoadBalancerRequest, CallMetadata callMetadata);
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/AutoScalingSpringResourceTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/AutoScalingSpringResourceTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import rx.Completable;
 import rx.Observable;
 
+import static com.netflix.titus.testkit.junit.spring.SpringMockMvcUtil.JUNIT_REST_CALL_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,61 +59,61 @@ public class AutoScalingSpringResourceTest {
 
     @Test
     public void testGetAllScalingPolicies() throws Exception {
-        when(serviceMock.getAllScalingPolicies()).thenReturn(Observable.just(GET_POLICY_RESULT));
+        when(serviceMock.getAllScalingPolicies(JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(GET_POLICY_RESULT));
         GetPolicyResult entity = SpringMockMvcUtil.doGet(mockMvc, "/api/v3/autoscaling/scalingPolicies", GetPolicyResult.class);
         assertThat(entity).isEqualTo(GET_POLICY_RESULT);
 
-        verify(serviceMock, times(1)).getAllScalingPolicies();
+        verify(serviceMock, times(1)).getAllScalingPolicies(JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testGetScalingPolicyForJob() throws Exception {
         JobId jobId = JobId.newBuilder().setId("myJobId").build();
-        when(serviceMock.getJobScalingPolicies(jobId)).thenReturn(Observable.just(GET_POLICY_RESULT));
+        when(serviceMock.getJobScalingPolicies(jobId, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(GET_POLICY_RESULT));
         GetPolicyResult entity = SpringMockMvcUtil.doGet(mockMvc, String.format("/api/v3/autoscaling/scalingPolicies/%s", jobId.getId()), GetPolicyResult.class);
         assertThat(entity).isEqualTo(GET_POLICY_RESULT);
 
-        verify(serviceMock, times(1)).getJobScalingPolicies(jobId);
+        verify(serviceMock, times(1)).getJobScalingPolicies(jobId, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testSetScalingPolicy() throws Exception {
         PutPolicyRequest request = PutPolicyRequest.newBuilder().build();
 
-        when(serviceMock.setAutoScalingPolicy(request)).thenReturn(Observable.just(SCALING_POLICY_ID));
+        when(serviceMock.setAutoScalingPolicy(request, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(SCALING_POLICY_ID));
         ScalingPolicyID entity = SpringMockMvcUtil.doPost(mockMvc, "/api/v3/autoscaling/scalingPolicy", request, ScalingPolicyID.class);
         assertThat(entity).isEqualTo(SCALING_POLICY_ID);
 
-        verify(serviceMock, times(1)).setAutoScalingPolicy(request);
+        verify(serviceMock, times(1)).setAutoScalingPolicy(request, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testGetScalingPolicy() throws Exception {
-        when(serviceMock.getScalingPolicy(SCALING_POLICY_ID)).thenReturn(Observable.just(GET_POLICY_RESULT));
+        when(serviceMock.getScalingPolicy(SCALING_POLICY_ID, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(GET_POLICY_RESULT));
         GetPolicyResult entity = SpringMockMvcUtil.doGet(mockMvc, String.format("/api/v3/autoscaling/scalingPolicy/%s", SCALING_POLICY_ID.getId()), GetPolicyResult.class);
         assertThat(entity).isEqualTo(GET_POLICY_RESULT);
 
-        verify(serviceMock, times(1)).getScalingPolicy(SCALING_POLICY_ID);
+        verify(serviceMock, times(1)).getScalingPolicy(SCALING_POLICY_ID, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testRemovePolicy() throws Exception {
         DeletePolicyRequest request = DeletePolicyRequest.newBuilder().setId(SCALING_POLICY_ID).build();
 
-        when(serviceMock.deleteAutoScalingPolicy(request)).thenReturn(Completable.complete());
+        when(serviceMock.deleteAutoScalingPolicy(request, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doDelete(mockMvc, String.format("/api/v3/autoscaling/scalingPolicy/%s", SCALING_POLICY_ID.getId()));
 
-        verify(serviceMock, times(1)).deleteAutoScalingPolicy(request);
+        verify(serviceMock, times(1)).deleteAutoScalingPolicy(request, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testUpdateScalingPolicy() throws Exception {
         UpdatePolicyRequest request = UpdatePolicyRequest.newBuilder().build();
 
-        when(serviceMock.updateAutoScalingPolicy(request)).thenReturn(Completable.complete());
+        when(serviceMock.updateAutoScalingPolicy(request, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPut(mockMvc, "/api/v3/autoscaling/scalingPolicy", request);
 
-        verify(serviceMock, times(1)).updateAutoScalingPolicy(request);
+        verify(serviceMock, times(1)).updateAutoScalingPolicy(request, JUNIT_REST_CALL_METADATA);
 
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementSpringResourceTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementSpringResourceTest.java
@@ -100,15 +100,11 @@ public class JobManagementSpringResourceTest {
     @MockBean
     public SystemLogService systemLog;
 
-    @MockBean
-    public CallMetadataResolver callMetadataResolver;
-
     @Autowired
     private MockMvc mockMvc;
 
     @Before
     public void setUp() {
-        when(callMetadataResolver.resolve()).thenReturn(Optional.of(JUNIT_REST_CALL_METADATA));
     }
 
     @Test
@@ -125,10 +121,10 @@ public class JobManagementSpringResourceTest {
         Capacity capacity = Capacity.newBuilder().setMin(1).setDesired(2).setMax(3).build();
         JobCapacityUpdate forwardedRequest = JobCapacityUpdate.newBuilder().setJobId(JOB_ID_1).setCapacity(capacity).build();
 
-        when(jobServiceGatewayMock.updateJobCapacity(forwardedRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.updateJobCapacity(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPut(mockMvc, String.format("/api/v3/jobs/%s/instances", JOB_ID_1), capacity);
 
-        verify(jobServiceGatewayMock, times(1)).updateJobCapacity(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).updateJobCapacity(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -143,10 +139,10 @@ public class JobManagementSpringResourceTest {
                 .setJobCapacityWithOptionalAttributes(restRequest)
                 .build();
 
-        when(jobServiceGatewayMock.updateJobCapacityWithOptionalAttributes(forwardedRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.updateJobCapacityWithOptionalAttributes(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPut(mockMvc, String.format("/api/v3/jobs/%s/capacityAttributes", JOB_ID_1), restRequest);
 
-        verify(jobServiceGatewayMock, times(1)).updateJobCapacityWithOptionalAttributes(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).updateJobCapacityWithOptionalAttributes(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -161,10 +157,10 @@ public class JobManagementSpringResourceTest {
                 .setServiceJobProcesses(restRequest)
                 .build();
 
-        when(jobServiceGatewayMock.updateJobProcesses(forwardedRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.updateJobProcesses(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPut(mockMvc, String.format("/api/v3/jobs/%s/jobprocesses", JOB_ID_1), restRequest);
 
-        verify(jobServiceGatewayMock, times(1)).updateJobProcesses(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).updateJobProcesses(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -176,10 +172,10 @@ public class JobManagementSpringResourceTest {
                 .setDisruptionBudget(restRequest)
                 .build();
 
-        when(jobServiceGatewayMock.updateJobDisruptionBudget(forwardedRequest)).thenReturn(Mono.empty());
+        when(jobServiceGatewayMock.updateJobDisruptionBudget(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Mono.empty());
         SpringMockMvcUtil.doPut(mockMvc, String.format("/api/v3/jobs/%s/disruptionBudget", JOB_ID_1), restRequest);
 
-        verify(jobServiceGatewayMock, times(1)).updateJobDisruptionBudget(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).updateJobDisruptionBudget(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -189,10 +185,10 @@ public class JobManagementSpringResourceTest {
                 .putAttributes("keyA", "valueA")
                 .build();
 
-        when(jobServiceGatewayMock.updateJobAttributes(restRequest)).thenReturn(Mono.empty());
+        when(jobServiceGatewayMock.updateJobAttributes(restRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Mono.empty());
         SpringMockMvcUtil.doPut(mockMvc, String.format("/api/v3/jobs/%s/attributes", JOB_ID_1), restRequest);
 
-        verify(jobServiceGatewayMock, times(1)).updateJobAttributes(restRequest);
+        verify(jobServiceGatewayMock, times(1)).updateJobAttributes(restRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -201,10 +197,10 @@ public class JobManagementSpringResourceTest {
                 .setJobId(JOB_ID_1)
                 .addKeys("keyA")
                 .build();
-        when(jobServiceGatewayMock.deleteJobAttributes(forwardedRequest)).thenReturn(Mono.empty());
+        when(jobServiceGatewayMock.deleteJobAttributes(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Mono.empty());
         SpringMockMvcUtil.doDelete(mockMvc, String.format("/api/v3/jobs/%s/attributes", JOB_ID_1), "keys", "keyA");
 
-        verify(jobServiceGatewayMock, times(1)).deleteJobAttributes(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).deleteJobAttributes(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -213,10 +209,10 @@ public class JobManagementSpringResourceTest {
                 .setId(JOB_ID_1)
                 .setEnableStatus(true)
                 .build();
-        when(jobServiceGatewayMock.updateJobStatus(forwardedRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.updateJobStatus(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPost(mockMvc, String.format("/api/v3/jobs/%s/enable", JOB_ID_1));
 
-        verify(jobServiceGatewayMock, times(1)).updateJobStatus(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).updateJobStatus(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -225,19 +221,19 @@ public class JobManagementSpringResourceTest {
                 .setId(JOB_ID_1)
                 .setEnableStatus(false)
                 .build();
-        when(jobServiceGatewayMock.updateJobStatus(forwardedRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.updateJobStatus(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPost(mockMvc, String.format("/api/v3/jobs/%s/disable", JOB_ID_1));
 
-        verify(jobServiceGatewayMock, times(1)).updateJobStatus(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).updateJobStatus(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testFindJob() throws Exception {
-        when(jobServiceGatewayMock.findJob(JOB_ID_1)).thenReturn(Observable.just(JOB_1));
+        when(jobServiceGatewayMock.findJob(JOB_ID_1, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(JOB_1));
         Job entity = SpringMockMvcUtil.doGet(mockMvc, String.format("/api/v3/jobs/%s", JOB_ID_1), Job.class);
         assertThat(entity).isEqualTo(JOB_1);
 
-        verify(jobServiceGatewayMock, times(1)).findJob(JOB_ID_1);
+        verify(jobServiceGatewayMock, times(1)).findJob(JOB_ID_1, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -250,28 +246,28 @@ public class JobManagementSpringResourceTest {
                 .setPagination(paginationOf(NEXT_PAGE_OF_2))
                 .addAllItems(asList(JOB_1, JOB_2))
                 .build();
-        when(jobServiceGatewayMock.findJobs(forwardedRequest)).thenReturn(Observable.just(expectedResult));
+        when(jobServiceGatewayMock.findJobs(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(expectedResult));
         JobQueryResult entity = SpringMockMvcUtil.doPaginatedGet(mockMvc, "/api/v3/jobs", JobQueryResult.class, NEXT_PAGE_OF_2, "filter1", "value1");
         assertThat(entity).isEqualTo(expectedResult);
 
-        verify(jobServiceGatewayMock, times(1)).findJobs(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).findJobs(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testKillJob() throws Exception {
-        when(jobServiceGatewayMock.killJob(JOB_ID_1)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.killJob(JOB_ID_1, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doDelete(mockMvc, String.format("/api/v3/jobs/%s", JOB_ID_1));
 
-        verify(jobServiceGatewayMock, times(1)).killJob(JOB_ID_1);
+        verify(jobServiceGatewayMock, times(1)).killJob(JOB_ID_1, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
     public void testFindTask() throws Exception {
-        when(jobServiceGatewayMock.findTask(TASK_ID_1)).thenReturn(Observable.just(TASK_1));
+        when(jobServiceGatewayMock.findTask(TASK_ID_1, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(TASK_1));
         Task entity = SpringMockMvcUtil.doGet(mockMvc, String.format("/api/v3/tasks/%s", TASK_ID_1), Task.class);
         assertThat(entity).isEqualTo(TASK_1);
 
-        verify(jobServiceGatewayMock, times(1)).findTask(TASK_ID_1);
+        verify(jobServiceGatewayMock, times(1)).findTask(TASK_ID_1, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -284,11 +280,11 @@ public class JobManagementSpringResourceTest {
                 .setPagination(paginationOf(NEXT_PAGE_OF_2))
                 .addAllItems(asList(TASK_1, TASK_2))
                 .build();
-        when(jobServiceGatewayMock.findTasks(forwardedRequest)).thenReturn(Observable.just(expectedResult));
+        when(jobServiceGatewayMock.findTasks(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(expectedResult));
         TaskQueryResult entity = SpringMockMvcUtil.doPaginatedGet(mockMvc, "/api/v3/tasks", TaskQueryResult.class, NEXT_PAGE_OF_2, "filter1", "value1");
         assertThat(entity).isEqualTo(expectedResult);
 
-        verify(jobServiceGatewayMock, times(1)).findTasks(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).findTasks(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -298,10 +294,10 @@ public class JobManagementSpringResourceTest {
                 .setShrink(true)
                 .setPreventMinSizeUpdate(true)
                 .build();
-        when(jobServiceGatewayMock.killTask(forwardedRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.killTask(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doDelete(mockMvc, String.format("/api/v3/tasks/%s", TASK_ID_1), "shrink", "true", "preventMinSizeUpdate", "true");
 
-        verify(jobServiceGatewayMock, times(1)).killTask(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).killTask(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -311,10 +307,10 @@ public class JobManagementSpringResourceTest {
                 .putAttributes("keyA", "valueA")
                 .build();
 
-        when(jobServiceGatewayMock.updateTaskAttributes(restRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.updateTaskAttributes(restRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPut(mockMvc, String.format("/api/v3/tasks/%s/attributes", TASK_ID_1), restRequest);
 
-        verify(jobServiceGatewayMock, times(1)).updateTaskAttributes(restRequest);
+        verify(jobServiceGatewayMock, times(1)).updateTaskAttributes(restRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -323,10 +319,10 @@ public class JobManagementSpringResourceTest {
                 .setTaskId(TASK_ID_1)
                 .addKeys("keyA")
                 .build();
-        when(jobServiceGatewayMock.deleteTaskAttributes(forwardedRequest)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.deleteTaskAttributes(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doDelete(mockMvc, String.format("/api/v3/tasks/%s/attributes", TASK_ID_1), "keys", "keyA");
 
-        verify(jobServiceGatewayMock, times(1)).deleteTaskAttributes(forwardedRequest);
+        verify(jobServiceGatewayMock, times(1)).deleteTaskAttributes(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -336,9 +332,9 @@ public class JobManagementSpringResourceTest {
                 .setTargetJobId(JOB_2.getId())
                 .setTaskId(TASK_ID_1)
                 .build();
-        when(jobServiceGatewayMock.moveTask(request)).thenReturn(Completable.complete());
+        when(jobServiceGatewayMock.moveTask(request, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
         SpringMockMvcUtil.doPost(mockMvc, "/api/v3/tasks/move", request);
 
-        verify(jobServiceGatewayMock, times(1)).moveTask(request);
+        verify(jobServiceGatewayMock, times(1)).moveTask(request, JUNIT_REST_CALL_METADATA);
     }
 }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerResourceTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerResourceTest.java
@@ -70,7 +70,7 @@ public class LoadBalancerResourceTest {
     @Test
     public void getJobLoadBalancersTest() {
         GetJobLoadBalancersResult expectedResult = GetJobLoadBalancersResult.newBuilder().build();
-        when(loadBalancerService.getLoadBalancers(any())).thenReturn(Observable.just(expectedResult));
+        when(loadBalancerService.getLoadBalancers(any(), any())).thenReturn(Observable.just(expectedResult));
 
         GetJobLoadBalancersResult actualResult = loadBalancerResource.getJobLoadBalancers(TEST_JOB_ID);
 
@@ -81,7 +81,7 @@ public class LoadBalancerResourceTest {
     public void getAllJobsTest() {
         GetAllLoadBalancersResult expectedResult = GetAllLoadBalancersResult.newBuilder().build();
         when(uriInfo.getQueryParameters()).thenReturn(getDefaultPageParameters());
-        when(loadBalancerService.getAllLoadBalancers(any())).thenReturn(Observable.just(expectedResult));
+        when(loadBalancerService.getAllLoadBalancers(any(), any())).thenReturn(Observable.just(expectedResult));
 
         GetAllLoadBalancersResult actualResult = loadBalancerResource.getAllLoadBalancers(uriInfo);
 
@@ -90,7 +90,7 @@ public class LoadBalancerResourceTest {
 
     @Test
     public void addLoadBalancerSucceededTest() {
-        when(loadBalancerService.addLoadBalancer(any())).thenReturn(Completable.complete());
+        when(loadBalancerService.addLoadBalancer(any(), any())).thenReturn(Completable.complete());
 
         Response response = loadBalancerResource.addLoadBalancer(TEST_JOB_ID, TEST_LOAD_BALANCER_ID);
         assertEquals(200, response.getStatus());
@@ -99,14 +99,14 @@ public class LoadBalancerResourceTest {
     @Test(expected = TitusServiceException.class)
     public void addLoadBalancerFailedTest() {
         TitusServiceException exception = TitusServiceException.jobNotFound(TEST_JOB_ID);
-        when(loadBalancerService.addLoadBalancer(any())).thenReturn(Completable.error(exception));
+        when(loadBalancerService.addLoadBalancer(any(), any())).thenReturn(Completable.error(exception));
 
         loadBalancerResource.addLoadBalancer(TEST_JOB_ID, TEST_LOAD_BALANCER_ID);
     }
 
     @Test
     public void removeLoadBalancerSucceededTest() {
-        when(loadBalancerService.removeLoadBalancer(any())).thenReturn(Completable.complete());
+        when(loadBalancerService.removeLoadBalancer(any(), any())).thenReturn(Completable.complete());
 
         Response response = loadBalancerResource.removeLoadBalancer(TEST_JOB_ID, TEST_LOAD_BALANCER_ID);
         assertEquals(200, response.getStatus());
@@ -115,7 +115,7 @@ public class LoadBalancerResourceTest {
     @Test(expected = TitusServiceException.class)
     public void removeLoadBalancerFailedTest() {
         TitusServiceException exception = TitusServiceException.jobNotFound(TEST_JOB_ID);
-        when(loadBalancerService.removeLoadBalancer(any())).thenReturn(Completable.error(exception));
+        when(loadBalancerService.removeLoadBalancer(any(), any())).thenReturn(Completable.error(exception));
 
         loadBalancerResource.removeLoadBalancer(TEST_JOB_ID, TEST_LOAD_BALANCER_ID);
     }

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerSpringResourceTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerSpringResourceTest.java
@@ -26,7 +26,6 @@ import com.netflix.titus.grpc.protogen.GetJobLoadBalancersResult;
 import com.netflix.titus.grpc.protogen.JobId;
 import com.netflix.titus.grpc.protogen.LoadBalancerId;
 import com.netflix.titus.grpc.protogen.RemoveLoadBalancerRequest;
-import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
 import com.netflix.titus.runtime.service.LoadBalancerService;
 import com.netflix.titus.testkit.junit.spring.SpringMockMvcUtil;
 import org.junit.Test;
@@ -41,6 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import rx.Completable;
 import rx.Observable;
 
+import static com.netflix.titus.testkit.junit.spring.SpringMockMvcUtil.JUNIT_REST_CALL_METADATA;
 import static com.netflix.titus.testkit.junit.spring.SpringMockMvcUtil.NEXT_PAGE_OF_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
@@ -66,20 +66,17 @@ public class LoadBalancerSpringResourceTest {
     @MockBean
     private SystemLogService systemLogService;
 
-    @MockBean
-    private CallMetadataResolver callMetadataResolver;
-
     @Autowired
     private MockMvc mockMvc;
 
     @Test
     public void testGetJobLoadBalancers() throws Exception {
         JobId jobIdWrapper = JobId.newBuilder().setId(JOB_ID).build();
-        when(serviceMock.getLoadBalancers(jobIdWrapper)).thenReturn(Observable.just(GET_JOB_LOAD_BALANCERS_RESULT));
+        when(serviceMock.getLoadBalancers(jobIdWrapper, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(GET_JOB_LOAD_BALANCERS_RESULT));
         GetJobLoadBalancersResult entity = SpringMockMvcUtil.doGet(mockMvc, String.format("/api/v3/loadBalancers/%s", JOB_ID), GetJobLoadBalancersResult.class);
         assertThat(entity).isEqualTo(GET_JOB_LOAD_BALANCERS_RESULT);
 
-        verify(serviceMock, times(1)).getLoadBalancers(jobIdWrapper);
+        verify(serviceMock, times(1)).getLoadBalancers(jobIdWrapper, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -89,12 +86,12 @@ public class LoadBalancerSpringResourceTest {
                 .setPagination(SpringMockMvcUtil.paginationOf(NEXT_PAGE_OF_1))
                 .addJobLoadBalancers(GET_JOB_LOAD_BALANCERS_RESULT)
                 .build();
-        when(serviceMock.getAllLoadBalancers(request)).thenReturn(Observable.just(response));
+        when(serviceMock.getAllLoadBalancers(request, JUNIT_REST_CALL_METADATA)).thenReturn(Observable.just(response));
 
         GetAllLoadBalancersResult entity = SpringMockMvcUtil.doPaginatedGet(mockMvc, "/api/v3/loadBalancers", GetAllLoadBalancersResult.class, NEXT_PAGE_OF_1);
         assertThat(entity).isEqualTo(response);
 
-        verify(serviceMock, times(1)).getAllLoadBalancers(request);
+        verify(serviceMock, times(1)).getAllLoadBalancers(request, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -103,7 +100,7 @@ public class LoadBalancerSpringResourceTest {
                 .setJobId(JOB_ID)
                 .setLoadBalancerId(LoadBalancerId.newBuilder().setId(LOAD_BALANCER_ID).build())
                 .build();
-        when(serviceMock.addLoadBalancer(forwardedRequest)).thenReturn(Completable.complete());
+        when(serviceMock.addLoadBalancer(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
 
         SpringMockMvcUtil.doPost(
                 mockMvc,
@@ -113,7 +110,7 @@ public class LoadBalancerSpringResourceTest {
                 Optional.of(new String[]{"jobId", JOB_ID, "loadBalancerId", LOAD_BALANCER_ID})
         );
 
-        verify(serviceMock, times(1)).addLoadBalancer(forwardedRequest);
+        verify(serviceMock, times(1)).addLoadBalancer(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 
     @Test
@@ -122,7 +119,7 @@ public class LoadBalancerSpringResourceTest {
                 .setJobId(JOB_ID)
                 .setLoadBalancerId(LoadBalancerId.newBuilder().setId(LOAD_BALANCER_ID).build())
                 .build();
-        when(serviceMock.removeLoadBalancer(forwardedRequest)).thenReturn(Completable.complete());
+        when(serviceMock.removeLoadBalancer(forwardedRequest, JUNIT_REST_CALL_METADATA)).thenReturn(Completable.complete());
 
         SpringMockMvcUtil.doDelete(
                 mockMvc,
@@ -130,6 +127,6 @@ public class LoadBalancerSpringResourceTest {
                 "jobId", JOB_ID, "loadBalancerId", LOAD_BALANCER_ID
         );
 
-        verify(serviceMock, times(1)).removeLoadBalancer(forwardedRequest);
+        verify(serviceMock, times(1)).removeLoadBalancer(forwardedRequest, JUNIT_REST_CALL_METADATA);
     }
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/junit/spring/SpringMockMvcUtil.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/junit/spring/SpringMockMvcUtil.java
@@ -86,7 +86,7 @@ public final class SpringMockMvcUtil {
     }
 
     public static <E extends Message> E doGet(MockMvc mockMvc, String path, Class<E> entityType) throws Exception {
-        return executeGet(mockMvc, newBuilder(entityType), get(path));
+        return executeGet(mockMvc, newBuilder(entityType), MockMvcRequestBuilders.get(path).principal(JUNIT_AUTHENTICATION));
     }
 
     public static <E extends Message> E doPaginatedGet(MockMvc mockMvc, String path, Class<E> entityType, Page page, String... queryParameters) throws Exception {
@@ -160,6 +160,7 @@ public final class SpringMockMvcUtil {
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.put(path)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("UTF-8")
+                .principal(JUNIT_AUTHENTICATION)
                 .content(JsonFormat.printer().print(body));
         mockMvc.perform(requestBuilder)
                 .andDo(print())
@@ -167,10 +168,11 @@ public final class SpringMockMvcUtil {
                 .andReturn();
     }
 
-    public static <B extends Message> void doDelete(MockMvc mockMvc, String path, String... queryParameters) throws Exception {
+    public static void doDelete(MockMvc mockMvc, String path, String... queryParameters) throws Exception {
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.delete(path)
                 .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("UTF-8");
+                .characterEncoding("UTF-8")
+                .principal(JUNIT_AUTHENTICATION);
         for (int i = 0; i < queryParameters.length; i += 2) {
             requestBuilder.queryParam(queryParameters[i], queryParameters[i + 1]);
         }


### PR DESCRIPTION
With this change the CallMetadata processing is done at a transport level and passed
explicitly to downstream services. This makes it more robust, and less
implementation specific.
