### PR TITLE
Feature/resource pool assignment

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -124,6 +124,8 @@ public final class JobAttributes {
      */
     public static final String JOB_PARAMETER_ATTRIBUTES_TOLERATIONS = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "tolerations";
 
+    public static final String JOB_PARAMETER_RESOURCE_POOLS = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "resourcePools";
+
     // Container Attributes
 
     /**

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool.CapacityGroupPodResourcePoolResolver;
 import com.netflix.titus.runtime.connector.kubernetes.KubeConnectorConfiguration;
 
 @Configuration(prefix = "titusMaster.directKube")
@@ -148,4 +149,10 @@ public interface DirectKubeConfiguration extends KubeConnectorConfiguration {
      */
     @DefaultValue("200")
     int getPodCreateConcurrencyLimit();
+
+    /**
+     * Frequency at which {@link CapacityGroupPodResourcePoolResolver} resolve configuration is re-read.
+     */
+    @DefaultValue("5000")
+    long getCapacityGroupPodResourcePoolResolverUpdateIntervalMs();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/PodAffinityFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/PodAffinityFactory.java
@@ -29,5 +29,9 @@ import io.kubernetes.client.openapi.models.V1Affinity;
  */
 public interface PodAffinityFactory {
 
+    /**
+     * Returns Kubernetes {@link V1Affinity} rules for a task, and a map of key/value pairs that are added to
+     * pod annotations.
+     */
     Pair<V1Affinity, Map<String, String>> buildV1Affinity(Job<?> job, Task task);
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/CapacityGroupPodResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/CapacityGroupPodResourcePoolResolver.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.Iterators;
+import com.netflix.archaius.api.Config;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeConfiguration;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CapacityGroupPodResourcePoolResolver implements PodResourcePoolResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(CapacityGroupPodResourcePoolResolver.class);
+
+    private final DirectKubeConfiguration configuration;
+    private final Config config;
+    private final ApplicationSlaManagementService capacityGroupService;
+    private final TitusRuntime titusRuntime;
+
+    private final Lock lock = new ReentrantLock();
+    private volatile List<Pair<String, Pattern>> resourcePoolToCapacityGroupMappers;
+    private volatile long lastUpdate;
+
+    public CapacityGroupPodResourcePoolResolver(DirectKubeConfiguration configuration,
+                                                Config config,
+                                                ApplicationSlaManagementService capacityGroupService,
+                                                TitusRuntime titusRuntime) {
+        this.configuration = configuration;
+        this.config = config;
+        this.capacityGroupService = capacityGroupService;
+        this.titusRuntime = titusRuntime;
+        refreshResourcePoolToCapacityGroupMappers();
+    }
+
+    @Override
+    public List<ResourcePoolAssignment> resolve(Job<?> job) {
+        ApplicationSLA capacityGroup = JobManagerUtil.getCapacityGroupDescriptor(job.getJobDescriptor(), capacityGroupService);
+        if (capacityGroup == null) {
+            return Collections.emptyList();
+        }
+
+        List<Pair<String, Pattern>> currentMappers = getCurrentMappers();
+        for (Pair<String, Pattern> next : currentMappers) {
+            Pattern pattern = next.getRight();
+            if (pattern.matcher(capacityGroup.getAppName()).matches()) {
+                return Collections.singletonList(ResourcePoolAssignment.newBuilder()
+                        .withResourcePoolName(next.getLeft())
+                        .withRule(String.format("Capacity group %s matches %s", capacityGroup.getAppName(), pattern.toString()))
+                        .build()
+                );
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<Pair<String, Pattern>> getCurrentMappers() {
+        if (!titusRuntime.getClock().isPast(lastUpdate + configuration.getCapacityGroupPodResourcePoolResolverUpdateIntervalMs())) {
+            return resourcePoolToCapacityGroupMappers;
+        }
+
+        if (!lock.tryLock()) {
+            return resourcePoolToCapacityGroupMappers;
+        }
+
+        try {
+            refreshResourcePoolToCapacityGroupMappers();
+        } finally {
+            lock.unlock();
+        }
+        return resourcePoolToCapacityGroupMappers;
+    }
+
+    private void refreshResourcePoolToCapacityGroupMappers() {
+        List<Pair<String, Pattern>> result = new ArrayList<>();
+
+        String[] orderKeys = Iterators.toArray(config.getKeys(), String.class);
+        Arrays.sort(orderKeys);
+
+        for (String name : orderKeys) {
+            String patternText = config.getString(name);
+            try {
+                result.add(Pair.of(name, Pattern.compile(patternText)));
+            } catch (Exception e) {
+                logger.warn("Cannot parse resource pool rule: name={}, pattern={}", name, patternText, e);
+            }
+        }
+
+        this.resourcePoolToCapacityGroupMappers = result;
+        this.lastUpdate = titusRuntime.getClock().wallTime();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ExplicitJobPodResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ExplicitJobPodResourcePoolResolver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.common.util.StringExt;
+
+/**
+ * Pick a resource pool directly by setting a job parameter.
+ */
+public class ExplicitJobPodResourcePoolResolver implements PodResourcePoolResolver {
+    @Override
+    public List<ResourcePoolAssignment> resolve(Job<?> job) {
+        List<String> resourcePoolNames = StringExt.splitByComma(
+                job.getJobDescriptor().getAttributes().get(JobAttributes.JOB_PARAMETER_RESOURCE_POOLS)
+        );
+        if (resourcePoolNames.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String rule = "Job requested placement in resource pools: " + resourcePoolNames;
+        return resourcePoolNames.stream().map(name ->
+                ResourcePoolAssignment.newBuilder().withResourcePoolName(name).withRule(rule).build()
+        ).collect(Collectors.toList());
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolver.java
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.mesos.kubeapiserver.direct;
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
 
-import java.util.Map;
+import java.util.List;
 
 import com.netflix.titus.api.jobmanager.model.job.Job;
-import com.netflix.titus.api.jobmanager.model.job.Task;
-import com.netflix.titus.common.util.tuple.Pair;
-import io.kubernetes.client.openapi.models.V1Affinity;
 
 /**
- * Builds pod affinity and ant-affinity rules for a job/task. This includes both the job level hard and soft
- * constraints, as well as Titus system level constraints.
+ * {@link PodResourcePoolResolver} is an abstraction for resolving a set of resource pools in which a pod can be placed.
  */
-public interface PodAffinityFactory {
+public interface PodResourcePoolResolver {
 
-    Pair<V1Affinity, Map<String, String>> buildV1Affinity(Job<?> job, Task task);
+    List<ResourcePoolAssignment> resolve(Job<?> job);
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolverChain.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolverChain.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+
+public class PodResourcePoolResolverChain implements PodResourcePoolResolver {
+
+    private final List<PodResourcePoolResolver> delegates;
+
+    public PodResourcePoolResolverChain(List<PodResourcePoolResolver> delegates) {
+        this.delegates = delegates;
+    }
+
+    @Override
+    public List<ResourcePoolAssignment> resolve(Job<?> job) {
+        for (PodResourcePoolResolver delegate : delegates) {
+            List<ResourcePoolAssignment> result = delegate.resolve(job);
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolvers.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolvers.java
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.master.mesos.kubeapiserver.direct;
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
 
-import java.util.Map;
+public final class PodResourcePoolResolvers {
 
-import com.netflix.titus.api.jobmanager.model.job.Job;
-import com.netflix.titus.api.jobmanager.model.job.Task;
-import com.netflix.titus.common.util.tuple.Pair;
-import io.kubernetes.client.openapi.models.V1Affinity;
+    public static final String RESOURCE_POOL_ELASTIC = "elastic";
 
-/**
- * Builds pod affinity and ant-affinity rules for a job/task. This includes both the job level hard and soft
- * constraints, as well as Titus system level constraints.
- */
-public interface PodAffinityFactory {
+    public static final String RESOURCE_POOL_RESERVED = "reserved";
 
-    Pair<V1Affinity, Map<String, String>> buildV1Affinity(Job<?> job, Task task);
+    public static final String RESOURCE_POOL_GPU_PREFIX = "elasticGpu";
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ResourcePoolAssignment.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ResourcePoolAssignment.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.Objects;
+
+public class ResourcePoolAssignment {
+
+    private final String resourcePoolName;
+    private final String rule;
+
+    public ResourcePoolAssignment(String resourcePoolName, String rule) {
+        this.resourcePoolName = resourcePoolName;
+        this.rule = rule;
+    }
+
+    public String getResourcePoolName() {
+        return resourcePoolName;
+    }
+
+    public String getRule() {
+        return rule;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResourcePoolAssignment that = (ResourcePoolAssignment) o;
+        return Objects.equals(resourcePoolName, that.resourcePoolName) &&
+                Objects.equals(rule, that.rule);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourcePoolName, rule);
+    }
+
+    @Override
+    public String toString() {
+        return "ResourcePoolAssignment{" +
+                "resourcePoolName='" + resourcePoolName + '\'' +
+                ", rule='" + rule + '\'' +
+                '}';
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String resourcePoolName;
+        private String rule;
+
+        private Builder() {
+        }
+
+        public Builder withResourcePoolName(String resourcePoolName) {
+            this.resourcePoolName = resourcePoolName;
+            return this;
+        }
+
+        public Builder withRule(String rule) {
+            this.rule = rule;
+            return this;
+        }
+
+        public ResourcePoolAssignment build() {
+            return new ResourcePoolAssignment(resourcePoolName, rule);
+        }
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ResourcePoolAssignment.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ResourcePoolAssignment.java
@@ -18,6 +18,8 @@ package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
 
 import java.util.Objects;
 
+import com.google.common.base.Preconditions;
+
 public class ResourcePoolAssignment {
 
     private final String resourcePoolName;
@@ -84,6 +86,8 @@ public class ResourcePoolAssignment {
         }
 
         public ResourcePoolAssignment build() {
+            Preconditions.checkNotNull(resourcePoolName, "resource pool name is null");
+            Preconditions.checkNotNull(rule, "rule is null");
             return new ResourcePoolAssignment(resourcePoolName, rule);
         }
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/TierPodResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/TierPodResourcePoolResolver.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.api.model.Tier;
+import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+
+public class TierPodResourcePoolResolver implements PodResourcePoolResolver {
+
+    private static final ResourcePoolAssignment ASSIGNMENT_ELASTIC = ResourcePoolAssignment.newBuilder()
+            .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC)
+            .withRule("Flex tier assigned to elastic resource pool")
+            .build();
+
+    private static final ResourcePoolAssignment ASSIGNMENT_RESERVED = ResourcePoolAssignment.newBuilder()
+            .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
+            .withRule("Flex tier assigned to elastic resource pool")
+            .build();
+
+    private final ApplicationSlaManagementService capacityGroupService;
+
+    public TierPodResourcePoolResolver(ApplicationSlaManagementService capacityGroupService) {
+        this.capacityGroupService = capacityGroupService;
+    }
+
+    @Override
+    public List<ResourcePoolAssignment> resolve(Job<?> job) {
+        ApplicationSLA capacityGroup = JobManagerUtil.getCapacityGroupDescriptor(job.getJobDescriptor(), capacityGroupService);
+        if (capacityGroup == null || capacityGroup.getTier() != Tier.Critical) {
+            return Collections.singletonList(ASSIGNMENT_ELASTIC);
+        }
+        return Collections.singletonList(ASSIGNMENT_RESERVED);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/TierPodResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/TierPodResourcePoolResolver.java
@@ -34,7 +34,7 @@ public class TierPodResourcePoolResolver implements PodResourcePoolResolver {
 
     private static final ResourcePoolAssignment ASSIGNMENT_RESERVED = ResourcePoolAssignment.newBuilder()
             .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
-            .withRule("Flex tier assigned to elastic resource pool")
+            .withRule("Critical tier assigned to reserved resource pool")
             .build();
 
     private final ApplicationSlaManagementService capacityGroupService;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactory.java
@@ -25,7 +25,11 @@ import javax.inject.Singleton;
 
 import com.netflix.titus.api.jobmanager.JobConstraints;
 import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.api.model.Tier;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeConfiguration;
@@ -35,10 +39,13 @@ import io.kubernetes.client.openapi.models.V1Toleration;
 public class DefaultTaintTolerationFactory implements TaintTolerationFactory {
 
     private final DirectKubeConfiguration configuration;
+    private final ApplicationSlaManagementService capacityManagement;
 
     @Inject
-    public DefaultTaintTolerationFactory(DirectKubeConfiguration configuration) {
+    public DefaultTaintTolerationFactory(DirectKubeConfiguration configuration,
+                                         ApplicationSlaManagementService capacityManagement) {
         this.configuration = configuration;
+        this.capacityManagement = capacityManagement;
     }
 
     @Override
@@ -49,11 +56,21 @@ public class DefaultTaintTolerationFactory implements TaintTolerationFactory {
         tolerations.add(Tolerations.TOLERATION_VIRTUAL_KUBLET);
         tolerations.add(Tolerations.TOLERATION_KUBE_SCHEDULER);
 
+        tolerations.add(resolveTierToleration(job));
         resolveAvailabilityZoneToleration(job).ifPresent(tolerations::add);
         resolveGpuInstanceTypeToleration(job).ifPresent(tolerations::add);
         resolveKubeBackendToleration(job).ifPresent(tolerations::add);
 
         return tolerations;
+    }
+
+    private V1Toleration resolveTierToleration(Job job) {
+        String capacityGroupName = JobFunctions.getEffectiveCapacityGroup(job);
+        ApplicationSLA capacityGroup = capacityManagement.findApplicationSLA(capacityGroupName).orElse(null);
+        if (capacityGroup == null) {
+            return Tolerations.TOLERATION_TIER_FLEX;
+        }
+        return capacityGroup.getTier() == Tier.Critical ? Tolerations.TOLERATION_TIER_CRITICAL : Tolerations.TOLERATION_TIER_FLEX;
     }
 
     private Optional<V1Toleration> resolveAvailabilityZoneToleration(Job job) {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/CapacityGroupPodResourcePoolResolverTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/CapacityGroupPodResourcePoolResolverTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.archaius.config.DefaultSettableConfig;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.api.model.Tier;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.archaius2.Archaius2Ext;
+import com.netflix.titus.common.util.time.TestClock;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeConfiguration;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CapacityGroupPodResourcePoolResolverTest {
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test();
+
+    private final TestClock clock = (TestClock) titusRuntime.getClock();
+
+    private final DefaultSettableConfig config = new DefaultSettableConfig();
+
+    private final DirectKubeConfiguration configuration = Archaius2Ext.newConfiguration(DirectKubeConfiguration.class);
+
+    private final ApplicationSlaManagementService capacityGroupService = mock(ApplicationSlaManagementService.class);
+
+    private final CapacityGroupPodResourcePoolResolver resolver = new CapacityGroupPodResourcePoolResolver(
+            configuration,
+            config,
+            capacityGroupService,
+            titusRuntime
+    );
+
+    @Before
+    public void setUp() throws Exception {
+        when(capacityGroupService.getApplicationSLA("myFlex")).thenReturn(ApplicationSLA.newBuilder()
+                .withAppName("myFlex")
+                .withTier(Tier.Flex)
+                .build()
+        );
+        when(capacityGroupService.getApplicationSLA("myCritical")).thenReturn(ApplicationSLA.newBuilder()
+                .withAppName("myCritical")
+                .withTier(Tier.Critical)
+                .build()
+        );
+
+        config.setProperty("elastic", ".*Flex");
+        config.setProperty("reserved", ".*Critical");
+        clock.advanceTime(1, TimeUnit.HOURS);
+    }
+
+    @Test
+    public void testBasic() {
+        // Map to elastic
+        List<ResourcePoolAssignment> result = resolver.resolve(newJob("myFlex"));
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo("elastic");
+
+        // Map to reserved
+        result = resolver.resolve(newJob("myCritical"));
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo("reserved");
+    }
+
+    @Test
+    public void testUpdate() {
+        // Entries are ordered so this one gets ahead
+        config.setProperty("anElastic", ".*Flex");
+        clock.advanceTime(1, TimeUnit.HOURS);
+
+        List<ResourcePoolAssignment> result = resolver.resolve(newJob("myFlex"));
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo("anElastic");
+    }
+
+    private Job newJob(String capacityGroup) {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob();
+        job = job.toBuilder()
+                .withJobDescriptor(job.getJobDescriptor().toBuilder()
+                        .withCapacityGroup(capacityGroup)
+                        .build()
+                )
+                .build();
+        return job;
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ExplicitJobPodResourcePoolResolverTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/ExplicitJobPodResourcePoolResolverTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExplicitJobPodResourcePoolResolverTest {
+
+    private final ExplicitJobPodResourcePoolResolver resolver = new ExplicitJobPodResourcePoolResolver();
+
+    @Test
+    public void testAssignment() {
+        List<ResourcePoolAssignment> result = resolver.resolve(newJob("myResourcePool"));
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo("myResourcePool");
+    }
+
+    private Job newJob(String resourcePool) {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob();
+        job = job.toBuilder()
+                .withJobDescriptor(job.getJobDescriptor().toBuilder()
+                        .withAttributes(Collections.singletonMap(
+                                JobAttributes.JOB_PARAMETER_RESOURCE_POOLS,
+                                resourcePool
+                        ))
+                        .build()
+                )
+                .build();
+        return job;
+    }
+
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolverChainTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolverChainTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PodResourcePoolResolverChainTest {
+
+    private final PodResourcePoolResolver delegate1 = mock(PodResourcePoolResolver.class);
+    private final PodResourcePoolResolver delegate2 = mock(PodResourcePoolResolver.class);
+
+    private final PodResourcePoolResolverChain resolver = new PodResourcePoolResolverChain(Arrays.asList(delegate1, delegate2));
+
+    @Test
+    public void testChainedExecution() {
+        when(delegate1.resolve(any())).thenReturn(Collections.emptyList());
+        when(delegate2.resolve(any())).thenReturn(Collections.singletonList(
+                ResourcePoolAssignment.newBuilder().withResourcePoolName("elastic").build())
+        );
+        List<ResourcePoolAssignment> result = resolver.resolve(JobGenerator.oneBatchJob());
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo("elastic");
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolverChainTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/PodResourcePoolResolverChainTest.java
@@ -39,7 +39,7 @@ public class PodResourcePoolResolverChainTest {
     public void testChainedExecution() {
         when(delegate1.resolve(any())).thenReturn(Collections.emptyList());
         when(delegate2.resolve(any())).thenReturn(Collections.singletonList(
-                ResourcePoolAssignment.newBuilder().withResourcePoolName("elastic").build())
+                ResourcePoolAssignment.newBuilder().withResourcePoolName("elastic").withRule("rule").build())
         );
         List<ResourcePoolAssignment> result = resolver.resolve(JobGenerator.oneBatchJob());
         assertThat(result).hasSize(1);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/TierPodResourcePoolResolverTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/resourcepool/TierPodResourcePoolResolverTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct.resourcepool;
+
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.api.model.Tier;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TierPodResourcePoolResolverTest {
+
+    private final ApplicationSlaManagementService capacityGroupService = mock(ApplicationSlaManagementService.class);
+
+    private final TierPodResourcePoolResolver resolver = new TierPodResourcePoolResolver(capacityGroupService);
+
+    @Before
+    public void setUp() throws Exception {
+        when(capacityGroupService.getApplicationSLA("myFlex")).thenReturn(ApplicationSLA.newBuilder()
+                .withAppName("myFlex")
+                .withTier(Tier.Flex)
+                .build()
+        );
+        when(capacityGroupService.getApplicationSLA("myCritical")).thenReturn(ApplicationSLA.newBuilder()
+                .withAppName("myCritical")
+                .withTier(Tier.Critical)
+                .build()
+        );
+    }
+
+    @Test
+    public void testFlex() {
+        List<ResourcePoolAssignment> result = resolver.resolve(newJob("myFlex"));
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+    }
+
+    @Test
+    public void testCritical() {
+        List<ResourcePoolAssignment> result = resolver.resolve(newJob("myCritical"));
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
+    }
+
+    private Job newJob(String capacityGroup) {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob();
+        job = job.toBuilder()
+                .withJobDescriptor(job.getJobDescriptor().toBuilder()
+                        .withCapacityGroup(capacityGroup)
+                        .build()
+                )
+                .build();
+        return job;
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactoryTest.java
@@ -26,7 +26,6 @@ import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeConfiguration;
-import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.testkit.model.job.JobGenerator;
 import io.kubernetes.client.openapi.models.V1Toleration;
 import org.junit.Test;
@@ -38,12 +37,7 @@ public class DefaultTaintTolerationFactoryTest {
 
     private final DirectKubeConfiguration configuration = mock(DirectKubeConfiguration.class);
 
-    private ApplicationSlaManagementService capacityManagement = mock(ApplicationSlaManagementService.class);
-
-    private final DefaultTaintTolerationFactory factory = new DefaultTaintTolerationFactory(
-            configuration,
-            capacityManagement
-    );
+    private final DefaultTaintTolerationFactory factory = new DefaultTaintTolerationFactory(configuration);
 
     @Test
     public void testGpuInstanceAssignment() {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/taint/DefaultTaintTolerationFactoryTest.java
@@ -24,6 +24,7 @@ import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeConfiguration;
 import com.netflix.titus.testkit.model.job.JobGenerator;
@@ -37,7 +38,12 @@ public class DefaultTaintTolerationFactoryTest {
 
     private final DirectKubeConfiguration configuration = mock(DirectKubeConfiguration.class);
 
-    private final DefaultTaintTolerationFactory factory = new DefaultTaintTolerationFactory(configuration);
+    private final ApplicationSlaManagementService capacityManagement = mock(ApplicationSlaManagementService.class);
+
+    private final DefaultTaintTolerationFactory factory = new DefaultTaintTolerationFactory(
+            configuration,
+            capacityManagement
+    );
 
     @Test
     public void testGpuInstanceAssignment() {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -45,6 +45,8 @@ public final class KubeConstants {
      */
     public static final String TITUS_NODE_DOMAIN = "node.titus.netflix.com/";
 
+    public static final String TITUS_SCALER_DOMAIN = "scaler.titus.netflix.com/";
+
     /**
      * Common prefix for Titus V3 job API specific annotations/labels.
      */
@@ -67,6 +69,8 @@ public final class KubeConstants {
     public static final String NODE_LABEL_MACHINE_GROUP = TITUS_NODE_DOMAIN + "asg";
 
     public static final String NODE_LABEL_KUBE_BACKEND = TITUS_NODE_DOMAIN + "backend";
+
+    public static final String NODE_LABEL_RESOURCE_POOL = TITUS_SCALER_DOMAIN + "resource-pool";
 
     /*
      * Titus taints.

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/connector/Node.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/connector/Node.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.supplementary.relocation.connector;
 
+import com.google.common.base.Preconditions;
+
 public class Node {
 
     private final String id;
@@ -112,6 +114,8 @@ public class Node {
         }
 
         public Node build() {
+            Preconditions.checkNotNull(id, "instance id is null");
+            Preconditions.checkNotNull(serverGroupId, "server group id is null");
             Node node = new Node(id, serverGroupId);
             node.relocationNotAllowed = this.relocationNotAllowed;
             node.relocationRequiredImmediately = this.relocationRequiredImmediately;

--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/connector/AggregatingNodeDataResolverTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/connector/AggregatingNodeDataResolverTest.java
@@ -39,6 +39,7 @@ public class AggregatingNodeDataResolverTest {
     private NodeDataResolver newDelegate(String nodeId, long stalenessMs) {
         Node node = Node.newBuilder()
                 .withId(nodeId)
+                .withServerGroupId("myServerGroup")
                 .build();
 
         NodeDataResolver resolver = mock(NodeDataResolver.class);


### PR DESCRIPTION
Resource pools replace tiers. When a KubeScheduler pod is created for a task, a resource pool affinity rules must be associated with it.