### PR TITLE
Extract GC controller logic from KubeApiServerIntegrator

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/MetricConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/MetricConstants.java
@@ -45,5 +45,7 @@ public class MetricConstants {
 
     public static final String METRIC_KUBERNETES = METRIC_ROOT + "kubernetes.";
 
+    public static final String METRIC_KUBERNETES_CONTROLLER = METRIC_KUBERNETES + "controller.";
+
     public static final String METRIC_LOADBALANCER = METRIC_ROOT + "loadBalancer.";
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/BaseGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/BaseGcController.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.PreDestroy;
+
+import com.netflix.spectator.api.Gauge;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.framework.scheduler.ScheduleReference;
+import com.netflix.titus.common.framework.scheduler.model.ScheduleDescriptor;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.Evaluators;
+import com.netflix.titus.common.util.ExecutorsExt;
+import com.netflix.titus.common.util.guice.annotation.Activator;
+import com.netflix.titus.common.util.guice.annotation.Deactivator;
+import com.netflix.titus.common.util.limiter.Limiters;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.limiter.tokenbucket.TokenBucket;
+import com.netflix.titus.master.MetricConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class BaseGcController<T> {
+    private static final Logger logger = LoggerFactory.getLogger(BaseGcController.class);
+
+    protected final String name;
+    protected final String description;
+    protected final TitusRuntime titusRuntime;
+    protected final LocalScheduler scheduler;
+    protected final FixedIntervalTokenBucketConfiguration tokenBucketConfiguration;
+    protected final ControllerConfiguration controllerConfiguration;
+
+    protected String metricRoot;
+    protected ExecutorService executorService;
+    protected ScheduleReference schedulerRef;
+    protected TokenBucket tokenBucket;
+
+    protected final Gauge skippedGauge;
+    protected final Gauge successesGauge;
+    protected final Gauge failuresGauge;
+
+    public BaseGcController(
+            String name,
+            String description,
+            TitusRuntime titusRuntime,
+            LocalScheduler scheduler,
+            FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+            ControllerConfiguration controllerConfiguration
+    ) {
+        this.name = name;
+        this.description = description;
+        this.titusRuntime = titusRuntime;
+        this.scheduler = scheduler;
+
+        this.metricRoot = MetricConstants.METRIC_KUBERNETES_CONTROLLER + name;
+
+        this.skippedGauge = titusRuntime.getRegistry().gauge(metricRoot, "type", "skipped");
+        this.successesGauge = titusRuntime.getRegistry().gauge(metricRoot, "type", "successes");
+        this.failuresGauge = titusRuntime.getRegistry().gauge(metricRoot, "type", "failures");
+        this.tokenBucketConfiguration = tokenBucketConfiguration;
+        this.controllerConfiguration = controllerConfiguration;
+    }
+
+    @Activator
+    public void enterActiveMode() {
+        ScheduleDescriptor gcScheduleDescriptor = ScheduleDescriptor.newBuilder()
+                .withName(name)
+                .withDescription(description)
+                .withInitialDelay(Duration.ofMillis(controllerConfiguration.getControllerInitialDelayMs()))
+                .withInterval(Duration.ofMillis(controllerConfiguration.getControllerIntervalMs()))
+                .withTimeout(Duration.ofMillis(controllerConfiguration.getControllerTimeoutMs()))
+                .build();
+
+        executorService = ExecutorsExt.namedSingleThreadExecutor(name);
+        schedulerRef = scheduler.schedule(gcScheduleDescriptor, e -> doGc(), executorService);
+
+        tokenBucket = Limiters.createInstrumentedFixedIntervalTokenBucket(
+                name + "TokenBucket",
+                tokenBucketConfiguration,
+                currentTokenBucket -> logger.info("Token bucket: {} configuration updated with: {}", name, currentTokenBucket),
+                titusRuntime
+        );
+    }
+
+    @Deactivator
+    @PreDestroy
+    public void shutdown() {
+        Evaluators.acceptNotNull(executorService, ExecutorService::shutdown);
+        Evaluators.acceptNotNull(schedulerRef, ScheduleReference::cancel);
+        resetGauges();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getMetricRoot() {
+        return metricRoot;
+    }
+
+    private void doGc() {
+        if (!controllerConfiguration.isControllerEnabled() || !shouldGc()) {
+            logger.info("Skipping gc execution for: {}", name);
+            resetGauges();
+            return;
+        }
+
+        List<T> allItemsToGc = Collections.emptyList();
+        try {
+            allItemsToGc = getItemsToGc();
+        } catch (Exception e) {
+            logger.error("Unable to get items to GC due to:", e);
+        }
+
+        int total = allItemsToGc.size();
+        int limitedNumberOfItemsToGc = (int) Math.min(total, tokenBucket.getNumberOfTokens());
+        int skipped = total - limitedNumberOfItemsToGc;
+        int successes = 0;
+        int failures = 0;
+
+        if (limitedNumberOfItemsToGc > 0 && tokenBucket.tryTake(limitedNumberOfItemsToGc)) {
+            List<T> itemsToGc = allItemsToGc.subList(0, limitedNumberOfItemsToGc);
+            logger.debug("Attempting to GC: {}", itemsToGc);
+            for (T item : itemsToGc) {
+                try {
+                    if (gcItem(item)) {
+                        successes++;
+                    } else {
+                        failures++;
+                    }
+                } catch (Exception e) {
+                    failures++;
+                    logger.error("Unable to GC: {} due to:", item, e);
+                }
+            }
+        }
+        setGauges(skipped, successes, failures);
+        logger.info("Finished GC iteration total:{}, skipped: {}, successes: {}, failures: {}", total,
+                skipped, successes, failures);
+    }
+
+    public abstract boolean shouldGc();
+
+    public abstract List<T> getItemsToGc();
+
+    public abstract boolean gcItem(T item);
+
+    private void setGauges(int skipped, int successes, int failures) {
+        skippedGauge.set(skipped);
+        successesGauge.set(successes);
+        failuresGauge.set(failures);
+    }
+
+    private void resetGauges() {
+        setGauges(0, 0, 0);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/ControllerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/ControllerConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+
+@Configuration(prefix = "titus.kubernetes.controller")
+public interface ControllerConfiguration {
+
+    /**
+     * @return whether or not the controller is enabled
+     */
+    @DefaultValue("true")
+    boolean isControllerEnabled();
+
+    /**
+     * @return the initial delay in milliseconds before the execution runs after process startup.
+     */
+    @DefaultValue("10000")
+    long getControllerInitialDelayMs();
+
+    /**
+     * @return the interval in milliseconds of how often the controller runs.
+     */
+    @DefaultValue("30000")
+    long getControllerIntervalMs();
+
+    /**
+     * @return the timeout of the controller's execution loop.
+     */
+    @DefaultValue("60000")
+    long getControllerTimeoutMs();
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/GcControllerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/GcControllerUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import com.google.gson.JsonSyntaxException;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1Pod;
+import org.slf4j.Logger;
+
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.BACKGROUND;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.DEFAULT_NAMESPACE;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.NOT_FOUND;
+
+public final class GcControllerUtil {
+
+    public static boolean deleteNode(KubeApiFacade kubeApiFacade, Logger logger, V1Node node) {
+        String nodeName = KubeUtil.getMetadataName(node.getMetadata());
+        try {
+            kubeApiFacade.getCoreV1Api().deleteNode(
+                    nodeName,
+                    null,
+                    null,
+                    0,
+                    null,
+                    BACKGROUND,
+                    null
+            );
+            return true;
+        } catch (JsonSyntaxException e) {
+            // this will be counted as successful as the response type mapping in the client is incorrect
+            return true;
+        } catch (ApiException e) {
+            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+                logger.error("Failed to delete node: {} with error: ", nodeName, e);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to delete node: {} with error: ", nodeName, e);
+        }
+        return false;
+    }
+
+    public static boolean deletePod(KubeApiFacade kubeApiFacade, Logger logger, V1Pod pod) {
+        String podName = KubeUtil.getMetadataName(pod.getMetadata());
+        try {
+            kubeApiFacade.getCoreV1Api().deleteNamespacedPod(
+                    podName,
+                    DEFAULT_NAMESPACE,
+                    null,
+                    null,
+                    0,
+                    null,
+                    BACKGROUND,
+                    null
+            );
+            return true;
+        } catch (JsonSyntaxException e) {
+            // this will be counted as successful as the response type mapping in the client is incorrect
+            return true;
+        } catch (ApiException e) {
+            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+                logger.error("Failed to delete pod: {} with error: ", podName, e);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to delete pod: {} with error: ", podName, e);
+        }
+        return false;
+    }
+
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/KubeControllerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/KubeControllerConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+
+@Configuration(prefix = "titus.kubernetes.controller")
+public interface KubeControllerConfiguration {
+
+    /**
+     * @return the accountId to use for GC.
+     */
+    @DefaultValue("")
+    String getAccountId();
+
+    /**
+     * @return the grace period of how old the Ready condition's timestamp can be before attempting to GC a node.
+     */
+    @DefaultValue("300000")
+    long getNodeGcGracePeriodMs();
+
+    /**
+     * Amount of time to wait before GC'ing a pod that is past its deletion timestamp. .
+     */
+    @DefaultValue("1800000")
+    long getPodsPastTerminationGracePeriodMs();
+
+    /**
+     * Amount of time to wait after the pod creation timestamp for unknown pods before deleting the pod.
+     */
+    @DefaultValue("300000")
+    long getPodUnknownGracePeriodMs();
+
+    /**
+     * Amount of time to wait after the pod finished timestamp for terminal pods before deleting the pod.
+     */
+    @DefaultValue("300000")
+    long getPodTerminalGracePeriodMs();
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/KubeControllerModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/KubeControllerModule.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.archaius.ConfigProxyFactory;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+
+import static com.netflix.titus.master.kubernetes.controller.NodeGcController.NODE_GC_CONTROLLER;
+import static com.netflix.titus.master.kubernetes.controller.PodDeletionGcController.POD_DELETION_GC_CONTROLLER;
+import static com.netflix.titus.master.kubernetes.controller.PodOnUnknownNodeGcController.POD_ON_UNKNOWN_NODE_GC_CONTROLLER;
+import static com.netflix.titus.master.kubernetes.controller.PodTerminalGcController.POD_TERMINAL_GC_CONTROLLER;
+import static com.netflix.titus.master.kubernetes.controller.PodUnknownGcController.POD_UNKNOWN_GC_CONTROLLER;
+
+public class KubeControllerModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(NodeGcController.class).asEagerSingleton();
+        bind(PodOnUnknownNodeGcController.class).asEagerSingleton();
+        bind(PodDeletionGcController.class).asEagerSingleton();
+        bind(PodTerminalGcController.class).asEagerSingleton();
+        bind(PodUnknownGcController.class).asEagerSingleton();
+    }
+
+    @Provides
+    @Singleton
+    public KubeControllerConfiguration getKubeControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(KubeControllerConfiguration.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(NODE_GC_CONTROLLER)
+    public FixedIntervalTokenBucketConfiguration getNodeGcControllerTokenBucketConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(FixedIntervalTokenBucketConfiguration.class, "titus.kubernetes.controller." + NODE_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(NODE_GC_CONTROLLER)
+    public ControllerConfiguration getNodeGcControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + NODE_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_ON_UNKNOWN_NODE_GC_CONTROLLER)
+    public FixedIntervalTokenBucketConfiguration getPodOnUnknownNodeGcControllerTokenBucketConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(FixedIntervalTokenBucketConfiguration.class, "titus.kubernetes.controller." + POD_ON_UNKNOWN_NODE_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_ON_UNKNOWN_NODE_GC_CONTROLLER)
+    public ControllerConfiguration getPodOnUnknownNodeGcControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + POD_ON_UNKNOWN_NODE_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_DELETION_GC_CONTROLLER)
+    public FixedIntervalTokenBucketConfiguration getPodDeletionGcControllerTokenBucketConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(FixedIntervalTokenBucketConfiguration.class, "titus.kubernetes.controller." + POD_DELETION_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_DELETION_GC_CONTROLLER)
+    public ControllerConfiguration getPodDeletionGcControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + POD_DELETION_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_TERMINAL_GC_CONTROLLER)
+    public FixedIntervalTokenBucketConfiguration getPodTerminalGcControllerTokenBucketConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(FixedIntervalTokenBucketConfiguration.class, "titus.kubernetes.controller." + POD_TERMINAL_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_TERMINAL_GC_CONTROLLER)
+    public ControllerConfiguration getPodTerminalGcControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + POD_TERMINAL_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_UNKNOWN_GC_CONTROLLER)
+    public FixedIntervalTokenBucketConfiguration getPodUnknownGcControllerTokenBucketConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(FixedIntervalTokenBucketConfiguration.class, "titus.kubernetes.controller." + POD_UNKNOWN_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(POD_UNKNOWN_GC_CONTROLLER)
+    public ControllerConfiguration getPodUnknownGcControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + POD_UNKNOWN_GC_CONTROLLER);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.titus.api.agent.model.AgentInstance;
+import com.netflix.titus.api.agent.model.InstanceLifecycleState;
+import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.Clock;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1NodeCondition;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.NODE_LABEL_ACCOUNT_ID;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.READY;
+
+/**
+ * Responsible for deleting Kubernetes node objects when they no longer exist in agent management. This will eventually be moved
+ * to a new component.
+ */
+
+@Singleton
+public class NodeGcController extends BaseGcController<V1Node> {
+    public static final String NODE_GC_CONTROLLER = "nodeGcController";
+    public static final String NODE_GC_CONTROLLER_DESCRIPTION = "GC nodes that are not in agent management and are not reachable.";
+
+    private static final Logger logger = LoggerFactory.getLogger(NodeGcController.class);
+    private final AgentManagementService agentManagementService;
+    private final KubeApiFacade kubeApiFacade;
+    private final Clock clock;
+    private final KubeControllerConfiguration kubeControllerConfiguration;
+
+    @Inject
+    public NodeGcController(
+            TitusRuntime titusRuntime,
+            LocalScheduler scheduler,
+            @Named(NODE_GC_CONTROLLER) FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+            @Named(NODE_GC_CONTROLLER) ControllerConfiguration controllerConfiguration,
+            AgentManagementService agentManagementService,
+            KubeApiFacade kubeApiFacade,
+            KubeControllerConfiguration kubeControllerConfiguration
+    ) {
+        super(
+                NODE_GC_CONTROLLER,
+                NODE_GC_CONTROLLER_DESCRIPTION,
+                titusRuntime,
+                scheduler,
+                tokenBucketConfiguration,
+                controllerConfiguration
+        );
+        this.agentManagementService = agentManagementService;
+        this.kubeApiFacade = kubeApiFacade;
+        this.clock = titusRuntime.getClock();
+        this.kubeControllerConfiguration = kubeControllerConfiguration;
+    }
+
+    @Override
+    public boolean shouldGc() {
+        return kubeApiFacade.getNodeInformer().hasSynced();
+    }
+
+    @Override
+    public List<V1Node> getItemsToGc() {
+        return kubeApiFacade.getNodeInformer().getIndexer().list().stream()
+                .filter(this::isNodeInConfiguredAccount)
+                .filter(this::isNodeEligibleForGc)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean gcItem(V1Node item) {
+        return GcControllerUtil.deleteNode(kubeApiFacade, logger, item);
+    }
+
+    @VisibleForTesting
+    boolean isNodeInConfiguredAccount(V1Node node) {
+        V1ObjectMeta metadata = node.getMetadata();
+        if (metadata == null) {
+            return false;
+        }
+
+        Map<String, String> annotations = metadata.getAnnotations();
+        if (annotations == null || annotations.isEmpty()) {
+            return false;
+        }
+
+        String accountId = annotations.getOrDefault(NODE_LABEL_ACCOUNT_ID, "");
+        return accountId.equals(kubeControllerConfiguration.getAccountId());
+    }
+
+    @VisibleForTesting
+    boolean isNodeEligibleForGc(V1Node node) {
+        String nodeName = KubeUtil.getMetadataName(node.getMetadata());
+        Optional<V1NodeCondition> readyNodeConditionOpt = KubeUtil.findNodeCondition(node, READY);
+        if (StringExt.isNotEmpty(nodeName) && readyNodeConditionOpt.isPresent()) {
+            V1NodeCondition readyNodeCondition = readyNodeConditionOpt.get();
+            boolean isReadyConditionTimestampPastGracePeriod = hasConditionGracePeriodElapsed(readyNodeCondition,
+                    kubeControllerConfiguration.getNodeGcGracePeriodMs());
+            return isReadyConditionTimestampPastGracePeriod && isAgentInstanceNotAvailable(nodeName);
+        }
+        return false;
+    }
+
+    private boolean hasConditionGracePeriodElapsed(V1NodeCondition condition, long gracePeriodMs) {
+        DateTime lastHeartbeatTime = condition.getLastHeartbeatTime();
+        return lastHeartbeatTime != null && clock.isPast(lastHeartbeatTime.getMillis() + gracePeriodMs);
+    }
+
+    private boolean isAgentInstanceNotAvailable(String nodeName) {
+        if (StringExt.isEmpty(nodeName)) {
+            return false;
+        }
+
+        Optional<AgentInstance> agentInstanceOpt = agentManagementService.findAgentInstance(nodeName);
+        if (!agentInstanceOpt.isPresent()) {
+            return true;
+        }
+
+        AgentInstance agentInstance = agentInstanceOpt.get();
+        return agentInstance.getLifecycleStatus().getState() == InstanceLifecycleState.Stopped;
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodDeletionGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodDeletionGcController.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.Clock;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.PENDING;
+
+@Singleton
+public class PodDeletionGcController extends BaseGcController<V1Pod> {
+    public static final String POD_DELETION_GC_CONTROLLER = "podDeletionGcController";
+    public static final String POD_DELETION_GC_CONTROLLER_DESCRIPTION = "GC pods with a deletion timestamp that needs to be cleaned up.";
+
+    private static final Logger logger = LoggerFactory.getLogger(PodDeletionGcController.class);
+    private final KubeApiFacade kubeApiFacade;
+    private final Clock clock;
+    private final KubeControllerConfiguration kubeControllerConfiguration;
+
+    @Inject
+    public PodDeletionGcController(
+            TitusRuntime titusRuntime,
+            LocalScheduler scheduler,
+            @Named(POD_DELETION_GC_CONTROLLER) FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+            @Named(POD_DELETION_GC_CONTROLLER) ControllerConfiguration controllerConfiguration,
+            KubeApiFacade kubeApiFacade,
+            KubeControllerConfiguration kubeControllerConfiguration
+    ) {
+        super(
+                POD_DELETION_GC_CONTROLLER,
+                POD_DELETION_GC_CONTROLLER_DESCRIPTION,
+                titusRuntime,
+                scheduler,
+                tokenBucketConfiguration,
+                controllerConfiguration
+        );
+        this.kubeApiFacade = kubeApiFacade;
+        this.kubeControllerConfiguration = kubeControllerConfiguration;
+        this.clock = titusRuntime.getClock();
+    }
+
+    @Override
+    public boolean shouldGc() {
+        return kubeApiFacade.getNodeInformer().hasSynced() && kubeApiFacade.getPodInformer().hasSynced();
+    }
+
+    @Override
+    public List<V1Pod> getItemsToGc() {
+        return kubeApiFacade.getPodInformer().getIndexer().list()
+                .stream()
+                .filter(p -> isPodInPendingPhaseWithDeletionTimestamp(p) || isPodPastDeletionTimestamp(p))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean gcItem(V1Pod item) {
+        return GcControllerUtil.deletePod(kubeApiFacade, logger, item);
+    }
+
+    @VisibleForTesting
+    boolean isPodInPendingPhaseWithDeletionTimestamp(V1Pod pod) {
+        if (pod == null || pod.getMetadata() == null || pod.getStatus() == null) {
+            return false;
+        }
+        DateTime deletionTimestamp = pod.getMetadata().getDeletionTimestamp();
+        return deletionTimestamp != null && PENDING.equalsIgnoreCase(pod.getStatus().getPhase());
+    }
+
+    @VisibleForTesting
+    boolean isPodPastDeletionTimestamp(V1Pod pod) {
+        V1PodSpec spec = pod.getSpec();
+        V1ObjectMeta metadata = pod.getMetadata();
+        if (spec == null || metadata == null) {
+            return false;
+        }
+
+        Long terminationGracePeriodSeconds = spec.getTerminationGracePeriodSeconds();
+        DateTime deletionTimestamp = metadata.getDeletionTimestamp();
+        if (terminationGracePeriodSeconds == null || deletionTimestamp == null) {
+            return false;
+        }
+
+        long terminationGracePeriodMs = terminationGracePeriodSeconds * 1000L;
+        return clock.isPast(deletionTimestamp.getMillis() + terminationGracePeriodMs
+                + kubeControllerConfiguration.getPodsPastTerminationGracePeriodMs());
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodOnUnknownNodeGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodOnUnknownNodeGcController.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1Pod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Singleton
+public class PodOnUnknownNodeGcController extends BaseGcController<V1Pod> {
+    public static final String POD_ON_UNKNOWN_NODE_GC_CONTROLLER = "podOnUnknownNodeGcController";
+    public static final String POD_ON_UNKNOWN_NODE_GC_CONTROLLER_DESCRIPTION = "GC pods on unknown nodes.";
+
+    private static final Logger logger = LoggerFactory.getLogger(PodOnUnknownNodeGcController.class);
+    private final KubeApiFacade kubeApiFacade;
+
+    @Inject
+    public PodOnUnknownNodeGcController(
+            TitusRuntime titusRuntime,
+            LocalScheduler scheduler,
+            @Named(POD_ON_UNKNOWN_NODE_GC_CONTROLLER) FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+            @Named(POD_ON_UNKNOWN_NODE_GC_CONTROLLER) ControllerConfiguration controllerConfiguration,
+            KubeApiFacade kubeApiFacade
+    ) {
+        super(
+                POD_ON_UNKNOWN_NODE_GC_CONTROLLER,
+                POD_ON_UNKNOWN_NODE_GC_CONTROLLER_DESCRIPTION,
+                titusRuntime,
+                scheduler,
+                tokenBucketConfiguration,
+                controllerConfiguration
+        );
+        this.kubeApiFacade = kubeApiFacade;
+    }
+
+    @Override
+    public boolean shouldGc() {
+        return kubeApiFacade.getNodeInformer().hasSynced() && kubeApiFacade.getPodInformer().hasSynced();
+    }
+
+    @Override
+    public List<V1Pod> getItemsToGc() {
+        Set<String> knownNodeNames = kubeApiFacade.getNodeInformer().getIndexer().list()
+                .stream()
+                .map(n -> KubeUtil.getMetadataName(n.getMetadata()))
+                .collect(Collectors.toSet());
+        return kubeApiFacade.getPodInformer().getIndexer().list()
+                .stream()
+                .filter(p -> isPodOnUnknownNode(p, knownNodeNames))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean gcItem(V1Pod item) {
+        return GcControllerUtil.deletePod(kubeApiFacade, logger, item);
+    }
+
+    @VisibleForTesting
+    boolean isPodOnUnknownNode(V1Pod pod, Set<String> knownNodeNames) {
+        if (pod == null || pod.getSpec() == null) {
+            return false;
+        }
+
+        String nodeName = pod.getSpec().getNodeName();
+        return StringExt.isNotEmpty(nodeName) && !knownNodeNames.contains(nodeName);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodTerminalGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodTerminalGcController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.Clock;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class PodTerminalGcController extends BaseGcController<V1Pod> {
+    public static final String POD_TERMINAL_GC_CONTROLLER = "podTerminalGcController";
+    public static final String POD_TERMINAL_GC_CONTROLLER_DESCRIPTION = "GC pods that are terminal to Titus.";
+
+    private static final Logger logger = LoggerFactory.getLogger(PodTerminalGcController.class);
+    private final KubeApiFacade kubeApiFacade;
+    private final Clock clock;
+    private final KubeControllerConfiguration kubeControllerConfiguration;
+    private final V3JobOperations v3JobOperations;
+
+    @Inject
+    public PodTerminalGcController(
+            TitusRuntime titusRuntime,
+            LocalScheduler scheduler,
+            @Named(POD_TERMINAL_GC_CONTROLLER) FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+            @Named(POD_TERMINAL_GC_CONTROLLER) ControllerConfiguration controllerConfiguration,
+            KubeApiFacade kubeApiFacade,
+            KubeControllerConfiguration kubeControllerConfiguration,
+            V3JobOperations v3JobOperations
+    ) {
+        super(
+                POD_TERMINAL_GC_CONTROLLER,
+                POD_TERMINAL_GC_CONTROLLER_DESCRIPTION,
+                titusRuntime,
+                scheduler,
+                tokenBucketConfiguration,
+                controllerConfiguration
+        );
+        this.kubeApiFacade = kubeApiFacade;
+        this.kubeControllerConfiguration = kubeControllerConfiguration;
+        this.clock = titusRuntime.getClock();
+        this.v3JobOperations = v3JobOperations;
+    }
+
+    @Override
+    public boolean shouldGc() {
+        return kubeApiFacade.getPodInformer().hasSynced();
+    }
+
+    @Override
+    public List<V1Pod> getItemsToGc() {
+        Map<String, Task> currentTasks = v3JobOperations.getTasks().stream()
+                .collect(Collectors.toMap(Task::getId, Function.identity()));
+        return kubeApiFacade.getPodInformer().getIndexer().list().stream()
+                .filter(p -> isPodTerminal(p, currentTasks))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean gcItem(V1Pod item) {
+        return GcControllerUtil.deletePod(kubeApiFacade, logger, item);
+    }
+
+    @VisibleForTesting
+    boolean isPodTerminal(V1Pod pod, Map<String, Task> currentTasks) {
+        String podName = KubeUtil.getMetadataName(pod.getMetadata());
+        Task task = currentTasks.get(podName);
+        if (task != null) {
+            if (TaskState.isTerminalState(task.getStatus().getState())) {
+                return clock.isPast(task.getStatus().getTimestamp() + kubeControllerConfiguration.getPodTerminalGracePeriodMs());
+            }
+            return false;
+        }
+
+        V1PodStatus status = pod.getStatus();
+        if (status != null && KubeUtil.isPodPhaseTerminal(status.getPhase())) {
+            return KubeUtil.findFinishedTimestamp(pod)
+                    .map(timestamp -> clock.isPast(timestamp + kubeControllerConfiguration.getPodTerminalGracePeriodMs()))
+                    .orElse(true);
+        }
+        return false;
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodUnknownGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PodUnknownGcController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.Clock;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class PodUnknownGcController extends BaseGcController<V1Pod> {
+    public static final String POD_UNKNOWN_GC_CONTROLLER = "podUnknownGcController";
+    public static final String POD_UNKNOWN_GC_CONTROLLER_DESCRIPTION = "GC pods that are unknown to Titus.";
+
+    private static final Logger logger = LoggerFactory.getLogger(PodUnknownGcController.class);
+    private final KubeApiFacade kubeApiFacade;
+    private final Clock clock;
+    private final KubeControllerConfiguration kubeControllerConfiguration;
+    private final V3JobOperations v3JobOperations;
+
+    @Inject
+    public PodUnknownGcController(
+            TitusRuntime titusRuntime,
+            LocalScheduler scheduler,
+            @Named(POD_UNKNOWN_GC_CONTROLLER) FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+            @Named(POD_UNKNOWN_GC_CONTROLLER) ControllerConfiguration controllerConfiguration,
+            KubeApiFacade kubeApiFacade,
+            KubeControllerConfiguration kubeControllerConfiguration,
+            V3JobOperations v3JobOperations
+    ) {
+        super(
+                POD_UNKNOWN_GC_CONTROLLER,
+                POD_UNKNOWN_GC_CONTROLLER_DESCRIPTION,
+                titusRuntime,
+                scheduler,
+                tokenBucketConfiguration,
+                controllerConfiguration
+        );
+        this.kubeApiFacade = kubeApiFacade;
+        this.kubeControllerConfiguration = kubeControllerConfiguration;
+        this.clock = titusRuntime.getClock();
+        this.v3JobOperations = v3JobOperations;
+    }
+
+    @Override
+    public boolean shouldGc() {
+        return kubeApiFacade.getPodInformer().hasSynced();
+    }
+
+    @Override
+    public List<V1Pod> getItemsToGc() {
+        Map<String, Task> currentTasks = v3JobOperations.getTasks().stream()
+                .collect(Collectors.toMap(Task::getId, Function.identity()));
+        return kubeApiFacade.getPodInformer().getIndexer().list().stream()
+                .filter(p -> isPodUnknownToJobManagement(p, currentTasks))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean gcItem(V1Pod item) {
+        return GcControllerUtil.deletePod(kubeApiFacade, logger, item);
+    }
+
+    @VisibleForTesting
+    boolean isPodUnknownToJobManagement(V1Pod pod, Map<String, Task> currentTasks) {
+        V1ObjectMeta metadata = pod.getMetadata();
+        V1PodStatus status = pod.getStatus();
+
+        if (metadata == null || status == null) {
+            // this pod is missing data so GC it
+            return true;
+        }
+
+        if (KubeUtil.isPodPhaseTerminal(status.getPhase()) || currentTasks.containsKey(metadata.getName())) {
+            return false;
+        }
+
+        DateTime creationTimestamp = metadata.getCreationTimestamp();
+        return creationTimestamp != null &&
+                clock.isPast(creationTimestamp.getMillis() + kubeControllerConfiguration.getPodUnknownGracePeriodMs());
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeModule.java
@@ -29,6 +29,7 @@ import com.netflix.archaius.api.Config;
 import com.netflix.titus.api.FeatureActivationConfiguration;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.master.kubernetes.controller.KubeControllerModule;
 import com.netflix.titus.master.mesos.MesosConfiguration;
 import com.netflix.titus.master.mesos.VirtualMachineMasterService;
 import com.netflix.titus.master.mesos.kubeapiserver.client.JobControllerKubeApiFacade;
@@ -57,7 +58,7 @@ import io.kubernetes.client.openapi.ApiClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.netflix.titus.master.mesos.kubeapiserver.KubeApiServerIntegrator.GC_UNKNOWN_PODS;
+import static com.netflix.titus.master.mesos.kubeapiserver.DefaultKubeJobManagementReconciler.GC_UNKNOWN_PODS;
 
 public class KubeModule extends AbstractModule {
 
@@ -74,6 +75,7 @@ public class KubeModule extends AbstractModule {
         bind(PodAffinityFactory.class).to(DefaultPodAffinityFactory.class);
         bind(TaintTolerationFactory.class).to(DefaultTaintTolerationFactory.class);
         bind(VirtualMachineMasterService.class).annotatedWith(Names.named(MESOS_KUBE_ADAPTER)).to(KubeApiServerIntegrator.class);
+        install(new KubeControllerModule());
     }
 
     @Provides

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
@@ -56,6 +56,9 @@ import io.kubernetes.client.openapi.models.V1ContainerStateWaiting;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1NodeAddress;
+import io.kubernetes.client.openapi.models.V1NodeCondition;
+import io.kubernetes.client.openapi.models.V1NodeStatus;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1Taint;
 import io.kubernetes.client.openapi.models.V1Toleration;
@@ -368,6 +371,33 @@ public class KubeUtil {
 
             sink.onCancel(call::cancel);
         });
+    }
+
+    /**
+     * Get pod name
+     */
+    public static String getMetadataName(V1ObjectMeta metadata) {
+        if (metadata == null) {
+            return "";
+        }
+
+        return metadata.getName();
+    }
+
+    public static Optional<V1NodeCondition> findNodeCondition(V1Node node, String type) {
+        V1NodeStatus status = node.getStatus();
+        if (status == null) {
+            return Optional.empty();
+        }
+        List<V1NodeCondition> conditions = status.getConditions();
+        if (conditions != null) {
+            for (V1NodeCondition condition : conditions) {
+                if (condition.getType().equals(type)) {
+                    return Optional.of(condition);
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     public static boolean hasUninitializedTaint(V1Node node) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
@@ -121,12 +121,6 @@ public interface DirectKubeConfiguration extends KubeConnectorConfiguration {
     long getPodTerminationGracePeriodSeconds();
 
     /**
-     * Amount of time to wait before GC'ing a pod with deletion timestamp.
-     */
-    @DefaultValue("1800000")
-    long getPodTerminationGcTimeoutMs();
-
-    /**
      * Amount of grace period to set when deleting a namespace pod.
      */
     @DefaultValue("300")
@@ -137,12 +131,6 @@ public interface DirectKubeConfiguration extends KubeConnectorConfiguration {
      */
     @DefaultValue("300000")
     long getNodeGcTtlMs();
-
-    /**
-     * Amount of time to wait after the pod creation timestamp for unknown pods before deleting the pod.
-     */
-    @DefaultValue("300000")
-    long getUnknownPodGcTimeoutMs();
 
     /**
      * Maximum number of concurrent pod create requests.

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/NodeGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/NodeGcControllerTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+
+import com.netflix.titus.api.agent.model.AgentInstance;
+import com.netflix.titus.api.agent.model.InstanceLifecycleState;
+import com.netflix.titus.api.agent.model.InstanceLifecycleStatus;
+import com.netflix.titus.api.agent.service.AgentManagementService;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.common.util.time.internal.DefaultTestClock;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1NodeCondition;
+import io.kubernetes.client.openapi.models.V1NodeSpec;
+import io.kubernetes.client.openapi.models.V1NodeStatus;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.NODE_LABEL_ACCOUNT_ID;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.READY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodeGcControllerTest {
+    private static final long NODE_GC_GRACE_PERIOD = 1000L;
+    private static final String NODE_NAME = "node-name";
+    private static final String CORRECT_ACCOUNT = "correct-account";
+    private static final String INCORRECT_ACCOUNT = "incorrect-account";
+    private static final TestClock clock = new DefaultTestClock();
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test(clock);
+    private final LocalScheduler scheduler = mock(LocalScheduler.class);
+    private final FixedIntervalTokenBucketConfiguration tokenBucketConfiguration = mock(FixedIntervalTokenBucketConfiguration.class);
+    private final ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
+    private final AgentManagementService agentManagementService = mock(AgentManagementService.class);
+    private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
+    private final KubeControllerConfiguration kubeControllerConfiguration = mock(KubeControllerConfiguration.class);
+
+    private final NodeGcController nodeGcController = new NodeGcController(
+            titusRuntime,
+            scheduler,
+            tokenBucketConfiguration,
+            controllerConfiguration,
+            agentManagementService,
+            kubeApiFacade,
+            kubeControllerConfiguration
+    );
+
+
+    @BeforeEach
+    void setUp() {
+        when(kubeControllerConfiguration.getAccountId()).thenReturn(CORRECT_ACCOUNT);
+        when(kubeControllerConfiguration.getNodeGcGracePeriodMs()).thenReturn(NODE_GC_GRACE_PERIOD);
+    }
+
+    /**
+     * The node is in the wrong account and should return false.
+     */
+    @Test
+    void nodeIsInWrongAccount() {
+        V1Node node = new V1Node()
+                .metadata(new V1ObjectMeta().name(NODE_NAME).annotations(Collections.singletonMap(NODE_LABEL_ACCOUNT_ID, INCORRECT_ACCOUNT)))
+                .spec(new V1NodeSpec())
+                .status(null);
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isFalse();
+    }
+
+    /**
+     * The node object is missing information and should return false.
+     */
+    @Test
+    void nodeIsInvalid() {
+        V1Node node = new V1Node()
+                .metadata(new V1ObjectMeta().name(NODE_NAME).annotations(Collections.singletonMap(NODE_LABEL_ACCOUNT_ID, CORRECT_ACCOUNT)))
+                .spec(new V1NodeSpec())
+                .status(null);
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isFalse();
+    }
+
+    /**
+     * The node condition ready last heartbeat time should return false if it is not past the configured grace period.
+     */
+    @Test
+    void nodeReadyConditionTimestampIsNotPastGracePeriod() {
+        long now = clock.wallTime();
+        V1NodeCondition readyCondition = new V1NodeCondition().type(READY).lastHeartbeatTime(new DateTime(now));
+        V1Node node = new V1Node()
+                .metadata(new V1ObjectMeta().name(NODE_NAME).annotations(Collections.singletonMap(NODE_LABEL_ACCOUNT_ID, CORRECT_ACCOUNT)))
+                .spec(new V1NodeSpec())
+                .status(new V1NodeStatus().addConditionsItem(readyCondition));
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isFalse();
+    }
+
+    /**
+     * The node condition ready last heartbeat time should return true if it is past the configured grace period.
+     */
+    @Test
+    void nodeReadyConditionTimestampIsPastGracePeriod() {
+        long now = clock.wallTime();
+        clock.advanceTime(Duration.ofMillis(NODE_GC_GRACE_PERIOD + 1));
+        V1NodeCondition readyCondition = new V1NodeCondition().type(READY).lastHeartbeatTime(new DateTime(now));
+        V1Node node = new V1Node()
+                .metadata(new V1ObjectMeta().name(NODE_NAME).annotations(Collections.singletonMap(NODE_LABEL_ACCOUNT_ID, CORRECT_ACCOUNT)))
+                .spec(new V1NodeSpec())
+                .status(new V1NodeStatus().addConditionsItem(readyCondition));
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isTrue();
+    }
+
+    /**
+     * The agent instance for the node object does not exist in agent management and should return true.
+     */
+    @Test
+    void agentInstanceNotInAgentManagement() {
+        long now = clock.wallTime();
+        clock.advanceTime(Duration.ofMillis(NODE_GC_GRACE_PERIOD + 1));
+        V1NodeCondition readyCondition = new V1NodeCondition().type(READY).lastHeartbeatTime(new DateTime(now));
+        V1Node node = new V1Node()
+                .metadata(new V1ObjectMeta().name(NODE_NAME).annotations(Collections.singletonMap(NODE_LABEL_ACCOUNT_ID, CORRECT_ACCOUNT)))
+                .spec(new V1NodeSpec())
+                .status(new V1NodeStatus().addConditionsItem(readyCondition));
+        when(agentManagementService.findAgentInstance(NODE_NAME)).thenReturn(Optional.empty());
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isTrue();
+    }
+
+    /**
+     * The agent instance is not in the stopped state and should return false.
+     */
+    @Test
+    void agentInstanceIsNotStopped() {
+        long now = clock.wallTime();
+        clock.advanceTime(Duration.ofMillis(NODE_GC_GRACE_PERIOD + 1));
+        V1NodeCondition readyCondition = new V1NodeCondition().type(READY).lastHeartbeatTime(new DateTime(now));
+        V1Node node = new V1Node()
+                .metadata(new V1ObjectMeta().name(NODE_NAME).annotations(Collections.singletonMap(NODE_LABEL_ACCOUNT_ID, CORRECT_ACCOUNT)))
+                .spec(new V1NodeSpec())
+                .status(new V1NodeStatus().addConditionsItem(readyCondition));
+
+        AgentInstance agentInstance = AgentInstance.newBuilder()
+                .withId(NODE_NAME)
+                .withDeploymentStatus(InstanceLifecycleStatus.newBuilder().withState(InstanceLifecycleState.Started).build())
+                .build();
+        when(agentManagementService.findAgentInstance(NODE_NAME)).thenReturn(Optional.of(agentInstance));
+
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isFalse();
+    }
+
+    /**
+     * The agent instance is in the stopped state and should return true.
+     */
+    @Test
+    void agentInstanceIsStopped() {
+        long now = clock.wallTime();
+        clock.advanceTime(Duration.ofMillis(NODE_GC_GRACE_PERIOD + 1));
+        V1NodeCondition readyCondition = new V1NodeCondition().type(READY).lastHeartbeatTime(new DateTime(now));
+        V1Node node = new V1Node()
+                .metadata(new V1ObjectMeta().name(NODE_NAME).annotations(Collections.singletonMap(NODE_LABEL_ACCOUNT_ID, CORRECT_ACCOUNT)))
+                .spec(new V1NodeSpec())
+                .status(new V1NodeStatus().addConditionsItem(readyCondition));
+
+        AgentInstance agentInstance = AgentInstance.newBuilder()
+                .withId(NODE_NAME)
+                .withDeploymentStatus(InstanceLifecycleStatus.newBuilder().withState(InstanceLifecycleState.Stopped).build())
+                .build();
+        when(agentManagementService.findAgentInstance(NODE_NAME)).thenReturn(Optional.of(agentInstance));
+
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isTrue();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodDeletionGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodDeletionGcControllerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.time.Duration;
+
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.common.util.time.internal.DefaultTestClock;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.PENDING;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.RUNNING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PodDeletionGcControllerTest {
+    private static final String NODE_NAME = "node-name";
+    private static final String POD_NAME = "pod-name";
+    private static final TestClock clock = new DefaultTestClock();
+    private static final long POD_DELETION_TIMESTAMP_GRACE_PERIOD = 1000L;
+    private static final long POD_TERMINATION_GRACE_PERIOD_SEC = 30L;
+    private static final long POD_TERMINATION_GRACE_PERIOD_MS = POD_TERMINATION_GRACE_PERIOD_SEC * 1000;
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test(clock);
+    private final FixedIntervalTokenBucketConfiguration tokenBucketConfiguration = mock(FixedIntervalTokenBucketConfiguration.class);
+    private final ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
+    private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
+    private final LocalScheduler scheduler = mock(LocalScheduler.class);
+    private final KubeControllerConfiguration kubeControllerConfiguration = mock(KubeControllerConfiguration.class);
+
+    private final PodDeletionGcController podDeletionGcController = new PodDeletionGcController(
+            titusRuntime,
+            scheduler,
+            tokenBucketConfiguration,
+            controllerConfiguration,
+            kubeApiFacade,
+            kubeControllerConfiguration
+    );
+
+
+    @BeforeEach
+    void setUp() {
+        when(kubeControllerConfiguration.getPodsPastTerminationGracePeriodMs()).thenReturn(POD_DELETION_TIMESTAMP_GRACE_PERIOD);
+    }
+
+    /**
+     * The pod has a deletion timestamp that is past the termination and deletion grace periods and should return true.
+     */
+    @Test
+    void podIsPastDeletionTimestamp() {
+        V1Pod pod = new V1Pod()
+                .metadata(
+                        new V1ObjectMeta()
+                                .name(POD_NAME)
+                                .deletionTimestamp(new DateTime(clock.wallTime()))
+                )
+                .spec(
+                        new V1PodSpec()
+                                .nodeName(NODE_NAME)
+                                .terminationGracePeriodSeconds(POD_TERMINATION_GRACE_PERIOD_SEC))
+                .status(null);
+
+        clock.advanceTime(Duration.ofMillis(POD_TERMINATION_GRACE_PERIOD_MS + POD_DELETION_TIMESTAMP_GRACE_PERIOD + 1));
+
+        Assertions.assertThat(podDeletionGcController.isPodPastDeletionTimestamp(pod)).isTrue();
+    }
+
+    /**
+     * The pod has a deletion timestamp that is not past the termination and deletion grace periods and should return false.
+     */
+    @Test
+    void podIsNotPastDeletionTimestamp() {
+        V1Pod pod = new V1Pod()
+                .metadata(
+                        new V1ObjectMeta()
+                                .name(POD_NAME)
+                                .deletionTimestamp(new DateTime(clock.wallTime()))
+                )
+                .spec(
+                        new V1PodSpec()
+                                .nodeName(NODE_NAME)
+                                .terminationGracePeriodSeconds(POD_TERMINATION_GRACE_PERIOD_SEC))
+                .status(null);
+
+        Assertions.assertThat(podDeletionGcController.isPodPastDeletionTimestamp(pod)).isFalse();
+    }
+
+    /**
+     * The pod has a deletion timestamp and is in the Pending phase so should return true.
+     */
+    @Test
+    void podIsPendingPhaseWithDeletionTimestamp() {
+        V1Pod pod = new V1Pod()
+                .metadata(
+                        new V1ObjectMeta()
+                                .name(POD_NAME)
+                                .deletionTimestamp(new DateTime(clock.wallTime()))
+                )
+                .spec(new V1PodSpec())
+                .status(new V1PodStatus().phase(PENDING));
+
+        Assertions.assertThat(podDeletionGcController.isPodInPendingPhaseWithDeletionTimestamp(pod)).isTrue();
+    }
+
+    /**
+     * The pod has a deletion timestamp and is in the Running phase so should return false.
+     */
+    @Test
+    void podIsInRunningPhaseWithDeletionTimestamp() {
+        V1Pod pod = new V1Pod()
+                .metadata(
+                        new V1ObjectMeta()
+                                .name(POD_NAME)
+                                .deletionTimestamp(new DateTime(clock.wallTime()))
+                )
+                .spec(new V1PodSpec())
+                .status(new V1PodStatus().phase(RUNNING));
+
+        Assertions.assertThat(podDeletionGcController.isPodInPendingPhaseWithDeletionTimestamp(pod)).isFalse();
+    }
+
+    /**
+     * The pod does not have a deletion timestamp and is in the Pending phase so should return false.
+     */
+    @Test
+    void podDoesNotHaveDeletionTimestamp() {
+        V1Pod pod = new V1Pod()
+                .metadata(
+                        new V1ObjectMeta()
+                                .name(POD_NAME)
+                )
+                .spec(new V1PodSpec())
+                .status(new V1PodStatus().phase(PENDING));
+
+        Assertions.assertThat(podDeletionGcController.isPodInPendingPhaseWithDeletionTimestamp(pod)).isFalse();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodOnUnknownNodeGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodOnUnknownNodeGcControllerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.Collections;
+
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.common.util.time.internal.DefaultTestClock;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class PodOnUnknownNodeGcControllerTest {
+    private static final String NODE_NAME = "node-name";
+    private static final String POD_NAME = "pod-name";
+    private static final TestClock clock = new DefaultTestClock();
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test(clock);
+    private final FixedIntervalTokenBucketConfiguration tokenBucketConfiguration = mock(FixedIntervalTokenBucketConfiguration.class);
+    private final ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
+    private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
+    private final LocalScheduler scheduler = mock(LocalScheduler.class);
+
+    private final PodOnUnknownNodeGcController podGcController = new PodOnUnknownNodeGcController(
+            titusRuntime,
+            scheduler,
+            tokenBucketConfiguration,
+            controllerConfiguration,
+            kubeApiFacade
+    );
+
+    /**
+     * The pod has a node name for a node that is not known and should return true.
+     */
+    @Test
+    void podIsOnUnknownNode() {
+        V1Pod pod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(POD_NAME))
+                .spec(new V1PodSpec().nodeName(NODE_NAME))
+                .status(null);
+
+        Assertions.assertThat(podGcController.isPodOnUnknownNode(pod, Collections.emptySet())).isTrue();
+    }
+
+    /**
+     * The pod has a node name for a node that is known and should return false.
+     */
+    @Test
+    void podIsOnKnownNode() {
+        V1Pod pod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(POD_NAME))
+                .spec(new V1PodSpec().nodeName(NODE_NAME))
+                .status(null);
+
+        Assertions.assertThat(podGcController.isPodOnUnknownNode(pod, Collections.singleton(NODE_NAME))).isFalse();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodTerminalGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodTerminalGcControllerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.common.util.time.internal.DefaultTestClock;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.RUNNING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PodTerminalGcControllerTest {
+    private static final String POD_NAME = "pod-name";
+    private static final TestClock clock = new DefaultTestClock();
+    private static final long POD_TERMINAL_GRACE_PERIOD = 1000L;
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test(clock);
+    private final FixedIntervalTokenBucketConfiguration tokenBucketConfiguration = mock(FixedIntervalTokenBucketConfiguration.class);
+    private final ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
+    private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
+    private final LocalScheduler scheduler = mock(LocalScheduler.class);
+    private final KubeControllerConfiguration kubeControllerConfiguration = mock(KubeControllerConfiguration.class);
+    private final V3JobOperations v3JobOperations = mock(V3JobOperations.class);
+
+    private final PodTerminalGcController podGcController = new PodTerminalGcController(
+            titusRuntime,
+            scheduler,
+            tokenBucketConfiguration,
+            controllerConfiguration,
+            kubeApiFacade,
+            kubeControllerConfiguration,
+            v3JobOperations
+    );
+
+    /**
+     * The pod is not terminal and should not be GC'ed
+     */
+    @Test
+    void podIsNotTerminal() {
+        when(kubeControllerConfiguration.getPodTerminalGracePeriodMs()).thenReturn(POD_TERMINAL_GRACE_PERIOD);
+
+        V1Pod pod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(POD_NAME).creationTimestamp(new DateTime(clock.wallTime())))
+                .status(new V1PodStatus().phase(RUNNING));
+
+        TaskStatus taskStatus = TaskStatus.newBuilder()
+                .withState(TaskState.Started)
+                .withTimestamp(clock.wallTime())
+                .build();
+        Task task = JobGenerator.oneBatchTask().toBuilder().withStatus(taskStatus).build();
+
+        clock.advanceTime(Duration.ofMillis(POD_TERMINAL_GRACE_PERIOD + 1));
+
+        Map<String, Task> currentTasks = Collections.singletonMap(POD_NAME, task);
+        Assertions.assertThat(podGcController.isPodTerminal(pod, currentTasks)).isFalse();
+    }
+
+    /**
+     * The pod is terminal but has not yet passed the configured grace period so it should not be GC'ed
+     */
+    @Test
+    void podIsTerminalWithoutGracePeriod() {
+        when(kubeControllerConfiguration.getPodTerminalGracePeriodMs()).thenReturn(POD_TERMINAL_GRACE_PERIOD);
+
+        V1Pod pod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(POD_NAME).creationTimestamp(new DateTime(clock.wallTime())))
+                .status(new V1PodStatus().phase(RUNNING));
+
+        TaskStatus taskStatus = TaskStatus.newBuilder()
+                .withState(TaskState.Started)
+                .withTimestamp(clock.wallTime())
+                .build();
+        Task task = JobGenerator.oneBatchTask().toBuilder().withStatus(taskStatus).build();
+
+        Map<String, Task> currentTasks = Collections.singletonMap(POD_NAME, task);
+        Assertions.assertThat(podGcController.isPodTerminal(pod, currentTasks)).isFalse();
+    }
+
+    /**
+     * The pod is terminal and should be GC'ed
+     */
+    @Test
+    void podIsTerminal() {
+        when(kubeControllerConfiguration.getPodTerminalGracePeriodMs()).thenReturn(POD_TERMINAL_GRACE_PERIOD);
+
+        V1Pod pod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(POD_NAME).creationTimestamp(new DateTime(clock.wallTime())))
+                .status(new V1PodStatus().phase(RUNNING));
+
+        TaskStatus taskStatus = TaskStatus.newBuilder()
+                .withState(TaskState.Finished)
+                .withTimestamp(clock.wallTime())
+                .build();
+        Task task = JobGenerator.oneBatchTask().toBuilder().withStatus(taskStatus).build();
+
+        clock.advanceTime(Duration.ofMillis(POD_TERMINAL_GRACE_PERIOD + 1));
+
+        Map<String, Task> currentTasks = Collections.singletonMap(POD_NAME, task);
+        Assertions.assertThat(podGcController.isPodTerminal(pod, currentTasks)).isTrue();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodUnknownGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PodUnknownGcControllerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.common.util.time.internal.DefaultTestClock;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.RUNNING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PodUnknownGcControllerTest {
+    private static final String POD_NAME = "pod-name";
+    private static final TestClock clock = new DefaultTestClock();
+    private static final long POD_UNKNOWN_GRACE_PERIOD = 1000L;
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test(clock);
+    private final FixedIntervalTokenBucketConfiguration tokenBucketConfiguration = mock(FixedIntervalTokenBucketConfiguration.class);
+    private final ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
+    private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
+    private final LocalScheduler scheduler = mock(LocalScheduler.class);
+    private final KubeControllerConfiguration kubeControllerConfiguration = mock(KubeControllerConfiguration.class);
+    private final V3JobOperations v3JobOperations = mock(V3JobOperations.class);
+
+    private final PodUnknownGcController podGcController = new PodUnknownGcController(
+            titusRuntime,
+            scheduler,
+            tokenBucketConfiguration,
+            controllerConfiguration,
+            kubeApiFacade,
+            kubeControllerConfiguration,
+            v3JobOperations
+    );
+
+    /**
+     * The pod is known to job management and should not be GC'ed
+     */
+    @Test
+    void podIsKnownToJobManagement() {
+        when(kubeControllerConfiguration.getPodUnknownGracePeriodMs()).thenReturn(POD_UNKNOWN_GRACE_PERIOD);
+
+        V1Pod pod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(POD_NAME).creationTimestamp(new DateTime(clock.wallTime())))
+                .status(new V1PodStatus().phase(RUNNING));
+
+        clock.advanceTime(Duration.ofMillis(POD_UNKNOWN_GRACE_PERIOD + 1));
+
+        Map<String, Task> currentTasks = Collections.singletonMap(POD_NAME, mock(Task.class));
+        Assertions.assertThat(podGcController.isPodUnknownToJobManagement(pod, currentTasks)).isFalse();
+    }
+
+    /**
+     * The pod is unknown to job management and should be GC'ed
+     */
+    @Test
+    void podIsUnknownToJobManagement() {
+        when(kubeControllerConfiguration.getPodUnknownGracePeriodMs()).thenReturn(POD_UNKNOWN_GRACE_PERIOD);
+
+        V1Pod pod = new V1Pod()
+                .metadata(new V1ObjectMeta().name(POD_NAME).creationTimestamp(new DateTime(clock.wallTime())))
+                .status(new V1PodStatus().phase(RUNNING));
+
+        clock.advanceTime(Duration.ofMillis(POD_UNKNOWN_GRACE_PERIOD + 1));
+
+        Map<String, Task> currentTasks = Collections.singletonMap("", mock(Task.class));
+        Assertions.assertThat(podGcController.isPodUnknownToJobManagement(pod, currentTasks)).isTrue();
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -72,6 +72,8 @@ public final class KubeConstants {
 
     public static final String NODE_LABEL_MACHINE_GROUP = TITUS_NODE_DOMAIN + "asg";
 
+    public static final String NODE_LABEL_ACCOUNT_ID = TITUS_NODE_DOMAIN + "accountId";
+
     public static final String NODE_LABEL_KUBE_BACKEND = TITUS_NODE_DOMAIN + "backend";
 
     public static final String NODE_LABEL_RESOURCE_POOL = TITUS_SCALER_DOMAIN + "resource-pool";
@@ -136,5 +138,17 @@ public final class KubeConstants {
      * Opportunistic resource CRD used when allocating opportunistic resources to a Pod during scheduling
      */
     public static final String OPPORTUNISTIC_ID = "opportunistic.scheduler.titus.netflix.com/id";
+
+    /*
+     * API Constants
+     */
+    public static final String DEFAULT_NAMESPACE = "default";
+    public static final String NOT_FOUND = "Not Found";
+    public static final String READY = "Ready";
+    public static final String PENDING = "Pending";
+    public static final String RUNNING = "Running";
+    public static final String SUCCEEDED = "Succeeded";
+    public static final String FAILED = "Failed";
+    public static final String BACKGROUND = "Background";
 
 }


### PR DESCRIPTION
### Description of the Change
* Extract gc controller logic from KubeApiServerIntegrator into new GC controllers.
* Separate podAdd,podUpdate event handling from podDelete.
* In podDelete, add a missing KillInitiated status to indicate something outside of Titus terminate the container.