### PR TITLE
Add a sanitizer for service mesh image attribute.

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -180,6 +180,22 @@ public final class JobAttributes {
      */
     public static final String JOB_CONTAINER_ATTRIBUTE_ACCOUNT_ID = "titusParameter.agent.accountId";
 
+    /**
+     * Enable service mesh.
+     */
+    public static final String JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED = "titusParameter.agent.service.serviceMesh.enabled";
+
+    /**
+     * Container to use for service mesh.
+     */
+    public static final String JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER = "titusParameter.agent.service.serviceMesh.container";
+
+    /**
+     * Set to true when sanitization for container images (digest) fails open
+     */
+    public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_SERVICEMESH_IMAGE = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.serviceMesh";
+
+
     private JobAttributes() {
     }
 }

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageSanitizerTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageSanitizerTest.java
@@ -24,7 +24,7 @@ import com.netflix.titus.common.model.sanitizer.ValidationError;
 import com.netflix.titus.runtime.connector.registry.RegistryClient;
 import com.netflix.titus.runtime.connector.registry.TitusRegistryException;
 import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizer;
-import com.netflix.titus.runtime.endpoint.admission.JobImageValidatorConfiguration;
+import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizerConfiguration;
 import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +43,7 @@ public class JobImageSanitizerTest {
     private static final String tag = "myTag";
     private static final String digest = "sha256:f9f5bb506406b80454a4255b33ed2e4383b9e4a32fb94d6f7e51922704e818fa";
 
-    private final JobImageValidatorConfiguration configuration = mock(JobImageValidatorConfiguration.class);
+    private final JobImageSanitizerConfiguration configuration = mock(JobImageSanitizerConfiguration.class);
     private final RegistryClient registryClient = mock(RegistryClient.class);
     private JobImageSanitizer sanitizer;
 

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ServiceMeshImageSanitizerTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ServiceMeshImageSanitizerTest.java
@@ -18,16 +18,13 @@ package com.netflix.titus.gateway.service.v3.internal;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.titus.api.jobmanager.JobAttributes;
-import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.runtime.connector.registry.RegistryClient;
 import com.netflix.titus.runtime.connector.registry.TitusRegistryException;
-import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizer;
-import com.netflix.titus.runtime.endpoint.admission.JobImageValidatorConfiguration;
 import com.netflix.titus.runtime.endpoint.admission.ServiceMeshImageSanitizer;
-import com.netflix.titus.runtime.endpoint.admission.ServiceMeshImageValidatorConfiguration;
+import com.netflix.titus.runtime.endpoint.admission.ServiceMeshImageSanitizerConfiguration;
 import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +46,7 @@ public class ServiceMeshImageSanitizerTest {
     private static final String tag = "proxydTag";
     private static final String digest = "sha256:f9f5bb506406b80454a4255b33ed2e4383b9e4a32fb94d6f7e51922704e818fa";
 
-    private final ServiceMeshImageValidatorConfiguration configuration = mock(ServiceMeshImageValidatorConfiguration.class);
+    private final ServiceMeshImageSanitizerConfiguration configuration = mock(ServiceMeshImageSanitizerConfiguration.class);
     private final RegistryClient registryClient = mock(RegistryClient.class);
     private ServiceMeshImageSanitizer sanitizer;
 

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ServiceMeshImageSanitizerTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ServiceMeshImageSanitizerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.gateway.service.v3.internal;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.model.job.Image;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.sanitizer.ValidationError;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.runtime.connector.registry.RegistryClient;
+import com.netflix.titus.runtime.connector.registry.TitusRegistryException;
+import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizer;
+import com.netflix.titus.runtime.endpoint.admission.JobImageValidatorConfiguration;
+import com.netflix.titus.runtime.endpoint.admission.ServiceMeshImageSanitizer;
+import com.netflix.titus.runtime.endpoint.admission.ServiceMeshImageValidatorConfiguration;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ServiceMeshImageSanitizerTest {
+
+    private static final String repo = "proxydRepo/proxydImage";
+    private static final String tag = "proxydTag";
+    private static final String digest = "sha256:f9f5bb506406b80454a4255b33ed2e4383b9e4a32fb94d6f7e51922704e818fa";
+
+    private final ServiceMeshImageValidatorConfiguration configuration = mock(ServiceMeshImageValidatorConfiguration.class);
+    private final RegistryClient registryClient = mock(RegistryClient.class);
+    private ServiceMeshImageSanitizer sanitizer;
+
+    private final String imageNameDigest = String.format("%s@%s", repo, digest);
+    private final Map<String, String> digestAttrs = new HashMap<String, String>() {
+        {
+            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED, "true");
+            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER, imageNameDigest);
+        }
+    };
+    private final JobDescriptor<?> jobDescriptorWithDigest = JobDescriptorGenerator.batchJobDescriptors()
+            .map(jd -> jd.but(d -> d.toBuilder()
+                    .withAttributes(CollectionsExt.copyAndAdd(d.getAttributes(), digestAttrs))
+                    .build()))
+            .getValue();
+
+    private final String imageNameTag = String.format("%s:%s", repo, tag);
+    private final Map<String, String> tagAttrs = new HashMap<String, String>() {
+        {
+            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED, "true");
+            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER, imageNameTag);
+        }
+    };
+    private final JobDescriptor<?> jobDescriptorWithTag = JobDescriptorGenerator.batchJobDescriptors()
+            .map(jd -> jd.but(d -> d.toBuilder()
+                    .withAttributes(CollectionsExt.copyAndAdd(d.getAttributes(), tagAttrs))
+                    .build()))
+            .getValue();
+
+    @Before
+    public void setUp() {
+        when(configuration.isEnabled()).thenReturn(true);
+        when(configuration.getServiceMeshImageValidationTimeoutMs()).thenReturn(1000L);
+        when(configuration.getErrorType()).thenReturn(ValidationError.Type.HARD.name());
+        when(registryClient.getImageDigest(anyString(), anyString())).thenReturn(Mono.just(digest));
+        sanitizer = new ServiceMeshImageSanitizer(configuration, registryClient, new DefaultRegistry());
+    }
+
+    @Test
+    public void testJobWithTagResolution() {
+        when(registryClient.getImageDigest(anyString(), anyString())).thenReturn(Mono.just(digest));
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptorWithTag))
+                .assertNext(jobDescriptor -> assertThat(jobDescriptor
+                        .getAttributes()
+                        .get(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER))
+                        .isEqualTo(imageNameDigest))
+                .verifyComplete();
+    }
+
+    @Test
+    public void testJobWithNonExistentTag() {
+        when(registryClient.getImageDigest(anyString(), anyString()))
+                .thenReturn(Mono.error(TitusRegistryException.imageNotFound(repo, tag)));
+
+        StepVerifier.create(sanitizer.sanitize(jobDescriptorWithTag))
+                .expectErrorSatisfies(throwable -> {
+                    assertThat(throwable).isInstanceOf(TitusRegistryException.class);
+                    assertThat(((TitusRegistryException) throwable).getErrorCode()).isEqualByComparingTo(TitusRegistryException.ErrorCode.IMAGE_NOT_FOUND);
+                })
+                .verify();
+    }
+
+    /**
+     * This test verifies that non-NOT_FOUND errors are suppressed and the original job descriptor is returned.
+     */
+    @Test
+    public void testSuppressedInternalError() {
+        when(registryClient.getImageDigest(anyString(), anyString()))
+                .thenReturn(Mono.error(TitusRegistryException.internalError(repo, tag, HttpStatus.INTERNAL_SERVER_ERROR)));
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptorWithTag))
+                .assertNext(jd -> {
+                    assertThat(((JobDescriptor<?>) jd).getAttributes())
+                            .containsEntry(JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_SERVICEMESH_IMAGE, "true");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testJobWithDigestExists() {
+        when(registryClient.getImageDigest(anyString(), anyString())).thenReturn(Mono.just(digest));
+
+        StepVerifier.create(sanitizer.sanitize(jobDescriptorWithDigest))
+                .expectNextCount(0) // nothing to do when digest is valid
+                .verifyComplete();
+    }
+}

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ServiceMeshImageSanitizerTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/ServiceMeshImageSanitizerTest.java
@@ -50,27 +50,23 @@ public class ServiceMeshImageSanitizerTest {
     private final RegistryClient registryClient = mock(RegistryClient.class);
     private ServiceMeshImageSanitizer sanitizer;
 
-    private final String imageNameDigest = String.format("%s@%s", repo, digest);
-    private final Map<String, String> digestAttrs = new HashMap<String, String>() {
-        {
-            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED, "true");
-            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER, imageNameDigest);
-        }
-    };
-    private final JobDescriptor<?> jobDescriptorWithDigest = JobDescriptorGenerator.batchJobDescriptors()
+    private static final String imageNameDigest = String.format("%s@%s", repo, digest);
+    private static final Map<String, String> digestAttrs = CollectionsExt.asMap(
+            JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED, "true",
+            JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER, imageNameDigest);
+
+    private static final JobDescriptor<?> jobDescriptorWithDigest = JobDescriptorGenerator.batchJobDescriptors()
             .map(jd -> jd.but(d -> d.toBuilder()
                     .withAttributes(CollectionsExt.copyAndAdd(d.getAttributes(), digestAttrs))
                     .build()))
             .getValue();
 
