### PR TITLE
metrics: tag task update counters with applicationName

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobAndTaskMetrics.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobAndTaskMetrics.java
@@ -150,12 +150,14 @@ public class JobAndTaskMetrics {
     }
 
     private void updateTaskMetrics(TaskUpdateEvent event) {
-        Pair<Tier, String> assignment = JobManagerUtil.getTierAssignment(event.getCurrentJob(), applicationSlaManagementService);
+        Job<?> job = event.getCurrentJob();
         Task task = event.getCurrentTask();
+        Pair<Tier, String> assignment = JobManagerUtil.getTierAssignment(job, applicationSlaManagementService);
         registry.counter(
                 TASK_STATE_CHANGE_METRIC_NAME,
                 "tier", assignment.getLeft().name(),
                 "capacityGroup", assignment.getRight(),
+                "applicationName", job.getJobDescriptor().getApplicationName(),
                 "state", task.getStatus().getState().name(),
                 "kubeScheduler", "" + JobFunctions.isOwnedByKubeScheduler(task)
         ).increment();


### PR DESCRIPTION
This is helpful in determining what applicationName is responsible for big spikes (surges) in task launches.

While in theory applicationName has an unbound cardinality, and is a user-provided value that could cause issues with high cardinality metrics, in practice we already have other counter metrics in the system using it as a tag, and the cardinality in live production systems tends to be manageable.

As a compromise, I decided to leave task state counters (gauges) as-is (only tagged/aggregated to the `capacityGroup` level) since having to track per-application gauges would be more risky and prone to memory leaks.