### PR TITLE
RFC - Make the kubeapiserver connector understand pod ips from kubelet

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
@@ -290,8 +290,13 @@ public class KubeNotificationProcessor {
                 .build();
 
         Task fixedTask = fillInMissingStates(podWrapper, updatedTask);
-        Task taskWithPlacementData = JobManagerUtil.attachPlacementData(fixedTask, executorDetailsOpt);
-        Task taskWithNodeMetadata = node.map(n -> attachNodeMetadata(taskWithPlacementData, n)).orElse(taskWithPlacementData);
+        Task taskWithExecutorData;
+        if (executorDetailsOpt.isPresent()) {
+            taskWithExecutorData = JobManagerUtil.attachTitusExecutorData(fixedTask, executorDetailsOpt);
+        } else {
+            taskWithExecutorData = JobManagerUtil.attachKubeletData(fixedTask, podWrapper);
+        }
+        Task taskWithNodeMetadata = node.map(n -> attachNodeMetadata(taskWithExecutorData, n)).orElse(taskWithExecutorData);
         Task taskWithAnnotations = addMissingAttributes(podWrapper, taskWithNodeMetadata);
 
         return taskWithAnnotations;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
@@ -132,6 +132,9 @@ public class KubeUtil {
     }
 
     public static Optional<V1ContainerState> findContainerState(V1Pod pod) {
+        if (pod.getStatus() == null) {
+            return Optional.empty();
+        }
         List<V1ContainerStatus> containerStatuses = pod.getStatus().getContainerStatuses();
         if (containerStatuses != null) {
             for (V1ContainerStatus status : containerStatuses) {


### PR DESCRIPTION
I kinda don't know what I'm doing here.

It looks like vk + executor add extra annotations after the fact ([here](https://github.com/Netflix-Skunkworks/titus-virtual-kubelet/blob/68ea9b6c6183b91eaa12d2d2505f18732d81aae6/provider/runtime_pod.go#L188)) to provide networking metadata back to the control plane.

This doesn't work on kubelet at all, so the control plane has no idea what ip address a kubelet pod has.

I don't know how easy it is going to be to add these annotations via kubelet, but this unblocks things a little bit by getting at least an ip address?