-    private final String imageNameTag = String.format("%s:%s", repo, tag);
-    private final Map<String, String> tagAttrs = new HashMap<String, String>() {
-        {
-            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED, "true");
-            put(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER, imageNameTag);
-        }
-    };
-    private final JobDescriptor<?> jobDescriptorWithTag = JobDescriptorGenerator.batchJobDescriptors()
+    private static final String imageNameTag = String.format("%s:%s", repo, tag);
+    private static final Map<String, String> tagAttrs = CollectionsExt.asMap(
+            JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED, "true",
+            JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER, imageNameTag);
+
+    private static final JobDescriptor<?> jobDescriptorWithTag = JobDescriptorGenerator.batchJobDescriptors()
             .map(jd -> jd.but(d -> d.toBuilder()
                     .withAttributes(CollectionsExt.copyAndAdd(d.getAttributes(), tagAttrs))
                     .build()))

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSanitizeTest.java
@@ -30,7 +30,7 @@ import com.netflix.titus.runtime.connector.registry.RegistryClient;
 import com.netflix.titus.runtime.connector.registry.TitusRegistryException;
 import com.netflix.titus.common.model.admission.AdmissionSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizer;
-import com.netflix.titus.runtime.endpoint.admission.JobImageValidatorConfiguration;
+import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizerConfiguration;
 import com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCell;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMasters;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
