### PR TITLE
kube-scheduler: case insensitive constraint names

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/CollectionsExt.java
@@ -595,6 +595,31 @@ public final class CollectionsExt {
         return -from - 1;
     }
 
+    /**
+     * Convert all keys to lower case, the behavior is undefined when values clash, and only one will be kept
+     */
+    public static <V> Map<String, V> toLowerCaseKeys(Map<String, V> entries) {
+        return entries.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> e.getKey().toLowerCase(),
+                        Map.Entry::getValue,
+                        (o, n) -> n
+                ));
+    }
+
+    /**
+     * Convert all keys to lower case, the behavior is undefined when values clash, and only one will be kept
+     */
+    public static <V> Map<String, V> toLowerCaseKeys(Map<String, V> entries, Supplier<Map<String, V>> mapSupplier) {
+        return entries.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> e.getKey().toLowerCase(),
+                        Map.Entry::getValue,
+                        (o, n) -> n,
+                        mapSupplier
+                ));
+    }
+
     public static class MapBuilder<K, V> {
 
         private final Map<K, V> out;

--- a/titus-common/src/test/java/com/netflix/titus/common/util/CollectionsExtTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/CollectionsExtTest.java
@@ -96,4 +96,11 @@ public class CollectionsExtTest {
             );
         }
     }
+
+    @Test
+    public void mapLowerCaseKeys() {
+        Map<String, String> result = CollectionsExt.toLowerCaseKeys(CollectionsExt.asMap("a", "foo", "b", "bar", "mIxEd", "UntouChed"));
+        assertThat(result).containsOnlyKeys("a", "b", "mixed");
+        assertThat(result).containsValues("foo", "bar", "UntouChed");
+    }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultPodAffinityFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultPodAffinityFactory.java
@@ -39,6 +39,8 @@ import io.kubernetes.client.openapi.models.V1PodAntiAffinity;
 import io.kubernetes.client.openapi.models.V1PreferredSchedulingTerm;
 import io.kubernetes.client.openapi.models.V1WeightedPodAffinityTerm;
 
+import static com.netflix.titus.common.util.CollectionsExt.toLowerCaseKeys;
+
 @Singleton
 public class DefaultPodAffinityFactory implements PodAffinityFactory {
 
@@ -55,22 +57,20 @@ public class DefaultPodAffinityFactory implements PodAffinityFactory {
 
     @Override
     public V1Affinity buildV1Affinity(Job<?> job, Task task) {
-        return new Processor(job, task).build();
+        return new Processor(job).build();
     }
 
     private class Processor {
 
         private final Job<?> job;
-        private final Task task;
         private final V1Affinity v1Affinity;
 
-        private Processor(Job<?> job, Task task) {
+        private Processor(Job<?> job) {
             this.job = job;
-            this.task = task;
             this.v1Affinity = new V1Affinity();
 
-            processJobConstraints(job.getJobDescriptor().getContainer().getHardConstraints(), true);
-            processJobConstraints(job.getJobDescriptor().getContainer().getSoftConstraints(), false);
+            processJobConstraints(toLowerCaseKeys(job.getJobDescriptor().getContainer().getHardConstraints()), true);
+            processJobConstraints(toLowerCaseKeys(job.getJobDescriptor().getContainer().getSoftConstraints()), false);
             processZoneConstraints();
         }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultSchedulingService.java
@@ -531,6 +531,9 @@ public class DefaultSchedulingService implements SchedulingService<V3QueueableTa
     }
 
     private void launchTasks(TaskAssignments taskAssignments) {
+        if (taskAssignments.getCount() <= 0) {
+            return; // noop
+        }
         long mesosStartTime = titusRuntime.getClock().wallTime();
         try {
             virtualMachineService.launchTasks(taskAssignments);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultPodAffinityFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultPodAffinityFactoryTest.java
@@ -53,7 +53,7 @@ public class DefaultPodAffinityFactoryTest {
 
     @Test
     public void testInstanceTypeAffinity() {
-        V1Affinity affinity = factory.buildV1Affinity(newJobWithHardConstraint(JobConstraints.MACHINE_TYPE, "r5.metal"), JobGenerator.oneBatchTask());
+        V1Affinity affinity = factory.buildV1Affinity(newJobWithHardConstraint(JobConstraints.MACHINE_TYPE.toUpperCase(), "r5.metal"), JobGenerator.oneBatchTask());
         V1NodeSelector nodeSelector = affinity.getNodeAffinity().getRequiredDuringSchedulingIgnoredDuringExecution();
         assertThat(nodeSelector.getNodeSelectorTerms()).hasSize(1);
     }


### PR DESCRIPTION
Input in jobDescriptors does not consider constraint names to be case sensitive. Likely the same for constraint values, but since some of them are identifiers, I opted to leave them untouched.