### PR TITLE
core task log locations populated from grpcTask

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -67,9 +67,25 @@ public final class TaskAttributes {
      * Log location attributes.
      */
 
-    public static final String TASK_ATTRIBUTE_S3_BUCKET_NAME = "task.log.s3BucketName";
+    public static final String TASK_ATTRIBUTE_LOG_PREFIX = "task.log.";
 
-    public static final String TASK_ATTRIBUTE_S3_PATH_PREFIX = "task.log.s3PathPrefix";
+    public static final String TASK_ATTRIBUTE_S3_BUCKET_NAME = TASK_ATTRIBUTE_LOG_PREFIX + "s3BucketName";
+
+    public static final String TASK_ATTRIBUTE_S3_PATH_PREFIX = TASK_ATTRIBUTE_LOG_PREFIX + "s3PathPrefix";
+
+    public static final String TASK_ATTRIBUTE_LOG_UI_LOCATION = TASK_ATTRIBUTE_LOG_PREFIX + "uiLogLocation";
+
+    public static final String TASK_ATTRIBUTE_LOG_S3_PREFIX = TASK_ATTRIBUTE_LOG_PREFIX + "s3.";
+
+    public static final String TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME = TASK_ATTRIBUTE_LOG_S3_PREFIX + "accountName";
+
+    public static final String TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID = TASK_ATTRIBUTE_LOG_S3_PREFIX + "accountId";
+
+    public static final String TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME = TASK_ATTRIBUTE_LOG_S3_PREFIX + "bucketName";
+
+    public static final String TASK_ATTRIBUTE_LOG_S3_KEY = TASK_ATTRIBUTE_LOG_S3_PREFIX + "key";
+
+    public static final String TASK_ATTRIBUTE_LOG_S3_REGION = TASK_ATTRIBUTE_LOG_S3_PREFIX + "region";
 
     /**
      * Id of the opportunistic allocation used for this task

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -518,7 +518,7 @@ public final class GrpcJobManagementModelConverters {
         return builder.build();
     }
 
-    static Map<String, String> buildAttributesMapForCoreTask(com.netflix.titus.grpc.protogen.Task grpcTask) {
+    private static Map<String, String> buildAttributesMapForCoreTask(com.netflix.titus.grpc.protogen.Task grpcTask) {
         Map<String, String> attributes = new HashMap<>(grpcTask.getAttributesMap());
         if (grpcTask.hasLogLocation()) {
             LogLocation logLocation = grpcTask.getLogLocation();

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -100,6 +100,12 @@ import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_SY
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_INDEX;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_ORIGINAL_ID;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_RESUBMIT_OF;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_KEY;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_REGION;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_UI_LOCATION;
 import static com.netflix.titus.common.util.CollectionsExt.isNullOrEmpty;
 import static com.netflix.titus.common.util.Evaluators.acceptNotNull;
 import static com.netflix.titus.common.util.Evaluators.applyNotNull;
@@ -501,7 +507,7 @@ public final class GrpcJobManagementModelConverters {
                 .withSystemResubmitNumber(systemResubmitNumber)
                 .withEvictionResubmitNumber(evictionResubmitNumber)
                 .withTaskContext(taskContext)
-                .withAttributes(grpcTask.getAttributesMap());
+                .withAttributes(buildAttributesMapForCoreTask(grpcTask));
 
         if (isBatchTask) { // Batch job
             ((BatchJobTask.Builder) builder).withIndex(Integer.parseInt(taskIndexStr));
@@ -510,6 +516,27 @@ public final class GrpcJobManagementModelConverters {
         }
 
         return builder.build();
+    }
+
+    static Map<String, String> buildAttributesMapForCoreTask(com.netflix.titus.grpc.protogen.Task grpcTask) {
+        Map<String, String> attributes = new HashMap<>(grpcTask.getAttributesMap());
+        if (grpcTask.hasLogLocation()) {
+            LogLocation logLocation = grpcTask.getLogLocation();
+            if (logLocation != null) {
+                if (logLocation.getUi() != null) {
+                    attributes.put(TASK_ATTRIBUTE_LOG_UI_LOCATION, logLocation.getUi().getUrl());
+                }
+                if (logLocation.getS3() != null) {
+                    LogLocation.S3 s3 = logLocation.getS3();
+                    attributes.put(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME, s3.getAccountName());
+                    attributes.put(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID, s3.getAccountId());
+                    attributes.put(TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME, s3.getBucket());
+                    attributes.put(TASK_ATTRIBUTE_LOG_S3_KEY, s3.getKey());
+                    attributes.put(TASK_ATTRIBUTE_LOG_S3_REGION, s3.getRegion());
+                }
+            }
+        }
+        return attributes;
     }
 
     public static Task toCoreTask(Job<?> job, com.netflix.titus.grpc.protogen.Task grpcTask) {

--- a/titus-client/src/test/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConvertersTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConvertersTest.java
@@ -1,0 +1,70 @@
+package com.netflix.titus.runtime.endpoint.v3.grpc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.netflix.titus.grpc.protogen.LogLocation;
+import com.netflix.titus.grpc.protogen.Task;
+import org.junit.Test;
+
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_RESUBMIT_NUMBER;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_ORIGINAL_ID;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_KEY;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_REGION;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_UI_LOCATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrpcJobManagementModelConvertersTest {
+
+    @Test
+    public void coreTaskLogAttributes() {
+        String taskId = "tid-1";
+        String uiLocation = "http://titus-ui/tasks/" + taskId;
+        String s3Bucket = "bucket-1";
+        String s3Key = "key-1";
+        String s3AccountId = "acc-1";
+        String s3AccountName = "acc-name-1";
+        String s3Region = "us-east-1";
+
+        Map<String, String> taskContext = new HashMap<>();
+        taskContext.put(TASK_ATTRIBUTES_TASK_ORIGINAL_ID, taskId);
+        taskContext.put(TASK_ATTRIBUTES_RESUBMIT_NUMBER, "1");
+        Task grpcTask = Task.newBuilder()
+                .setId(taskId)
+                .putAllTaskContext(taskContext)
+                .setLogLocation(LogLocation.newBuilder()
+                        .setUi(LogLocation.UI.newBuilder().setUrl(uiLocation))
+                        .setS3(LogLocation.S3.newBuilder()
+                                .setRegion(s3Region)
+                                .setBucket(s3Bucket)
+                                .setKey(s3Key)
+                                .setAccountId(s3AccountId)
+                                .setAccountName(s3AccountName))
+                        .build())
+                .build();
+
+        com.netflix.titus.api.jobmanager.model.job.Task coreTask = GrpcJobManagementModelConverters.toCoreTask(grpcTask);
+        assertThat(coreTask).isNotNull();
+        assertThat(coreTask.getAttributes()).hasSizeGreaterThan(0);
+        assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_S3_KEY)).isTrue();
+        assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_S3_KEY)).isEqualTo(s3Key);
+
+        assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME)).isTrue();
+        assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME)).isEqualTo(s3Bucket);
+
+        assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID)).isTrue();
+        assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID)).isEqualTo(s3AccountId);
+
+        assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME)).isTrue();
+        assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME)).isEqualTo(s3AccountName);
+
+        assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_S3_REGION)).isTrue();
+        assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_S3_REGION)).isEqualTo(s3Region);
+
+        assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_UI_LOCATION)).isTrue();
+        assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_UI_LOCATION)).isEqualTo(uiLocation);
+    }
+}


### PR DESCRIPTION
### Updates log location attributes for core Task type

RemoteJobManagementClient is used by JobDataReplicator to build a local cache of running jobs and tasks. It depends on converting a grpc Task object into a core Task object. In that process, it seems to be losing information about task log location that is provided by the grpc Task. This change is needed to enable client cache layers using RemoteJobManagementClient to access task log information including ui-link, s3 bucket / key, s3 account Id etc.