### PR TITLE
Rate limit reconciliation of tasks stuck in state

### DIFF
--- a/titus-common/src/main/java/com/netflix/titus/common/util/limiter/Limiters.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/limiter/Limiters.java
@@ -37,15 +37,20 @@ public class Limiters {
     }
 
     /**
+     * Useful for testing.
+     */
+    public static TokenBucket unlimited(String name) {
+        return new Unlimited(name);
+    }
+
+    /**
      * Create a {@link TokenBucket} with a fixed interval {@link RefillStrategy}.
      */
     public static TokenBucket createFixedIntervalTokenBucket(String name, long capacity, long initialNumberOfTokens,
                                                              long numberOfTokensPerInterval, long interval, TimeUnit unit) {
         RefillStrategy refillStrategy = new FixedIntervalRefillStrategy(Stopwatch.createStarted(),
                 numberOfTokensPerInterval, interval, unit);
-        TokenBucket tokenBucket = new DefaultTokenBucket(name, capacity, refillStrategy, initialNumberOfTokens);
-
-        return tokenBucket;
+        return new DefaultTokenBucket(name, capacity, refillStrategy, initialNumberOfTokens);
     }
 
     /**
@@ -74,5 +79,55 @@ public class Limiters {
                 ),
                 titusRuntime
         );
+    }
+
+    private static class Unlimited implements TokenBucket {
+        private final String name;
+
+        public Unlimited(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public long getCapacity() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public long getNumberOfTokens() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public boolean tryTake() {
+            return true;
+        }
+
+        @Override
+        public boolean tryTake(long numberOfTokens) {
+            return true;
+        }
+
+        @Override
+        public void take() {
+        }
+
+        @Override
+        public void take(long numberOfTokens) {
+        }
+
+        @Override
+        public void refill(long numberOfToken) {
+        }
+
+        @Override
+        public RefillStrategy getRefillStrategy() {
+            return null;
+        }
     }
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/util/limiter/Limiters.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/limiter/Limiters.java
@@ -83,6 +83,7 @@ public class Limiters {
 
     private static class Unlimited implements TokenBucket {
         private final String name;
+        private final UnlimitedRefillStrategy strategy = new UnlimitedRefillStrategy();
 
         public Unlimited(String name) {
             this.name = name;
@@ -127,7 +128,20 @@ public class Limiters {
 
         @Override
         public RefillStrategy getRefillStrategy() {
-            return null;
+            return strategy;
+        }
+
+    }
+
+    private static class UnlimitedRefillStrategy implements RefillStrategy {
+        @Override
+        public long refill() {
+            return 0;
+        }
+
+        @Override
+        public long getTimeUntilNextRefill(TimeUnit unit) {
+            return 0;
         }
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
@@ -26,6 +26,8 @@ import com.netflix.titus.api.jobmanager.model.job.JobState;
 @Configuration(prefix = "titusMaster.jobManager")
 public interface JobManagerConfiguration {
 
+    String STUCK_IN_STATE_TOKEN_BUCKET = "stuckInState";
+
     @DefaultValue("100")
     long getReconcilerIdleTimeoutMs();
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/V3JobManagerModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/V3JobManagerModule.java
@@ -31,7 +31,6 @@ import com.netflix.titus.api.FeatureActivationConfiguration;
 import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
 import com.netflix.titus.api.jobmanager.service.V3JobOperations;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine.DifferenceResolver;
-import com.netflix.titus.common.runtime.SystemLogEvent;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.limiter.Limiters;
 import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
@@ -84,13 +83,7 @@ public class V3JobManagerModule extends AbstractModule {
         return Limiters.createInstrumentedFixedIntervalTokenBucket(
                 JobManagerConfiguration.STUCK_IN_STATE_TOKEN_BUCKET,
                 config,
-                currentTokenBucket -> runtime.getSystemLogService().submit(
-                        SystemLogEvent.newBuilder()
-                                .withCategory(SystemLogEvent.Category.Other)
-                                .withComponent(V3JobManagerModule.class.getSimpleName())
-                                .withMessage(String.format("Detected %s token bucket configuration update: %s", JobManagerConfiguration.STUCK_IN_STATE_TOKEN_BUCKET, currentTokenBucket))
-                                .build()
-                ),
+                currentTokenBucket -> logger.info("Detected {} token bucket configuration update: {}", JobManagerConfiguration.STUCK_IN_STATE_TOKEN_BUCKET, currentTokenBucket),
                 runtime
         );
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
@@ -44,6 +44,8 @@ import com.netflix.titus.common.model.sanitizer.VerifierMode;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.archaius2.Archaius2Ext;
+import com.netflix.titus.common.util.limiter.Limiters;
+import com.netflix.titus.common.util.limiter.tokenbucket.TokenBucket;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.jobmanager.service.DefaultV3JobOperations;
 import com.netflix.titus.master.jobmanager.service.JobManagerConfiguration;
@@ -157,6 +159,7 @@ public class JobsScenarioBuilder {
             }
         };
 
+        TokenBucket stuckInStateRateLimiter = Limiters.unlimited("stuckInState");
         BatchDifferenceResolver batchDifferenceResolver = new BatchDifferenceResolver(
                 kubeApiServerIntegrator,
                 configuration,
@@ -170,6 +173,7 @@ public class JobsScenarioBuilder {
                 constraintEvaluatorTransformer,
                 systemSoftConstraint,
                 systemHardConstraint,
+                stuckInStateRateLimiter,
                 titusRuntime,
                 testScheduler
         );
@@ -186,10 +190,10 @@ public class JobsScenarioBuilder {
                 constraintEvaluatorTransformer,
                 systemSoftConstraint,
                 systemHardConstraint,
+                stuckInStateRateLimiter,
                 titusRuntime,
                 testScheduler
         );
-
 
         JobSubmitLimiter jobSubmitLimiter = new JobSubmitLimiter() {
             @Override


### PR DESCRIPTION
... with dynamic configuration.

This will help prevent bad feedback loops when task state gets stale (e.g.: pod informers are not receiving updates), or when downstream systems are slow, adding some back-pressure to reconciliation.