### PR TITLE
Scheduling failures classifier can throw NPEs

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/code/LoggingCodeInvariants.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/code/LoggingCodeInvariants.java
@@ -97,8 +97,9 @@ public class LoggingCodeInvariants extends CodeInvariants {
             logger.warn(message);
         } else {
             String exceptionMessage = e.getMessage() != null ? e.getMessage() : "";
-            String errorLocation = (e.getStackTrace() != null && e.getStackTrace().length > 0)
-                    ? e.getStackTrace()[0].toString()
+            StackTraceElement[] stackTrace = e.getStackTrace();
+            String errorLocation = (stackTrace != null && stackTrace.length > 0)
+                    ? stackTrace[0].toString()
                     : "no data";
             logger.warn("{}: error={}({}), at={}", message, e.getClass().getSimpleName(), exceptionMessage, errorLocation);
             logger.debug(message, e);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailureClassifier.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/TaskPlacementFailureClassifier.java
@@ -279,7 +279,7 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
 
         int count = 0;
         for (TaskAssignmentResult assignmentResult : assignmentResults) {
-            if (EXCLUSIVE_HOST_CONSTRAINT_NAME.equals(assignmentResult.getConstraintFailure().getName())) {
+            if (isExclusiveHost(assignmentResult.getConstraintFailure())) {
                 count++;
             }
         }
@@ -426,6 +426,13 @@ class TaskPlacementFailureClassifier<T extends TaskRequest> {
         }
 
         return false;
+    }
+
+    private boolean isExclusiveHost(ConstraintFailure constraintFailure) {
+        if (constraintFailure == null || StringExt.isEmpty(constraintFailure.getName())) {
+            return false;
+        }
+        return EXCLUSIVE_HOST_CONSTRAINT_NAME.equals(constraintFailure.getName());
     }
 
     private boolean isInUseIpAllocation(TaskAssignmentResult assignmentResult) {


### PR DESCRIPTION
These changes protect against NPEs when evaluating failures due to the `ExclusiveHost` constraint on a task already running on machines being evaluated. Not all scheduling failures will have a `ConstraintFailure` filled by Fenzo, and it can be `null`.