### PR TITLE
Disable compression in Kube ApiClient for faster LIST operations

### DIFF
--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/DisableCompressionInterceptor.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/DisableCompressionInterceptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.kubernetes;
+
+import java.io.IOException;
+import javax.ws.rs.core.HttpHeaders;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Disables compression by adding the Http header.
+ */
+public class DisableCompressionInterceptor implements Interceptor {
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+
+        Request newRequest = chain.request()
+                .newBuilder()
+                .addHeader(HttpHeaders.ACCEPT_ENCODING, "identity")
+                .build();
+
+        return chain.proceed(newRequest);
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosConfiguration.java
@@ -124,6 +124,12 @@ public interface MesosConfiguration {
     String getKubeConfigPath();
 
     /**
+     * @return whether to enable or disable compression when LISTing pods using kubernetes java client
+     */
+    @DefaultValue("false")
+    boolean isCompressionEnabledForKubeApiClient();
+
+    /**
      * @return whether or not to GC unknown pods
      */
     @DefaultValue("true")

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeModule.java
@@ -124,7 +124,8 @@ public class KubeModule extends AbstractModule {
                 configuration.getKubeConfigPath(),
                 KubeApiServerIntegrator.CLIENT_METRICS_PREFIX,
                 titusRuntime,
-                0L
+                0L,
+                configuration.isCompressionEnabledForKubeApiClient()
         );
     }
 


### PR DESCRIPTION
### Description of the Change

Disabling compression while LISTing a large number of resources for a given resource type is much faster compared to its counterpart.