### PR TITLE
fixing response from set target request for auto scaling callbacks

### DIFF
--- a/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AppAutoScalingCallbackSpringResource.java
+++ b/titus-ext/aws/src/main/java/com/netflix/titus/ext/aws/appscale/AppAutoScalingCallbackSpringResource.java
@@ -56,6 +56,7 @@ public class AppAutoScalingCallbackSpringResource {
         if (scalableTargetResourceInfo.getDesiredCapacity() < 0) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
-        return Responses.fromSingleValueObservable(awsGatewayCallbackService.setScalableTargetResourceInfo(jobId, scalableTargetResourceInfo, authentication.getCallMetadata()));
+        ScalableTargetResourceInfo updatedScalableTargetResourceInfo = Responses.fromSingleValueObservable(awsGatewayCallbackService.setScalableTargetResourceInfo(jobId, scalableTargetResourceInfo, authentication.getCallMetadata()));
+        return ResponseEntity.status(HttpStatus.OK.value()).body(updatedScalableTargetResourceInfo);
     }
 }

--- a/titus-ext/aws/src/test/java/com/netflix/titus/ext/aws/appscale/AppAutoScalingCallbackSpringResourceTest.java
+++ b/titus-ext/aws/src/test/java/com/netflix/titus/ext/aws/appscale/AppAutoScalingCallbackSpringResourceTest.java
@@ -1,0 +1,42 @@
+package com.netflix.titus.ext.aws.appscale;
+
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
+import com.netflix.titus.runtime.endpoint.metadata.spring.CallMetadataAuthentication;
+import org.junit.Test;
+import org.springframework.http.ResponseEntity;
+import rx.Observable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class AppAutoScalingCallbackSpringResourceTest {
+
+    @Test
+    public void testResponseEntity() {
+        AppAutoScalingCallbackService appAutoScalingCallbackService = mock(AppAutoScalingCallbackService.class);
+        String jobId = "job-1";
+        ScalableTargetResourceInfo scalableTargetResourceInfo = ScalableTargetResourceInfo.newBuilder().actualCapacity(4).desiredCapacity(6).scalingStatus(
+                DefaultAppAutoScalingCallbackService.ScalingStatus.Pending.name()).build();
+        CallMetadata callMetadata = CallMetadata.newBuilder().withCallerId("unit-testing").build();
+        CallMetadataAuthentication callMetadataAuthentication = mock(CallMetadataAuthentication.class);
+        when(callMetadataAuthentication.getCallMetadata()).thenReturn(callMetadata);
+
+        when(appAutoScalingCallbackService.setScalableTargetResourceInfo(jobId, scalableTargetResourceInfo, callMetadata))
+                .thenReturn(Observable.just(scalableTargetResourceInfo));
+        AppAutoScalingCallbackSpringResource springResource = new AppAutoScalingCallbackSpringResource(appAutoScalingCallbackService);
+        ResponseEntity<ScalableTargetResourceInfo> resp = springResource.setScalableTargetResourceInfo(jobId,
+                scalableTargetResourceInfo, callMetadataAuthentication);
+        assertThat(resp).isNotNull();
+        assertThat(resp.getStatusCodeValue()).isEqualTo(200);
+        assertThat(resp.getBody()).isEqualTo(scalableTargetResourceInfo);
+
+        scalableTargetResourceInfo.setDesiredCapacity(-1);
+        ResponseEntity<ScalableTargetResourceInfo> resp2 = springResource.setScalableTargetResourceInfo(jobId,
+                scalableTargetResourceInfo, callMetadataAuthentication);
+        assertThat(resp2).isNotNull();
+        assertThat(resp2.getStatusCodeValue()).isEqualTo(400);
+    }
+
+}


### PR DESCRIPTION
### Bug fix in auto scaling callback response

For a spring boot resource receiving set-target callback from auto scaling engine, response wasn't getting built properly. The bug fix here addressed it. 