@@ -68,7 +68,7 @@ public class JobSanitizeTest extends BaseIntegrationTest {
 
     private static final String missingImageErrorMsg = "does not exist in registry";
 
-    private final JobImageValidatorConfiguration configuration = mock(JobImageValidatorConfiguration.class);
+    private final JobImageSanitizerConfiguration configuration = mock(JobImageSanitizerConfiguration.class);
     private final RegistryClient registryClient = mock(RegistryClient.class);
 
     private final TitusStackResource titusStackResource = getTitusStackResource(

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/registry/TitusContainerRegistryModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/connector/registry/TitusContainerRegistryModule.java
@@ -21,7 +21,8 @@ import javax.inject.Singleton;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
-import com.netflix.titus.runtime.endpoint.admission.JobImageValidatorConfiguration;
+import com.netflix.titus.runtime.endpoint.admission.JobImageSanitizerConfiguration;
+import com.netflix.titus.runtime.endpoint.admission.ServiceMeshImageSanitizerConfiguration;
 
 public class TitusContainerRegistryModule extends AbstractModule {
     @Override
@@ -37,7 +38,13 @@ public class TitusContainerRegistryModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public JobImageValidatorConfiguration getJobImageValidatorConfiguration(ConfigProxyFactory factory) {
-        return factory.newProxy(JobImageValidatorConfiguration.class);
+    public JobImageSanitizerConfiguration getJobImageSanitizerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(JobImageSanitizerConfiguration.class);
+    }
+
+    @Provides
+    @Singleton
+    public ServiceMeshImageSanitizerConfiguration getServiceMeshImageSanitizerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ServiceMeshImageSanitizerConfiguration.class);
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
@@ -43,12 +43,12 @@ import reactor.core.publisher.Mono;
 public class JobImageSanitizer implements AdmissionSanitizer<JobDescriptor> {
     private static final Logger logger = LoggerFactory.getLogger(JobImageSanitizer.class);
 
-    private final JobImageValidatorConfiguration configuration;
+    private final JobImageSanitizerConfiguration configuration;
     private final RegistryClient registryClient;
     private final ValidatorMetrics validatorMetrics;
 
     @Inject
-    public JobImageSanitizer(JobImageValidatorConfiguration configuration, RegistryClient registryClient, Registry spectatorRegistry) {
+    public JobImageSanitizer(JobImageSanitizerConfiguration configuration, RegistryClient registryClient, Registry spectatorRegistry) {
         this.configuration = configuration;
         this.registryClient = registryClient;
         this.validatorMetrics = new ValidatorMetrics(this.getClass().getSimpleName(), spectatorRegistry);

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizerConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizerConfiguration.java
@@ -19,8 +19,8 @@ package com.netflix.titus.runtime.endpoint.admission;
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
 
-@Configuration(prefix = "titus.validate.serviceMesh.image")
-public interface ServiceMeshImageValidatorConfiguration extends AdmissionValidatorConfiguration {
+@Configuration(prefix = "titus.validate.job.image")
+public interface JobImageSanitizerConfiguration extends AdmissionValidatorConfiguration {
     @DefaultValue("true")
     boolean isEnabled();
 
@@ -29,5 +29,5 @@ public interface ServiceMeshImageValidatorConfiguration extends AdmissionValidat
      * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()}.
      */
     @DefaultValue("4500")
-    long getServiceMeshImageValidationTimeoutMs();
+    long getJobImageValidationTimeoutMs();
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
@@ -22,7 +22,6 @@ import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.common.model.admission.AdmissionSanitizer;
-import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.common.model.admission.ValidatorMetrics;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.runtime.connector.registry.RegistryClient;
@@ -43,12 +42,12 @@ import java.util.function.UnaryOperator;
 public class ServiceMeshImageSanitizer implements AdmissionSanitizer<JobDescriptor> {
     private static final Logger logger = LoggerFactory.getLogger(ServiceMeshImageSanitizer.class);
 
-    private final ServiceMeshImageValidatorConfiguration configuration;
+    private final ServiceMeshImageSanitizerConfiguration configuration;
     private final RegistryClient registryClient;
     private final ValidatorMetrics validatorMetrics;
 
     @Inject
-    public ServiceMeshImageSanitizer(ServiceMeshImageValidatorConfiguration configuration, RegistryClient registryClient, Registry spectatorRegistry) {
+    public ServiceMeshImageSanitizer(ServiceMeshImageSanitizerConfiguration configuration, RegistryClient registryClient, Registry spectatorRegistry) {
         this.configuration = configuration;
         this.registryClient = registryClient;
         this.validatorMetrics = new ValidatorMetrics(this.getClass().getSimpleName(), spectatorRegistry);

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.model.job.Image;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.common.model.admission.AdmissionSanitizer;
+import com.netflix.titus.common.model.admission.AdmissionValidator;
+import com.netflix.titus.common.model.admission.ValidatorMetrics;
+import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.runtime.connector.registry.RegistryClient;
+import com.netflix.titus.runtime.connector.registry.TitusRegistryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.Duration;
+import java.util.function.UnaryOperator;
+
+/**
+ * This {@link AdmissionValidator} implementation validates and sanitizes Job image information.
+ */
+@Singleton
+public class ServiceMeshImageSanitizer implements AdmissionSanitizer<JobDescriptor> {
+    private static final Logger logger = LoggerFactory.getLogger(ServiceMeshImageSanitizer.class);
+
+    private final ServiceMeshImageValidatorConfiguration configuration;
+    private final RegistryClient registryClient;
+    private final ValidatorMetrics validatorMetrics;
+
+    @Inject
+    public ServiceMeshImageSanitizer(ServiceMeshImageValidatorConfiguration configuration, RegistryClient registryClient, Registry spectatorRegistry) {
+        this.configuration = configuration;
+        this.registryClient = registryClient;
+        this.validatorMetrics = new ValidatorMetrics(this.getClass().getSimpleName(), spectatorRegistry);
+    }
+
+    /**
+     * @return a {@link UnaryOperator} that adds a sanitized Image or job attributes when sanitization was skipped
+     */
+    @Override
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor jobDescriptor) {
+        if (isDisabled()) {
+            return Mono.just(ServiceMeshImageSanitizer::skipSanitization);
+        }
+
+        if (!serviceMeshIsEnabled(jobDescriptor)) {
+            validatorMetrics.incrementValidationSkipped("serviceMeshNotEnabled");
+            return Mono.just(UnaryOperator.identity());
+        }
+
+        if (!serviceMeshIsPinned(jobDescriptor)) {
+            validatorMetrics.incrementValidationSkipped("serviceMeshNotPinned");
+            return Mono.just(UnaryOperator.identity());
+        }
+
+        Image image = getServiceMeshImage(jobDescriptor);
+        return sanitizeServiceMeshImage(image)
+                .map(ServiceMeshImageSanitizer::setMeshImageFunction)
+                .timeout(Duration.ofMillis(configuration.getServiceMeshImageValidationTimeoutMs()))
+                .doOnSuccess(j -> validatorMetrics.incrementValidationSuccess(image.getName()))
+                .onErrorReturn(throwable -> isAllowedException(throwable, image), ServiceMeshImageSanitizer::skipSanitization);
+    }
+
+    private static UnaryOperator<JobDescriptor> setMeshImageFunction(Image image) {
+        String imageName = toImageName(image);
+        return jobDescriptor -> JobFunctions.appendJobDescriptorAttribute(jobDescriptor,
+                JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER, imageName);
+    }
+
+    private Mono<Image> sanitizeServiceMeshImage(Image image) {
+        if (StringExt.isNotEmpty(image.getDigest())) {
+            return checkImageDigestExist(image).then(Mono.empty());
+        }
+
+        return registryClient.getImageDigest(image.getName(), image.getTag())
+                .map(digest -> image.toBuilder().withDigest(digest).build());
+    }
+
+    private Mono<String> checkImageDigestExist(Image image) {
+        return registryClient.getImageDigest(image.getName(), image.getDigest());
+    }
+
+    private boolean isDisabled() {
+        return !configuration.isEnabled();
+    }
+
+    private boolean serviceMeshIsEnabled(JobDescriptor<?> jobDescriptor) {
+        String enabled = jobDescriptor
+                .getAttributes()
+                .get(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_ENABLED);
+
+        if (enabled == null) {
+            return false;
+        }
+
+        return Boolean.parseBoolean(enabled);
+    }
+
+    private boolean serviceMeshIsPinned(JobDescriptor<?> jobDescriptor) {
+        return jobDescriptor
+                .getAttributes()
+                .containsKey(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER);
+    }
+
+    private Image getServiceMeshImage(JobDescriptor<?> jobDescriptor) {
+        String image = jobDescriptor
+                .getAttributes()
+                .get(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SERVICEMESH_CONTAINER);
+
+        return parseImageName(image);
+    }
+
+    private static Image parseImageName(String imageName) {
+        // Grammar
+        //
+        //  reference                       := name [ ":" tag ] [ "@" digest ]
+        //  name                            := [hostname '/'] component ['/' component]*
+        //  hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
+        //  hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+        //  port-number                     := /[0-9]+/
+        //  component                       := alpha-numeric [separator alpha-numeric]*
+        //  alpha-numeric                   := /[a-z0-9]+/
+        //  separator                       := /[_.]|__|[-]*/
+        //
+        //  tag                             := /[\w][\w.-]{0,127}/
+        //
+        //  digest                          := digest-algorithm ":" digest-hex
+        //  digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+        //  digest-algorithm-separator      := /[+.-_]/
+        //  digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
+        //  digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
+
+
+        int digestStart = imageName.lastIndexOf("@");
+        if (digestStart < 0) {
+            int tagStart = imageName.lastIndexOf(":");
+
+            String name = imageName.substring(0, tagStart);
+            String tag = imageName.substring(tagStart + 1);
+            return Image.newBuilder().withName(name).withTag(tag).build();
+        } else {
+            String name = imageName.substring(0, digestStart);
+            String digest = imageName.substring(digestStart + 1);
+            return Image.newBuilder().withName(name).withDigest(digest).build();
+        }
+    }
+
+    private static String toImageName(Image image) {
+        return String.format("%s@%s", image.getName(), image.getDigest());
+    }
+
+    /**
+     * Determines if this Exception should fail open, or produce a sanitization failure
+     */
+    private boolean isAllowedException(Throwable throwable, Image image) {
+        logger.error("Exception while checking image digest: {}", throwable.getMessage());
+        logger.debug("Full stacktrace", throwable);
+
+        String imageName = image.getName();
+        String imageVersion = image.getDigest().isEmpty() ? image.getTag() : image.getDigest();
+        String imageResource = String.format("%s_%s", imageName, imageVersion);
+
+        // Use a more specific error tag if available
+        if (throwable instanceof TitusRegistryException) {
+            TitusRegistryException tre = (TitusRegistryException) throwable;
+            validatorMetrics.incrementValidationError(
+                    imageResource,
+                    tre.getErrorCode().name());
+
+            return tre.getErrorCode() != TitusRegistryException.ErrorCode.IMAGE_NOT_FOUND;
+        } else {
+            validatorMetrics.incrementValidationError(
+                    imageResource,
+                    throwable.getClass().getSimpleName());
+        }
+
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JobDescriptor<?> skipSanitization(JobDescriptor<?> jobDescriptor) {
+        return JobFunctions.appendJobDescriptorAttribute(jobDescriptor,
+                JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_SERVICEMESH_IMAGE, true
+        );
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
@@ -37,7 +37,7 @@ import java.time.Duration;
 import java.util.function.UnaryOperator;
 
 /**
- * This {@link AdmissionValidator} implementation validates and sanitizes Job image information.
+ * This {@link AdmissionSanitizer} implementation validates and sanitizes service mesh image attributes.
  */
 @Singleton
 public class ServiceMeshImageSanitizer implements AdmissionSanitizer<JobDescriptor> {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizer.java
@@ -153,7 +153,10 @@ public class ServiceMeshImageSanitizer implements AdmissionSanitizer<JobDescript
         int digestStart = imageName.lastIndexOf("@");
         if (digestStart < 0) {
             int tagStart = imageName.lastIndexOf(":");
-
+            if (tagStart < 0) {
+                throw new IllegalArgumentException("cannot parse " + imageName + " as docker image name");
+            }
+            
             String name = imageName.substring(0, tagStart);
             String tag = imageName.substring(tagStart + 1);
             return Image.newBuilder().withName(name).withTag(tag).build();

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizerConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizerConfiguration.java
@@ -19,8 +19,8 @@ package com.netflix.titus.runtime.endpoint.admission;
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
 
-@Configuration(prefix = "titus.validate.job.image")
-public interface JobImageValidatorConfiguration extends AdmissionValidatorConfiguration {
+@Configuration(prefix = "titus.validate.serviceMesh.image")
+public interface ServiceMeshImageSanitizerConfiguration extends AdmissionValidatorConfiguration {
     @DefaultValue("true")
     boolean isEnabled();
 
@@ -29,5 +29,5 @@ public interface JobImageValidatorConfiguration extends AdmissionValidatorConfig
      * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()}.
      */
     @DefaultValue("4500")
-    long getJobImageValidationTimeoutMs();
+    long getServiceMeshImageValidationTimeoutMs();
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageValidatorConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageValidatorConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+
+@Configuration(prefix = "titus.validate.serviceMesh.image")
+public interface ServiceMeshImageValidatorConfiguration extends AdmissionValidatorConfiguration {
+    @DefaultValue("true")
+    boolean isEnabled();
+
+    /**
+     * Since Image validations are on the job accept path the timeout value is aggressive.
+     * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()}.
+     */
+    @DefaultValue("4500")
+    long getServiceMeshImageValidationTimeoutMs();
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
@@ -57,7 +57,8 @@ public class TitusAdmissionModule extends AbstractModule {
     @Singleton
     public AdmissionSanitizer<JobDescriptor> getJobSanitizer(TitusValidatorConfiguration configuration,
                                                              JobImageSanitizer jobImageSanitizer,
-                                                             JobIamValidator jobIamSanitizer) {
-        return new AggregatingSanitizer(configuration, Arrays.asList(jobImageSanitizer, jobIamSanitizer));
+                                                             JobIamValidator jobIamSanitizer,
+                                                             ServiceMeshImageSanitizer serviceMeshImageSanitizer) {
+        return new AggregatingSanitizer(configuration, Arrays.asList(jobImageSanitizer, jobIamSanitizer, serviceMeshImageSanitizer));
     }
 }


### PR DESCRIPTION
We expect the gateway to replace tags with digest when launching a job with service mesh container specified.

This allows the service networking team to have customers launch a service job with a release build, while making sure that all tasks launched for the job use the same version of proxyd.