### PR TITLE
opportunistic CPUs: faster fallback from low supply (surplus)

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/V3QueueableTask.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/V3QueueableTask.java
@@ -232,7 +232,7 @@ public class V3QueueableTask implements TitusQueuableTask<Job, Task> {
     }
 
     /**
-     * Decrease the amount of requested opportunistic CPUs on a scheduling failure, up to no opportunistic CPUs.
+     * Exponentially decrease the amount of requested opportunistic CPUs on a scheduling failure, up to no opportunistic CPUs.
      * <p>
      * This allows scheduling with the maximum amount of opportunistic CPUs at a given moment, and falling back to less
      * opportunistic CPUs when not enough are available, eventually falling back to not using any opportunistic CPUs and
@@ -251,7 +251,7 @@ public class V3QueueableTask implements TitusQueuableTask<Job, Task> {
         if (!isStillEnabled) {
             return;
         }
-        int newCount = opportunisticCpuCount.updateAndGet(current -> current >= 1 ? current - 1 : 0);
+        int newCount = opportunisticCpuCount.updateAndGet(current -> current >= 1 ? current >> 1 : 0);
         logger.info("Task {} opportunistic scheduling failed, reduced requested opportunistic cpus to {}",
                 task.getId(), newCount);
     }


### PR DESCRIPTION
With jobs elligible for opportunistic scheduling, reduce the number of allocated opportunistic CPUs by half on each failed scheduling iteration, accelerating fallback to regular scheduling (opportunisticCpus = 0) when there is not enough surplus of opportunistic CPUs available.

This trades off optimal usage of opportunistic CPUs for lower launch latencies, as opportunsitic tasks will sit on the queue for a shorter time waiting for opportunistic CPUs to show up.

It also introduces some bias in the amounts of opportunistic CPUs that are allocated to each task (e.g.: prime numbers, and number not divisible by 2 may be less likely to be used), but the tradeoff in queue times and reliability (during a large spike of opportunistic tasks and short supply) is worth for now.