### PR TITLE
fenzo should ignore nodes marked with uninitialized taint

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeConstants.java
@@ -66,6 +66,8 @@ public final class KubeConstants {
      * Titus taints.
      */
 
+    public static final String TAINT_NODE_UNINITIALIZED = TITUS_NODE_DOMAIN + "uninitialized";
+
     /**
      * Machines with this taint and value 'titus' can be used for pod placement.
      */

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
@@ -282,6 +282,11 @@ public class KubeUtil {
         if (CollectionsExt.isNullOrEmpty(taints)) {
             return true;
         }
+
+        if (hasUninitializedTaint(node)) {
+            return false;
+        }
+
         Set<String> schedulerTaintValues = taints.stream()
                 .filter(t -> KubeConstants.TAINT_SCHEDULER.equals(t.getKey()))
                 .map(t -> StringExt.safeTrim(t.getValue()))
@@ -361,5 +366,13 @@ public class KubeUtil {
 
             sink.onCancel(call::cancel);
         });
+    }
+
+    public static boolean hasUninitializedTaint(V1Node node) {
+        if (node.getSpec() != null && node.getSpec().getTaints() != null) {
+            return node.getSpec().getTaints().stream()
+                    .anyMatch(t -> KubeConstants.TAINT_NODE_UNINITIALIZED.equals(t.getKey()));
+        }
+        return false;
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtilTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtilTest.java
@@ -49,6 +49,7 @@ public class KubeUtilTest {
 
     private static final V1Taint TAINT_SCHEDULER_FENZO = new V1Taint().key(KubeConstants.TAINT_SCHEDULER).value(KubeConstants.TAINT_SCHEDULER_VALUE_FENZO);
     private static final V1Taint TAINT_SCHEDULER_OTHER = new V1Taint().key(KubeConstants.TAINT_SCHEDULER).value(KubeConstants.TAINT_SCHEDULER_VALUE_KUBE);
+    private static final V1Taint TAINT_NODE_UNINITIALIZED = new V1Taint().key(KubeConstants.TAINT_NODE_UNINITIALIZED).value("someValue");
     private static final V1Taint TAINT_TOLERATED_TAINT_1 = new V1Taint().key("toleratedTaint1").value("someValue");
     private static final V1Taint TAINT_TOLERATED_TAINT_2 = new V1Taint().key("toleratedTaint2").value("someValue");
     private static final V1Taint TAINT_NOT_TOLERATED_TAINT = new V1Taint().key("notToleratedTaint").value("someValue");
@@ -71,6 +72,7 @@ public class KubeUtilTest {
 
         assertThat(KubeUtil.hasFenzoSchedulerTaint(newNodeWithoutZone(TAINT_SCHEDULER_OTHER))).isFalse();
         assertThat(KubeUtil.hasFenzoSchedulerTaint(newNodeWithoutZone(TAINT_SCHEDULER_OTHER, TAINT_SCHEDULER_FENZO))).isFalse();
+        assertThat(KubeUtil.hasFenzoSchedulerTaint(newNodeWithoutZone(TAINT_NODE_UNINITIALIZED))).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Fenzo should ignore nodes that are tainted "node.titus.netflix.com/uninitialized" as part of handling nodes informed by K8s integration

