### PR TITLE
Improve messaging and timestamps when containers are terminated due to unresponsive nodes

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -104,6 +104,7 @@ import static com.netflix.titus.runtime.kubernetes.KubeConstants.NOT_FOUND;
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.PENDING;
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.RUNNING;
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.SUCCEEDED;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.NODE_LOST;
 
 /**
  * Responsible for integrating Kubernetes API Server concepts into Titus's Mesos based approaches.
@@ -681,10 +682,10 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
             if (!killInitiatedOpt.isPresent()) {
                 reasonCode = REASON_TASK_KILLED;
                 logger.debug("Publishing missing task status: KillInitiated for task: {}", podName);
-                if ("NodeLost".equals(status.getReason())) {
+                if (NODE_LOST.equals(status.getReason())) {
                     publishContainerEvent(podName, KillInitiated, reasonCode, "The host running the container was unexpectedly terminated", executorDetails, eventTimestamp);
                 } else {
-                    publishContainerEvent(podName, KillInitiated, reasonCode, "Container was terminated without going through Titus", executorDetails, eventTimestamp);
+                    publishContainerEvent(podName, KillInitiated, reasonCode, "Container was terminated without going through the Titus API", executorDetails, eventTimestamp);
                 }
             } else if (phase.equalsIgnoreCase(SUCCEEDED)) {
                 reasonCode = REASON_NORMAL;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -170,5 +170,5 @@ public final class KubeConstants {
     /**
      * Reconciler Event Constants
      */
-    public static final String NODE_LOST = "NodeList";
+    public static final String NODE_LOST = "NodeLost";
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -167,4 +167,8 @@ public final class KubeConstants {
     public static final String FAILED = "Failed";
     public static final String BACKGROUND = "Background";
 
+    /**
+     * Reconciler Event Constants
+     */
+    public static final String NODE_LOST = "NodeList";
 }


### PR DESCRIPTION
### Description of the Change

- Set appropriate message when pods are known to have been removed as a result of unresponsive node by Node Lifecycle Manager
- Instead of deletionTimestamp from the pod delete events, we use wallTime for KillInitiated and Finished events