### PR TITLE
node taints condition check

### DIFF
--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/RelocationConfiguration.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/RelocationConfiguration.java
@@ -51,8 +51,17 @@ public interface RelocationConfiguration {
     @DefaultValue("NONE")
     String getNodeRelocationRequiredImmediatelyTaints();
 
+    /**
+     * Pattern identifying bad node conditions
+     */
     @DefaultValue("UncorrectableMemoryFailure")
     String getBadNodeConditionPattern();
+
+    /**
+     * Pattern identifying bad node taints
+     */
+    @DefaultValue(".*unreachable")
+    String getBadTaintsPattern();
 
     @DefaultValue("false")
     boolean isTaskTerminationOnBadNodeConditionEnabled();
@@ -75,5 +84,12 @@ public interface RelocationConfiguration {
      */
     @DefaultValue("300")
     int getNodeConditionTransitionTimeThresholdSeconds();
+
+    /**
+     * It represents the last N seconds threshold for which the latest taint is sustained
+     * It helps us avoid picking up taint state that is sustained for a very short duration
+     */
+    @DefaultValue("300")
+    int getNodeTaintTransitionTimeThresholdSeconds();
 
 }

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/connector/AgentManagementNodeDataResolver.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/connector/AgentManagementNodeDataResolver.java
@@ -97,7 +97,7 @@ public class AgentManagementNodeDataResolver implements NodeDataResolver {
         );
 
         boolean serverGroupRelocationRequired = serverGroup.getLifecycleStatus().getState() == InstanceGroupLifecycleState.Removable;
-        boolean isNodeConditionBad = false;
+        boolean isNodeBad = false;
         V1Node k8sNode = k8sNodeIndexer.getByKey(instance.getId());
 
         if (k8sNode != null) {
@@ -107,7 +107,7 @@ public class AgentManagementNodeDataResolver implements NodeDataResolver {
             boolean hasBadTaint = NodePredicates.hasBadTaint(k8sNode, badTaintMatcherFactory,
                     relocationConfiguration.getNodeTaintTransitionTimeThresholdSeconds());
 
-            isNodeConditionBad = hasBadNodeCondition || hasBadTaint;
+            isNodeBad = hasBadNodeCondition || hasBadTaint;
         }
 
         return Node.newBuilder()
@@ -117,7 +117,7 @@ public class AgentManagementNodeDataResolver implements NodeDataResolver {
                 .withRelocationRequiredImmediately(relocationRequiredImmediately)
                 .withRelocationNotAllowed(relocationNotAllowed)
                 .withServerGroupRelocationRequired(serverGroupRelocationRequired)
-                .withBadCondition(isNodeConditionBad)
+                .withBadCondition(isNodeBad)
                 .build();
     }
 }

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/connector/NodePredicates.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/connector/NodePredicates.java
@@ -67,11 +67,11 @@ public class NodePredicates {
 
     @VisibleForTesting
     static boolean hasBadTaint(V1Node node, Function<String, Matcher> badTaintExpression,
-                                   int nodeTaintTransitionTimeThresholdSeconds) {
+                               int nodeTaintTransitionTimeThresholdSeconds) {
         if (node.getSpec() != null && node.getSpec().getTaints() != null) {
             return node.getSpec().getTaints().stream()
                     .anyMatch(v1Taint -> badTaintExpression.apply(v1Taint.getKey()).matches() &&
-                            matchesTaintValueIfAvailable(v1Taint, Boolean.toString(true)) &&
+                            matchesTaintValueIfAvailable(v1Taint, Boolean.TRUE.toString()) &&
                             !isTransitionedRecently(v1Taint.getTimeAdded(), nodeTaintTransitionTimeThresholdSeconds));
         }
         return false;


### PR DESCRIPTION
### Node taints check

As part of the relocation service, we have a way to enable task terminations based on a configurable set of node conditions. This change is adding a configurable set of node taints that could be enabled to effect immediate task terminations. It's adding the following options to configure this behavior

1.  badTaintsPattern - a regular expression identifying undesirable node taints as reported by kubernetes
2. nodeTaintTransitionTimeThresholdSeconds - it denotes (in seconds) the least amount of time the node should sustain a taint before being eligible for task terminations