### PR TITLE
exclusiveHost prevents opportunistic scheduling

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobConstraints.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobConstraints.java
@@ -70,6 +70,11 @@ public class JobConstraints {
      */
     public static final String KUBE_BACKEND = "kubebackend";
 
+    /**
+     * Taints that are tolerated on Kubernetes Nodes.
+     */
+    public static final String TOLERATION = "toleration";
+
     public static final Set<String> CONSTRAINT_NAMES = asSet(
             UNIQUE_HOST,
             EXCLUSIVE_HOST,

--- a/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScaler.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/clusteroperations/ClusterAgentAutoScaler.java
@@ -80,6 +80,10 @@ import rx.Completable;
 import rx.Scheduler;
 import rx.Subscription;
 
+import static com.netflix.titus.api.jobmanager.JobConstraints.MACHINE_GROUP;
+import static com.netflix.titus.api.jobmanager.JobConstraints.MACHINE_ID;
+import static com.netflix.titus.api.jobmanager.JobConstraints.MACHINE_TYPE;
+import static com.netflix.titus.api.jobmanager.JobConstraints.TOLERATION;
 import static com.netflix.titus.common.util.CollectionsExt.asSet;
 import static com.netflix.titus.master.MetricConstants.METRIC_CLUSTER_OPERATIONS;
 import static com.netflix.titus.master.clusteroperations.ClusterOperationFunctions.canFit;
@@ -108,7 +112,7 @@ public class ClusterAgentAutoScaler {
 
     private static final Comparator<AgentInstanceGroup> PREFER_ACTIVE_INSTANCE_GROUP_COMPARATOR = Comparator.comparing(ig -> ig.getLifecycleStatus().getState());
     private static final Comparator<AgentInstanceGroup> PREFER_PHASED_OUT_INSTANCE_GROUP_COMPARATOR = PREFER_ACTIVE_INSTANCE_GROUP_COMPARATOR.reversed();
-    private static final Set<String> IGNORED_HARD_CONSTRAINT_NAMES = asSet("machineid", "machinegroup", "machinetype", "toleration");
+    private static final Set<String> IGNORED_HARD_CONSTRAINT_NAMES = asSet(MACHINE_ID, MACHINE_GROUP, MACHINE_TYPE, TOLERATION);
     private static final Set<FailureKind> IGNORED_FAILURE_KINDS_WITH_LAUNCHGUARD = ImmutableSet.<FailureKind>builder()
             .addAll(FailureKind.NEVER_TRIGGER_AUTOSCALING)
             .add(FailureKind.LaunchGuard)

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/V3QueueableTask.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/V3QueueableTask.java
@@ -41,6 +41,7 @@ import com.netflix.titus.api.jobmanager.model.job.TwoLevelResource;
 import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.model.job.TitusQueuableTask;
+import com.netflix.titus.master.scheduler.SchedulerUtils;
 import com.netflix.titus.master.scheduler.constraint.ConstraintEvaluatorTransformer;
 import com.netflix.titus.master.scheduler.constraint.SystemHardConstraint;
 import com.netflix.titus.master.scheduler.constraint.SystemSoftConstraint;
@@ -259,13 +260,15 @@ public class V3QueueableTask implements TitusQueuableTask<Job, Task> {
      * Minimum requirements for opportunistic CPU scheduling:
      * <ul>
      *     <li>Opportunistic scheduling must be enabled system-wide.</li>
+     *     <li>Must not have the {@link com.netflix.titus.api.jobmanager.JobConstraints#EXCLUSIVE_HOST} hard constraint.</li>
      *     <li>Task must have a runtime prediction.</li>
      *     <li>Task must explicitly request an amount of opportunistic cpu.</li>
      * </ul>
      */
     @Override
     public boolean isCpuOpportunistic() {
-        return opportunisticCpuEnabled && runtimePrediction.isPresent() && getOpportunisticCpus() > 0;
+        return opportunisticCpuEnabled && !SchedulerUtils.hasExclusiveHostHardConstraint(this)
+                && runtimePrediction.isPresent() && getOpportunisticCpus() > 0;
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/V3ConstraintEvaluatorTransformer.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/constraint/V3ConstraintEvaluatorTransformer.java
@@ -35,6 +35,16 @@ import com.netflix.titus.master.scheduler.resourcecache.TaskCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.netflix.titus.api.jobmanager.JobConstraints.ACTIVE_HOST;
+import static com.netflix.titus.api.jobmanager.JobConstraints.AVAILABILITY_ZONE;
+import static com.netflix.titus.api.jobmanager.JobConstraints.EXCLUSIVE_HOST;
+import static com.netflix.titus.api.jobmanager.JobConstraints.MACHINE_GROUP;
+import static com.netflix.titus.api.jobmanager.JobConstraints.MACHINE_ID;
+import static com.netflix.titus.api.jobmanager.JobConstraints.MACHINE_TYPE;
+import static com.netflix.titus.api.jobmanager.JobConstraints.TOLERATION;
+import static com.netflix.titus.api.jobmanager.JobConstraints.UNIQUE_HOST;
+import static com.netflix.titus.api.jobmanager.JobConstraints.ZONE_BALANCE;
+
 /**
  * Maps V3 API constraint definitions into Fenzo model.
  * Supported Constraints:
@@ -61,17 +71,6 @@ public class V3ConstraintEvaluatorTransformer implements ConstraintEvaluatorTran
     private static final int EXPECTED_NUM_ZONES = 3;
 
     private static final ExclusiveHostConstraint EXCLUSIVE_HOST_CONSTRAINT = new ExclusiveHostConstraint();
-    private static final String EXCLUSIVE_HOST = "exclusivehost";
-    private static final String UNIQUE_HOST = "uniquehost";
-    private static final String ZONE_BALANCE = "zonebalance";
-
-    // Advanced Constraints
-    private static final String ACTIVE_HOST = "activehost";
-    private static final String AVAILABILITY_ZONE = "availabilityzone";
-    private static final String MACHINE_ID = "machineid";
-    private static final String MACHINE_GROUP = "machinegroup";
-    private static final String MACHINE_TYPE = "machinetype";
-    private static final String TOLERATION = "toleration";
 
     private final MasterConfiguration config;
     private final SchedulerConfiguration schedulerConfiguration;


### PR DESCRIPTION
Semantically it does not have sense to combine them both. In practice tasks that are assigned opportunistic CPUs may never be scheduled if they have the ExclusiveHost hard constraint, since there will be never any donors of underutilized CPUs on the same machine.

Unschedulable tasks end up triggering periodic (constant) scale ups of host machines (`ClusterAgentAutoScaler`).