### PR TITLE
Create all Pods concurrently in the fenzo result callback

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/TaskAssignments.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/TaskAssignments.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+import com.netflix.fenzo.VirtualMachineLease;
+import com.netflix.titus.common.util.tuple.Pair;
+
+public class TaskAssignments implements Iterable<TaskInfoRequest> {
+
+    private final List<Pair<Machine, List<TaskInfoRequest>>> assignmentsByMachine;
+    private final List<TaskInfoRequest> allTasks;
+
+    public TaskAssignments(List<Pair<Machine, List<TaskInfoRequest>>> assignmentsByMachine) {
+        this.assignmentsByMachine = assignmentsByMachine;
+        // the list below may need shuffling to avoid issues with bias on tasks being ordered by machine
+        this.allTasks = assignmentsByMachine.stream()
+                .flatMap(pair -> pair.getRight().stream())
+                .collect(Collectors.toList());
+    }
+
+    public int getCount() {
+        return allTasks.size();
+    }
+
+    public void forEach(BiConsumer<Machine, List<TaskInfoRequest>> consumer) {
+        for (Pair<Machine, List<TaskInfoRequest>> pair : assignmentsByMachine) {
+            consumer.accept(pair.getLeft(), pair.getRight());
+        }
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<TaskInfoRequest> iterator() {
+        return allTasks.iterator();
+    }
+
+    public static final class Machine {
+        private final String id;
+        private final List<VirtualMachineLease> leases;
+
+        public Machine(String id, List<VirtualMachineLease> leases) {
+            this.id = id;
+            this.leases = leases;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public List<VirtualMachineLease> getLeases() {
+            return leases;
+        }
+    }
+
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/VirtualMachineMasterService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/VirtualMachineMasterService.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import com.netflix.fenzo.VirtualMachineLease;
 import com.netflix.fenzo.functions.Action1;
-import org.apache.mesos.Protos;
 import rx.Observable;
 
 public interface VirtualMachineMasterService {
@@ -29,7 +28,7 @@ public interface VirtualMachineMasterService {
 
     void enterActiveMode();
 
-    void launchTasks(List<TaskInfoRequest> requests, List<VirtualMachineLease> leases);
+    void launchTasks(TaskAssignments taskAssignments);
 
     void rejectLease(VirtualMachineLease lease);
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
@@ -30,6 +30,7 @@ import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.mesos.ContainerEvent;
 import com.netflix.titus.master.mesos.LeaseRescindedEvent;
+import com.netflix.titus.master.mesos.TaskAssignments;
 import com.netflix.titus.master.mesos.TaskInfoRequest;
 import com.netflix.titus.master.mesos.TitusExecutorDetails;
 import com.netflix.titus.master.mesos.VirtualMachineMasterService;
@@ -147,7 +148,7 @@ class StubbedVirtualMachineMasterService implements VirtualMachineMasterService 
     }
 
     @Override
-    public void launchTasks(List<TaskInfoRequest> requests, List<VirtualMachineLease> leases) {
+    public void launchTasks(TaskAssignments taskAssignments) {
         throw new IllegalStateException("method not supported");
     }
 


### PR DESCRIPTION
Relevant **only when the kubernetes integration is enabled**, and **Fenzo is being used for scheduling** (not kube-scheduler).

Allow all pods to be created concurrently, instead of serializing calls per Node. In order to enable that, `VirtualMachineMasterService's` interface was modified to receive all assignments for all Nodes in a single call.