### PR TITLE
Deleted the field timestamp

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/agent/model/AgentInstance.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/agent/model/AgentInstance.java
@@ -138,7 +138,6 @@ public class AgentInstance {
         private String hostname;
         private InstanceLifecycleStatus instanceLifecycleStatus;
         private Map<String, String> attributes;
-        private long timestamp;
 
         private Builder() {
         }


### PR DESCRIPTION
### Description of the Change
I have deleted the field "private long timestamp" from the Builder class as it was unused. I am very new to this, forgive me If i wasted someone's time.