### PR TITLE
Default stuckInLaunchedTimeout: 1min -> 5min

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
@@ -48,7 +48,7 @@ public interface JobManagerConfiguration {
     @DefaultValue("300")
     int getConcurrentReconcilerStoreUpdateLimit();
 
-    @DefaultValue("60000")
+    @DefaultValue("300000")
     long getTaskInLaunchedStateTimeoutMs();
 
     @DefaultValue("720000")


### PR DESCRIPTION
Align the default stuckInLaunched timeout with other timeouts for job management. 1min (the previous setting) can be too low (determined empirically) when `SharedInformers` are getting stale. 5min (the new default) is more aligned with the default `stuckInStartInitiated` for service jobs, and gives a higher chance of problems with stale `SharedInformers` to be detected and remediated.