### PR TITLE
Constraint names are case insensitive

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -213,8 +213,23 @@ public final class JobFunctions {
                 .build();
     }
 
+    public static <E extends JobDescriptorExt> JobDescriptor<E> appendSoftConstraint(JobDescriptor<E> jobDescriptor,
+                                                                                     String name,
+                                                                                     String value) {
+        return jobDescriptor.toBuilder()
+                .withContainer(jobDescriptor.getContainer().toBuilder()
+                        .withSoftConstraints(CollectionsExt.copyAndAdd(jobDescriptor.getContainer().getSoftConstraints(), name, value))
+                        .build()
+                )
+                .build();
+    }
+
     public static <E extends JobDescriptorExt> Job<E> appendHardConstraint(Job<E> job, String name, String value) {
         return job.toBuilder().withJobDescriptor(appendHardConstraint(job.getJobDescriptor(), name, value)).build();
+    }
+
+    public static <E extends JobDescriptorExt> Job<E> appendSoftConstraint(Job<E> job, String name, String value) {
+        return job.toBuilder().withJobDescriptor(appendSoftConstraint(job.getJobDescriptor(), name, value)).build();
     }
 
     public static <E extends JobDescriptorExt> Job<E> appendJobDescriptorAttribute(Job<E> job,
@@ -223,6 +238,32 @@ public final class JobFunctions {
         return job.toBuilder()
                 .withJobDescriptor(appendJobDescriptorAttribute(job.getJobDescriptor(), attributeName, attributeValue))
                 .build();
+    }
+
+    /**
+     * Constraint names are case insensitive.
+     */
+    public static <E extends JobDescriptorExt> Optional<String> findHardConstraint(Job<E> job, String name) {
+        return findConstraint(job.getJobDescriptor().getContainer().getHardConstraints(), name);
+    }
+
+    /**
+     * Constraint names are case insensitive.
+     */
+    public static <E extends JobDescriptorExt> Optional<String> findSoftConstraint(Job<E> job, String name) {
+        return findConstraint(job.getJobDescriptor().getContainer().getSoftConstraints(), name);
+    }
+
+    private static Optional<String> findConstraint(Map<String, String> constraints, String name) {
+        if (CollectionsExt.isNullOrEmpty(constraints)) {
+            return Optional.empty();
+        }
+        for (String key : constraints.keySet()) {
+            if (key.equalsIgnoreCase(name)) {
+                return Optional.ofNullable(constraints.get(key));
+            }
+        }
+        return Optional.empty();
     }
 
     public static Task appendTaskAttribute(Task task, String attributeName, Object attributeValue) {

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobFunctionsTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/JobFunctionsTest.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.api.jobmanager.model.job;
 
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.common.util.time.Clock;
 import com.netflix.titus.common.util.time.Clocks;
 import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
@@ -82,5 +83,19 @@ public class JobFunctionsTest {
                 )
                 .build();
         assertThat(JobFunctions.containsExactlyTaskStates(task, TaskState.Accepted, TaskState.Launched, TaskState.StartInitiated, TaskState.KillInitiated)).isTrue();
+    }
+
+    @Test
+    public void testFindHardConstraint() {
+        Job<BatchJobExt> job = JobFunctions.appendHardConstraint(JobGenerator.oneBatchJob(), "MyConstraint", "good");
+        assertThat(JobFunctions.findHardConstraint(job, "myConstraint")).contains("good");
+        assertThat(JobFunctions.findSoftConstraint(job, "myConstraint")).isEmpty();
+    }
+
+    @Test
+    public void testFindSoftConstraint() {
+        Job<BatchJobExt> job = JobFunctions.appendSoftConstraint(JobGenerator.oneBatchJob(), "MyConstraint", "good");
+        assertThat(JobFunctions.findHardConstraint(job, "myConstraint")).isEmpty();
+        assertThat(JobFunctions.findSoftConstraint(job, "myConstraint")).contains("good");
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
@@ -414,9 +414,10 @@ public class DefaultTaskToPodConverter implements TaskToPodConverter {
         ).collect(Collectors.toList());
     }
 
-    private List<V1TopologySpreadConstraint> buildTopologySpreadConstraints(Job<?> job) {
-        boolean hard = Boolean.parseBoolean(job.getJobDescriptor().getContainer().getHardConstraints().get(JobConstraints.ZONE_BALANCE));
-        boolean soft = Boolean.parseBoolean(job.getJobDescriptor().getContainer().getSoftConstraints().get(JobConstraints.ZONE_BALANCE));
+    @VisibleForTesting
+    List<V1TopologySpreadConstraint> buildTopologySpreadConstraints(Job<?> job) {
+        boolean hard = Boolean.parseBoolean(JobFunctions.findHardConstraint(job, JobConstraints.ZONE_BALANCE).orElse("false"));
+        boolean soft = Boolean.parseBoolean(JobFunctions.findSoftConstraint(job, JobConstraints.ZONE_BALANCE).orElse("false"));
         if (!hard && !soft) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
The only place we do not handle this properly is in `DefaultTaskToPodConverter` when processing `zonebalance` constraint.