### PR TITLE
Fix scheduling classifier handling of ExclusiveHost hard constraint failures

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerUtils.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/SchedulerUtils.java
@@ -29,6 +29,7 @@ import com.netflix.fenzo.TaskRequest;
 import com.netflix.fenzo.TaskTracker;
 import com.netflix.fenzo.VirtualMachineCurrentState;
 import com.netflix.fenzo.VirtualMachineLease;
+import com.netflix.fenzo.plugins.ExclusiveHostConstraint;
 import com.netflix.fenzo.queues.QueuableTask;
 import com.netflix.titus.api.agent.model.AgentInstance;
 import com.netflix.titus.api.agent.model.AgentInstanceGroup;
@@ -54,6 +55,10 @@ public class SchedulerUtils {
             tier = Tier.Critical;
         }
         return tier;
+    }
+
+    public static boolean hasExclusiveHostHardConstraint(TaskRequest task) {
+        return task.getHardConstraints().stream().anyMatch(constraint -> constraint instanceof ExclusiveHostConstraint);
     }
 
     public static boolean hasGpuRequest(QueuableTask task) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
@@ -81,6 +81,8 @@ public class TaskPlacementFailure {
 
         /**
          * Task not launched due to other tasks with the exclusiveHost hard constraint on the same agent. It has the lowest priority.
+         *
+         * @see TaskPlacementFailureClassifier for how {@link FailureKind failure kinds} are used and what are their priorities
          */
         ExclusiveHost,
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
@@ -79,6 +79,11 @@ public class TaskPlacementFailure {
          */
         OpportunisticResource,
 
+        /**
+         * Task not launched due to other tasks with the exclusiveHost hard constraint on the same agent. It has the lowest priority.
+         */
+        ExclusiveHost,
+
         Unrecognized;
 
         /**
@@ -91,8 +96,8 @@ public class TaskPlacementFailure {
         );
 
         /**
-         * <tt>TRANSIENT</tt>, <tt>AgentContainerLimit</tt>, and <tt>NoActiveAgent</tt> (all agents are non-schedulable
-         * for a task) must never modify opportunistic scheduling behavior.
+         * Super set of <tt>TRANSIENT</tt> failures that must never modify opportunistic scheduling behavior. It
+         * includes failures that are expected to disappear after more capacity is added by {@link ClusterAgentAutoScaler}
          *
          * @see DefaultSchedulingService
          */
@@ -100,6 +105,8 @@ public class TaskPlacementFailure {
                 .addAll(TRANSIENT)
                 .add(AgentContainerLimit)
                 .add(NoActiveAgents)
+                .add(JobHardConstraint)
+                .add(ExclusiveHost)
                 .build();
 
         /**

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailure.java
@@ -84,11 +84,15 @@ public class TaskPlacementFailure {
         /**
          * Failures that are expected to go away, and should not be acted upon
          */
-        public static final Set<FailureKind> TRANSIENT = Sets.immutableEnumSet(WaitingForInUseIpAllocation, LaunchGuard);
+        public static final Set<FailureKind> TRANSIENT = Sets.immutableEnumSet(
+                WaitingForInUseIpAllocation,
+                LaunchGuard,
+                KubeApiNotReady
+        );
 
         /**
-         * <tt>TRANSIENT</tt> and <tt>NoActiveAgent</tt> (all agents are non-schedulable for a task) must never modify
-         * opportunistic scheduling behavior.
+         * <tt>TRANSIENT</tt>, <tt>AgentContainerLimit</tt>, and <tt>NoActiveAgent</tt> (all agents are non-schedulable
+         * for a task) must never modify opportunistic scheduling behavior.
          *
          * @see DefaultSchedulingService
          */
@@ -103,7 +107,11 @@ public class TaskPlacementFailure {
          *
          * @see ClusterAgentAutoScaler
          */
-        public static final Set<FailureKind> NEVER_TRIGGER_AUTOSCALING = Sets.immutableEnumSet(WaitingForInUseIpAllocation, OpportunisticResource);
+        public static final Set<FailureKind> NEVER_TRIGGER_AUTOSCALING = Sets.immutableEnumSet(
+                WaitingForInUseIpAllocation,
+                OpportunisticResource,
+                KubeApiNotReady
+        );
     }
 
     private final String taskId;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailureClassifier.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailureClassifier.java
@@ -297,7 +297,6 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
         return true;
     }
 
-
     private boolean processInUseIpAllocation(T taskRequest, List<TaskAssignmentResult> assignmentResults,
                                              Map<FailureKind, Map<T, List<TaskPlacementFailure>>> resultCollector) {
         int count = 0;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailureClassifier.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailureClassifier.java
@@ -139,7 +139,8 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
                 && !processAgentContainerLimit(taskRequest, assignmentResults, resultCollector)
                 && !processJobHardConstraints(taskRequest, assignmentResults, resultCollector)
                 && !processInUseIpAllocation(taskRequest, assignmentResults, resultCollector)
-                && !processOpportunisticResources(taskRequest, assignmentResults, resultCollector)) {
+                && !processOpportunisticResources(taskRequest, assignmentResults, resultCollector)
+                && !processExclusiveHost(taskRequest, assignmentResults, resultCollector)) {
             addToResultCollector(taskRequest, assignmentResults, resultCollector, -1, FailureKind.Unrecognized);
         }
     }
@@ -250,7 +251,7 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
         int count = 0;
         Set<String> hardConstraints = new HashSet<>();
         for (TaskAssignmentResult assignmentResult : assignmentResults) {
-            if (isJobHardConstraint(assignmentResult, hardConstraints)) {
+            if (isJobHardConstraint(taskRequest, assignmentResult, hardConstraints)) {
                 count++;
             }
         }
@@ -261,9 +262,41 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
         resultCollector.computeIfAbsent(FailureKind.JobHardConstraint, k -> new HashMap<>())
                 .computeIfAbsent(taskRequest, k -> new ArrayList<>())
                 .add(new JobHardConstraintPlacementFailure(taskRequest.getId(), count, hardConstraints, SchedulerUtils.getTier((QueuableTask) taskRequest), buildRawDataMap(taskRequest, assignmentResults)));
-
         return true;
     }
+
+    /**
+     * Failures on agents that already contain other tasks with ExclusiveHost hard constraints.
+     * <p>
+     * {@link FailureKind#ExclusiveHost} is the lowest priority and needs to be last in the chain since it only matters
+     * when it is the only failure on all agents.
+     */
+    private boolean processExclusiveHost(T taskRequest, List<TaskAssignmentResult> assignmentResults,
+                                         Map<FailureKind, Map<T, List<TaskPlacementFailure>>> resultCollector) {
+        if (SchedulerUtils.hasExclusiveHostHardConstraint(taskRequest)) {
+            return false; // should have been handled by processJobHardConstraints
+        }
+
+        int count = 0;
+        for (TaskAssignmentResult assignmentResult : assignmentResults) {
+            if (EXCLUSIVE_HOST_CONSTRAINT_NAME.equals(assignmentResult.getConstraintFailure().getName())) {
+                count++;
+            }
+        }
+        if (count == 0) {
+            return false;
+        }
+
+        resultCollector.computeIfAbsent(FailureKind.ExclusiveHost, k -> new HashMap<>())
+                .computeIfAbsent(taskRequest, k -> new ArrayList<>())
+                .add(new JobHardConstraintPlacementFailure(taskRequest.getId(), count,
+                        Collections.singleton(EXCLUSIVE_HOST_CONSTRAINT_NAME),
+                        SchedulerUtils.getTier((QueuableTask) taskRequest),
+                        buildRawDataMap(taskRequest, assignmentResults)
+                ));
+        return true;
+    }
+
 
     private boolean processInUseIpAllocation(T taskRequest, List<TaskAssignmentResult> assignmentResults,
                                              Map<FailureKind, Map<T, List<TaskPlacementFailure>>> resultCollector) {
@@ -375,7 +408,7 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
         return false;
     }
 
-    private boolean isJobHardConstraint(TaskAssignmentResult assignmentResult, Set<String> constraintCollector) {
+    private boolean isJobHardConstraint(T taskRequest, TaskAssignmentResult assignmentResult, Set<String> constraintCollector) {
         ConstraintFailure constraintFailure = assignmentResult.getConstraintFailure();
         if (constraintFailure == null || StringExt.isEmpty(constraintFailure.getName())) {
             return false;
@@ -384,7 +417,11 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
         String name = constraintFailure.getName();
         if (name.equals(V3UniqueHostConstraint.NAME)
                 || name.equals(V3ZoneBalancedHardConstraintEvaluator.NAME)
-                || name.equals(EXCLUSIVE_HOST_CONSTRAINT_NAME)) {
+                // ExclusiveHost failures apply both to tasks with the hard constraint, and tasks that didn't have the
+                // constraint, but were evaluated on agents already containing other tasks with the constraint. The
+                // former is classified as a JobHardConstraint failure, the latter is left to be marked as ExclusiveHost
+                // later in the chain
+                || (name.equals(EXCLUSIVE_HOST_CONSTRAINT_NAME) && SchedulerUtils.hasExclusiveHostHardConstraint(taskRequest))) {
             constraintCollector.add(name);
             return true;
         }


### PR DESCRIPTION
A failure for a task with the `ExclusiveHost` hard constraint is different from other tasks failing on a machine because it is already running another task with `ExclusiveHost`.

Both failure modes are classified with different priority to avoid prematurely triggering the ClusterAgentAutoscaler, when tasks that don't have the hard constraint are failing due to other transient scheduling failures.

Automated testing of this part of the codebase is unfortunately pretty difficult due to some Fenzo classes not being public and/or mockable, so I'm punting on junit tests.