### PR TITLE
Initial support for EBS volume model and validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.1-rc73'
+        titusApiDefinitionsVersion = '0.0.1-rc75'
 
         springVersion = '5.2.8.RELEASE'
         springSecurityVersion = '5.3.4.RELEASE'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -55,6 +55,11 @@ public final class JobAttributes {
     public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IMAGE = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.image";
 
     /**
+     * Set to true when sanitization for container EBS volumes fails open
+     */
+    public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_EBS = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.ebs";
+
+    /**
      * Set to true when job runtime prediction fails open
      */
     public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_RUNTIME_PREDICTION = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.runtimePrediction";
@@ -207,6 +212,20 @@ public final class JobAttributes {
      */
     public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_SERVICEMESH_IMAGE = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.serviceMesh";
 
+    /*
+     * EBS volume job attributes (set in {@link JobDescriptor#getAttributes()}.
+     * EBS volume IDs are attributes as we do not expect to expose them directly as first-class Titus API
+     * constructs but rather wait until the Kubernetes API to expose them directly.
+     * We expect the value to be a comma separated list of valid/existing EBS volume IDs.
+     */
+
+    public static final String JOB_ATTRIBUTES_EBS_VOLUME_IDS = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "ebs.volumeIds";
+
+    public static final String JOB_ATTRIBUTES_EBS_MOUNT_POINT = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "ebs.mountPoint";
+
+    public static final String JOB_ATTRIBUTES_EBS_MOUNT_PERM = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "ebs.mountPerm";
+
+    public static final String JOB_ATTRIBUTES_EBS_FS_TYPE = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "ebs.fsType";
 
     private JobAttributes() {
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -63,6 +63,7 @@ public final class TaskAttributes {
     public static final String TASK_ATTRIBUTES_TIER = "task.tier";
     public static final String TASK_ATTRIBUTES_IP_ALLOCATION_ID = "task.ipAllocationId";
     public static final String TASK_ATTRIBUTES_IN_USE_IP_ALLOCATION = "task.ipAllocationAlreadyInUseByTask";
+    public static final String TASK_ATTRIBUTES_EBS_VOLUME_ID = "task.ebs.volumeId";
 
     /*
      * Log location attributes.

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
@@ -26,6 +26,7 @@ import com.netflix.titus.api.jobmanager.model.job.sanitizer.EfsMountsSanitizer;
 import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
 import com.netflix.titus.api.model.EfsMount;
 import com.netflix.titus.common.model.sanitizer.ClassInvariant;
+import com.netflix.titus.common.model.sanitizer.CollectionInvariants;
 import com.netflix.titus.common.model.sanitizer.FieldInvariant;
 import com.netflix.titus.common.model.sanitizer.FieldSanitizer;
 import com.netflix.titus.common.util.CollectionsExt;
@@ -71,6 +72,7 @@ public class ContainerResources {
     private final List<SignedIpAddressAllocation> ipSignedAddressAllocations;
 
     @Valid
+    @CollectionInvariants(allowDuplicateValues = false)
     private final List<EbsVolume> ebsVolumes;
 
     public ContainerResources(double cpu,
@@ -92,7 +94,7 @@ public class ContainerResources {
         this.allocateIP = allocateIP;
         this.shmMB = shmMB;
         this.ipSignedAddressAllocations = CollectionsExt.nonNullImmutableCopyOf(ipSignedAddressAllocations);
-        this.ebsVolumes = ebsVolumes;
+        this.ebsVolumes = CollectionsExt.nonNullImmutableCopyOf(ebsVolumes);
     }
     public double getCpu() {
         return cpu;

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.api.jobmanager.model.job.sanitizer.EfsMountsSanitizer;
 import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
 import com.netflix.titus.api.model.EfsMount;
@@ -69,6 +70,9 @@ public class ContainerResources {
     @Valid
     private final List<SignedIpAddressAllocation> ipSignedAddressAllocations;
 
+    @Valid
+    private final List<EbsVolume> ebsVolumes;
+
     public ContainerResources(double cpu,
                               int gpu,
                               int memoryMB,
@@ -77,7 +81,8 @@ public class ContainerResources {
                               List<EfsMount> efsMounts,
                               boolean allocateIP,
                               int shmMB,
-                              List<SignedIpAddressAllocation> ipSignedAddressAllocations) {
+                              List<SignedIpAddressAllocation> ipSignedAddressAllocations,
+                              List<EbsVolume> ebsVolumes) {
         this.cpu = cpu;
         this.gpu = gpu;
         this.memoryMB = memoryMB;
@@ -87,6 +92,7 @@ public class ContainerResources {
         this.allocateIP = allocateIP;
         this.shmMB = shmMB;
         this.ipSignedAddressAllocations = CollectionsExt.nonNullImmutableCopyOf(ipSignedAddressAllocations);
+        this.ebsVolumes = ebsVolumes;
     }
     public double getCpu() {
         return cpu;
@@ -124,6 +130,10 @@ public class ContainerResources {
         return ipSignedAddressAllocations;
     }
 
+    public List<EbsVolume> getEbsVolumes() {
+        return ebsVolumes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -141,12 +151,13 @@ public class ContainerResources {
                 allocateIP == that.allocateIP &&
                 shmMB == that.shmMB &&
                 efsMounts.equals(that.efsMounts) &&
-                ipSignedAddressAllocations.equals(that.ipSignedAddressAllocations);
+                ipSignedAddressAllocations.equals(that.ipSignedAddressAllocations) &&
+                ebsVolumes.equals(that.ebsVolumes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(cpu, gpu, memoryMB, diskMB, networkMbps, efsMounts, allocateIP, shmMB, ipSignedAddressAllocations);
+        return Objects.hash(cpu, gpu, memoryMB, diskMB, networkMbps, efsMounts, allocateIP, shmMB, ipSignedAddressAllocations, ebsVolumes);
     }
 
     @Override
@@ -161,6 +172,7 @@ public class ContainerResources {
                 ", allocateIP=" + allocateIP +
                 ", shmMB=" + shmMB +
                 ", ipSignedAddressAllocations=" + ipSignedAddressAllocations +
+                ", ebsVolumes=" + ebsVolumes +
                 '}';
     }
 
@@ -182,7 +194,8 @@ public class ContainerResources {
                 .withAllocateIP(containerResources.isAllocateIP())
                 .withEfsMounts(containerResources.getEfsMounts())
                 .withShmMB(containerResources.getShmMB())
-                .withSignedIpAddressAllocations(containerResources.getSignedIpAddressAllocations());
+                .withSignedIpAddressAllocations(containerResources.getSignedIpAddressAllocations())
+                .withEbsVolumes(containerResources.getEbsVolumes());
     }
 
     public static final class Builder {
@@ -195,6 +208,7 @@ public class ContainerResources {
         private boolean allocateIP;
         private int shmMB;
         private List<SignedIpAddressAllocation> signedIpAddressAllocations;
+        private List<EbsVolume> ebsVolumes;
 
         private Builder() {
         }
@@ -244,6 +258,11 @@ public class ContainerResources {
             return this;
         }
 
+        public Builder withEbsVolumes(List<EbsVolume> ebsVolumes) {
+            this.ebsVolumes = ebsVolumes;
+            return this;
+        }
+
         public Builder but() {
             return newBuilder()
                     .withCpu(cpu)
@@ -253,7 +272,8 @@ public class ContainerResources {
                     .withNetworkMbps(networkMbps)
                     .withEfsMounts(efsMounts)
                     .withShmMB(shmMB)
-                    .withSignedIpAddressAllocations(signedIpAddressAllocations);
+                    .withSignedIpAddressAllocations(signedIpAddressAllocations)
+                    .withEbsVolumes(ebsVolumes);
         }
 
         public ContainerResources build() {
@@ -266,7 +286,8 @@ public class ContainerResources {
                     nonNull(efsMounts),
                     allocateIP,
                     shmMB,
-                    nonNull(signedIpAddressAllocations));
+                    nonNull(signedIpAddressAllocations),
+                    nonNull(ebsVolumes));
             return containerResources;
         }
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolume.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolume.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job.ebs;
+
+import java.util.Objects;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.google.common.base.Preconditions;
+
+public class EbsVolume {
+
+    public EbsVolume(String volumeId, String volumeAvailabilityZone, int volumeCapacityGB, String mountPath, MountPerm mountPerm, String fsType) {
+        this.volumeId = volumeId;
+        this.volumeAvailabilityZone = volumeAvailabilityZone;
+        this.volumeCapacityGB = volumeCapacityGB;
+        this.mountPath = mountPath;
+        this.mountPermissions = mountPerm;
+        this.fsType = fsType;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    public enum MountPerm {RO, RW}
+
+    @NotNull
+    @Size(min = 1, max = 512, message = "EBS volume ID cannot be empty or greater than 512 bytes")
+    private final String volumeId;
+
+    @Size(min = 1, max = 512, message = "EBS volume AZ cannot be empty or greater than 512 bytes")
+    private final String volumeAvailabilityZone;
+
+    private final int volumeCapacityGB;
+
+    @NotNull
+    @Size(min = 1, max = 1024, message = "EBS volume mount path cannot be empty or greater than 1024 bytes")
+    private final String mountPath;
+
+    @NotNull(message = "'mountPermissions' is null")
+    private final MountPerm mountPermissions;
+
+    @NotNull
+    @Size(min = 1, max = 512, message = "EBS volume FS type cannot be empty or greater than 512 bytes")
+    private final String fsType;
+
+    public String getVolumeId() {
+        return volumeId;
+    }
+
+    public String getVolumeAvailabilityZone() {
+        return volumeAvailabilityZone;
+    }
+
+    public int getVolumeCapacityGB() {
+        return volumeCapacityGB;
+    }
+
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    public MountPerm getMountPermissions() {
+        return mountPermissions;
+    }
+
+    public String getFsType() {
+        return fsType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EbsVolume ebsVolume = (EbsVolume) o;
+        return volumeCapacityGB == ebsVolume.volumeCapacityGB &&
+                volumeId.equals(ebsVolume.volumeId) &&
+                Objects.equals(volumeAvailabilityZone, ebsVolume.volumeAvailabilityZone) &&
+                mountPath.equals(ebsVolume.mountPath) &&
+                mountPermissions == ebsVolume.mountPermissions &&
+                fsType.equals(ebsVolume.fsType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(volumeId, volumeAvailabilityZone, volumeCapacityGB, mountPath, mountPermissions, fsType);
+    }
+
+    @Override
+    public String toString() {
+        return "EbsVolume{" +
+                "volumeId='" + volumeId + '\'' +
+                ", volumeAvailabilityZone='" + volumeAvailabilityZone + '\'' +
+                ", volumeCapacityGB=" + volumeCapacityGB +
+                ", mountPath='" + mountPath + '\'' +
+                ", mountPermissions=" + mountPermissions +
+                ", fsType='" + fsType + '\'' +
+                '}';
+    }
+
+    public static final class Builder {
+        private String volumeId;
+        private String volumeAvailabilityZone;
+        private int volumeCapacityGB;
+        private String mountPath;
+        private MountPerm mountPermissions;
+        private String fsType;
+
+        private Builder() {
+        }
+
+        private Builder(EbsVolume ebsVolume) {
+            this.volumeId = ebsVolume.getVolumeId();
+            this.volumeAvailabilityZone = ebsVolume.getVolumeAvailabilityZone();
+            this.volumeCapacityGB = ebsVolume.getVolumeCapacityGB();
+            this.mountPath = ebsVolume.getMountPath();
+            this.mountPermissions = ebsVolume.getMountPermissions();
+            this.fsType = ebsVolume.getFsType();
+        }
+
+        public Builder withVolumeId(String val) {
+            volumeId = val;
+            return this;
+        }
+
+        public Builder withVolumeAvailabilityZone(String val) {
+            volumeAvailabilityZone = val;
+            return this;
+        }
+
+        public Builder withVolumeCapacityGB(int val) {
+            volumeCapacityGB = val;
+            return this;
+        }
+
+        public Builder withMountPath(String val) {
+            mountPath = val;
+            return this;
+        }
+
+        public Builder withMountPermissions(MountPerm val) {
+            mountPermissions = val;
+            return this;
+        }
+
+        public Builder withFsType(String val) {
+            fsType = val;
+            return this;
+        }
+
+        public EbsVolume build() {
+            Preconditions.checkNotNull(volumeId, "Volume ID is null");
+            Preconditions.checkNotNull(mountPath, "Mount path is null");
+            Preconditions.checkNotNull(mountPermissions, "Mount permission is null");
+            Preconditions.checkNotNull(fsType, "File system type is null");
+            // Volume AZ and capacity may be set after object creation during object sanitization
+            return new EbsVolume(volumeId, volumeAvailabilityZone, volumeCapacityGB, mountPath, mountPermissions, fsType);
+        }
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolume.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolume.java
@@ -17,13 +17,14 @@
 package com.netflix.titus.api.jobmanager.model.job.ebs;
 
 import java.util.Objects;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import com.google.common.base.Preconditions;
 
 public class EbsVolume {
+
+    public enum MountPerm {RO, RW}
 
     public EbsVolume(String volumeId, String volumeAvailabilityZone, int volumeCapacityGB, String mountPath, MountPerm mountPerm, String fsType) {
         this.volumeId = volumeId;
@@ -41,8 +42,6 @@ public class EbsVolume {
     public Builder toBuilder() {
         return new Builder(this);
     }
-
-    public enum MountPerm {RO, RW}
 
     @NotNull
     @Size(min = 1, max = 512, message = "EBS volume ID cannot be empty or greater than 512 bytes")
@@ -177,6 +176,7 @@ public class EbsVolume {
             Preconditions.checkNotNull(mountPath, "Mount path is null");
             Preconditions.checkNotNull(mountPermissions, "Mount permission is null");
             Preconditions.checkNotNull(fsType, "File system type is null");
+
             // Volume AZ and capacity may be set after object creation during object sanitization
             return new EbsVolume(volumeId, volumeAvailabilityZone, volumeCapacityGB, mountPath, mountPermissions, fsType);
         }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolumeUtils.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolumeUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job.ebs;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.common.util.StringExt;
+
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_EBS_VOLUME_ID;
+
+/**
+ * Helper utilities for processing EBS volume related info.
+ */
+public class EbsVolumeUtils {
+
+    public static <E extends JobDescriptor.JobDescriptorExt> List<EbsVolume> getEbsVolumes(JobDescriptor<E> jobDescriptor) {
+        List<String> volumeIds = getVolumeIds(jobDescriptor);
+        Optional<String> mountPointOptional = getMountPoint(jobDescriptor);
+        Optional<EbsVolume.MountPerm> mountPermOptional = getEbsMountPerm(jobDescriptor);
+        Optional<String> fsTypeOptional = getEbsFsType(jobDescriptor);
+
+        if (!(mountPointOptional.isPresent() && mountPermOptional.isPresent() && fsTypeOptional.isPresent())) {
+            return Collections.emptyList();
+        }
+
+        String mountPoint = mountPointOptional.get();
+        EbsVolume.MountPerm mountPerm = mountPermOptional.get();
+        String fsType = fsTypeOptional.get();
+
+        return volumeIds.stream()
+                .map(volumeId -> EbsVolume.newBuilder()
+                        .withVolumeId(volumeId)
+                        .withMountPath(mountPoint)
+                        .withMountPermissions(mountPerm)
+                        .withFsType(fsType)
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public static <E extends JobDescriptor.JobDescriptorExt> List<String> getVolumeIds(JobDescriptor<E> jobDescriptor) {
+        String volumeIdsStr = StringExt.nonNull(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_EBS_VOLUME_IDS));
+        return Arrays.asList(volumeIdsStr.split(","));
+    }
+
+    public static <E extends JobDescriptor.JobDescriptorExt> Optional<String> getMountPoint(JobDescriptor<E> jobDescriptor) {
+        return Optional.ofNullable(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_EBS_MOUNT_POINT));
+    }
+
+    public static <E extends JobDescriptor.JobDescriptorExt> Optional<EbsVolume.MountPerm> getEbsMountPerm(JobDescriptor<E> jobDescriptor) throws IllegalArgumentException {
+        String mountPermStr = StringExt.nonNull(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_EBS_MOUNT_PERM)).toUpperCase();
+        return mountPermStr.isEmpty() ? Optional.empty() : Optional.of(EbsVolume.MountPerm.valueOf(mountPermStr));
+    }
+
+    public static <E extends JobDescriptor.JobDescriptorExt> Optional<String> getEbsFsType(JobDescriptor<E> jobDescriptor) {
+        return Optional.ofNullable(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_EBS_FS_TYPE));
+    }
+
+    public static Optional<EbsVolume> getEbsVolumeForTask(Job<?> job, Task task) {
+        String ebsVolumeId = task.getTaskContext().get(TASK_ATTRIBUTES_EBS_VOLUME_ID);
+        if (null == ebsVolumeId) {
+            return Optional.empty();
+        }
+
+        return job.getJobDescriptor().getContainer().getContainerResources().getEbsVolumes()
+                .stream()
+                .filter(ebsVolume -> ebsVolume.getVolumeId().equals(ebsVolumeId))
+                .findFirst();
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolumeUtils.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolumeUtils.java
@@ -35,8 +35,8 @@ import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_EB
 public class EbsVolumeUtils {
 
     public static <E extends JobDescriptor.JobDescriptorExt> List<EbsVolume> getEbsVolumes(JobDescriptor<E> jobDescriptor) {
-        List<String> volumeIds = getVolumeIds(jobDescriptor);
-        Optional<String> mountPointOptional = getMountPoint(jobDescriptor);
+        List<String> volumeIds = getEbsVolumeIds(jobDescriptor);
+        Optional<String> mountPointOptional = getEbsMountPoint(jobDescriptor);
         Optional<EbsVolume.MountPerm> mountPermOptional = getEbsMountPerm(jobDescriptor);
         Optional<String> fsTypeOptional = getEbsFsType(jobDescriptor);
 
@@ -58,12 +58,12 @@ public class EbsVolumeUtils {
                 .collect(Collectors.toList());
     }
 
-    public static <E extends JobDescriptor.JobDescriptorExt> List<String> getVolumeIds(JobDescriptor<E> jobDescriptor) {
+    public static <E extends JobDescriptor.JobDescriptorExt> List<String> getEbsVolumeIds(JobDescriptor<E> jobDescriptor) {
         String volumeIdsStr = StringExt.nonNull(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_EBS_VOLUME_IDS));
         return StringExt.splitByComma(volumeIdsStr);
     }
 
-    public static <E extends JobDescriptor.JobDescriptorExt> Optional<String> getMountPoint(JobDescriptor<E> jobDescriptor) {
+    public static <E extends JobDescriptor.JobDescriptorExt> Optional<String> getEbsMountPoint(JobDescriptor<E> jobDescriptor) {
         return Optional.ofNullable(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_EBS_MOUNT_POINT));
     }
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolumeUtils.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ebs/EbsVolumeUtils.java
@@ -16,7 +16,6 @@
 
 package com.netflix.titus.api.jobmanager.model.job.ebs;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -61,7 +60,7 @@ public class EbsVolumeUtils {
 
     public static <E extends JobDescriptor.JobDescriptorExt> List<String> getVolumeIds(JobDescriptor<E> jobDescriptor) {
         String volumeIdsStr = StringExt.nonNull(jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_EBS_VOLUME_IDS));
-        return Arrays.asList(volumeIdsStr.split(","));
+        return StringExt.splitByComma(volumeIdsStr);
     }
 
     public static <E extends JobDescriptor.JobDescriptorExt> Optional<String> getMountPoint(JobDescriptor<E> jobDescriptor) {

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/JobManagerException.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/JobManagerException.java
@@ -25,6 +25,7 @@ import com.netflix.titus.api.jobmanager.model.job.JobState;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.Tier;
@@ -175,6 +176,13 @@ public class JobManagerException extends RuntimeException {
         return new JobManagerException(
                 ErrorCode.InvalidContainerResources,
                 format("Job too large to run in the %s tier: requested=%s, limits=%s", tier, requestedResources, tierResourceLimits)
+        );
+    }
+
+    public static JobManagerException invalidContainerResources(EbsVolume ebsVolume, String message) {
+        return new JobManagerException(
+                ErrorCode.InvalidContainerResources,
+                format("Job has invalid EBS volume: volume id=%s, reason=%s", ebsVolume.getVolumeId(), message)
         );
     }
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/ContainerResourcesMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/ContainerResourcesMixin.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
 import com.netflix.titus.api.model.EfsMount;
 
@@ -35,6 +36,7 @@ public abstract class ContainerResourcesMixin {
                                    @JsonProperty("efsMounts") List<EfsMount> efsMounts,
                                    @JsonProperty("allocateIP") boolean allocateIP,
                                    @JsonProperty("shmMB") int shmMB,
-                                   @JsonProperty("signedIpAddressAllocations") List<SignedIpAddressAllocation> signedIpAddressAllocations) {
+                                   @JsonProperty("signedIpAddressAllocations") List<SignedIpAddressAllocation> signedIpAddressAllocations,
+                                   @JsonProperty("ebsVolumes") List<EbsVolume> ebsVolumes) {
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/EbsVolumeMixIn.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/EbsVolumeMixIn.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.store.mixin;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class EbsVolumeMixIn {
+
+    @JsonCreator
+    public EbsVolumeMixIn(@JsonProperty("volumeId") String volumeId,
+                          @JsonProperty("volumeAvailabilityZone") String volumeAvailabilityZone,
+                          @JsonProperty("volumeCapacityGB") int volumeCapacityGB,
+                          @JsonProperty("mountPath") String mountPath,
+                          @JsonProperty("mountPermissions")EbsVolume.MountPerm mountPermissions,
+                          @JsonProperty("fsType") String fsType) {
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
@@ -77,6 +77,7 @@ import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.SelfManagedDi
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.TimeWindow;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.UnhealthyTasksLimitDisruptionBudgetPolicy;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.UnlimitedDisruptionBudgetRate;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.model.job.migration.MigrationDetails;
@@ -101,6 +102,7 @@ import com.netflix.titus.api.jobmanager.store.mixin.DelayedRetryPolicyMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.DisruptionBudgetMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.DisruptionBudgetPolicyMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.DisruptionBudgetRateMixIn;
+import com.netflix.titus.api.jobmanager.store.mixin.EbsVolumeMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.ExponentialBackoffRetryPolicyMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.HourlyTimeWindowMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.ImageMixin;
@@ -271,6 +273,7 @@ public class ObjectMappers {
         objectMapper.addMixIn(IpAddressLocation.class, IpAddressLocationMixin.class);
         objectMapper.addMixIn(IpAddressAllocation.class, IpAddressAllocationMixin.class);
         objectMapper.addMixIn(SignedIpAddressAllocation.class, SignedIpAddressAllocationMixin.class);
+        objectMapper.addMixIn(EbsVolume.class, EbsVolumeMixIn.class);
 
         objectMapper.addMixIn(DisruptionBudget.class, DisruptionBudgetMixIn.class);
 

--- a/titus-common/src/main/java/com/netflix/titus/common/model/admission/AdmissionValidatorConfiguration.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/admission/AdmissionValidatorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.endpoint.admission;
+package com.netflix.titus.common.model.admission;
 
-import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.titus.common.model.sanitizer.ValidationError;
 
-@Configuration(prefix = "titus.validate.job")
-public interface TitusValidatorConfiguration extends AdmissionValidatorConfiguration {
-    @DefaultValue("5000")
-    int getTimeoutMs();
+public interface AdmissionValidatorConfiguration {
+    @DefaultValue("SOFT")
+    String getErrorType();
+
+    default ValidationError.Type toValidatorErrorType() {
+        return ValidationError.Type.valueOf(getErrorType().trim().toUpperCase());
+    }
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/model/admission/TitusValidatorConfiguration.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/admission/TitusValidatorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.endpoint.admission;
+package com.netflix.titus.common.model.admission;
 
+import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
-import com.netflix.titus.common.model.sanitizer.ValidationError;
 
-public interface AdmissionValidatorConfiguration {
-    @DefaultValue("SOFT")
-    String getErrorType();
-
-    default ValidationError.Type toValidatorErrorType() {
-        return ValidationError.Type.valueOf(getErrorType().trim().toUpperCase());
-    }
+@Configuration(prefix = "titus.validate.job")
+public interface TitusValidatorConfiguration extends AdmissionValidatorConfiguration {
+    @DefaultValue("5000")
+    int getTimeoutMs();
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/CollectionInvariants.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/CollectionInvariants.java
@@ -46,6 +46,8 @@ public @interface CollectionInvariants {
 
     boolean allowNullValues() default false;
 
+    boolean allowDuplicateValues() default true;
+
     String message() default "{CollectionInvariants.message}";
 
     Class<?>[] groups() default {};

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/CollectionValidator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/CollectionValidator.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import javax.validation.ConstraintValidatorContext;
 
 import com.netflix.titus.common.model.sanitizer.CollectionInvariants;
@@ -60,6 +59,13 @@ public class CollectionValidator extends AbstractConstraintValidator<CollectionI
         if (!constraintAnnotation.allowNullValues()) {
             if (value.stream().anyMatch(Objects::isNull)) {
                 attachMessage(constraintViolationBuilderFunction, "null values not allowed");
+                return false;
+            }
+        }
+
+        if (!constraintAnnotation.allowDuplicateValues()) {
+            if (value.stream().distinct().count() != value.size()) {
+                attachMessage(constraintViolationBuilderFunction, "duplicate values not allowed");
                 return false;
             }
         }

--- a/titus-common/src/test/java/com/netflix/titus/common/model/sanitizer/internal/CollectionValidatorTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/model/sanitizer/internal/CollectionValidatorTest.java
@@ -55,6 +55,13 @@ public class CollectionValidatorTest {
     }
 
     @Test
+    public void testCollectionWithDuplicateValues() {
+        Set<ConstraintViolation<ListWrapperWithUniqueValues>> violations = validator.validate(new ListWrapperWithUniqueValues(asList("A", "A", "C")));
+        assertThat(violations).hasSize(1);
+        assertThat(first(violations).getMessage()).isEqualTo("duplicate values not allowed");
+    }
+
+    @Test
     public void testValidMap() {
         assertThat(validator.validate(new MapWrapper(ImmutableMap.of(
                 "k1", "v1",
@@ -125,5 +132,14 @@ public class CollectionValidatorTest {
             this.values = values;
         }
 
+    }
+
+    static class ListWrapperWithUniqueValues {
+        @CollectionInvariants(allowDuplicateValues = false)
+        List<String> values;
+
+        ListWrapperWithUniqueValues(List<String> values) {
+            this.values = values;
+        }
     }
 }

--- a/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizer.java
+++ b/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizer.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.jobvalidator.ebs;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import javax.inject.Inject;
+
+import com.netflix.compute.validator.protogen.ComputeValidator;
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
+import com.netflix.titus.api.jobmanager.service.JobManagerException;
+import com.netflix.titus.common.model.admission.AdmissionSanitizer;
+import com.netflix.titus.common.model.admission.ValidatorMetrics;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.ext.jobvalidator.s3.ReactorValidationServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * This {@link com.netflix.titus.common.model.admission.AdmissionSanitizer} sanitizes Job EBS volume
+ * information. Sanitization adds required EBS volume metadata (e.g., AZ, capacity, etc...) that are
+ * retrieved from the validation service.
+ */
+public class JobEbsVolumeSanitizer implements AdmissionSanitizer<JobDescriptor> {
+
+    private static final Logger logger = LoggerFactory.getLogger(JobEbsVolumeSanitizer.class);
+
+    private static final long RETRY_COUNT = 5;
+
+    private final JobEbsVolumeSanitizerConfiguration configuration;
+    private final ReactorValidationServiceClient validationClient;
+    private final ValidatorMetrics metrics;
+
+    @Inject
+    public JobEbsVolumeSanitizer(JobEbsVolumeSanitizerConfiguration configuration,
+                                 ReactorValidationServiceClient validationClient,
+                                 TitusRuntime titusRuntime) {
+        this.configuration = configuration;
+        this.validationClient = validationClient;
+        this.metrics = new ValidatorMetrics(JobEbsVolumeSanitizer.class.getSimpleName(), titusRuntime.getRegistry());
+    }
+
+    /**
+     * @return a {@link UnaryOperator} that adds sanitized EBS volume List.
+     */
+    @Override
+    public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor jobDescriptor) {
+        if (!configuration.isEnabled()) {
+            metrics.incrementValidationSkipped(ValidatorMetrics.REASON_DISABLED);
+            return Mono.just(JobEbsVolumeSanitizer::skipSanitization);
+        }
+
+        List<EbsVolume> ebsVolumes = jobDescriptor.getContainer().getContainerResources().getEbsVolumes();
+        return Flux.fromIterable(ebsVolumes)
+                // Execute validation service calls concurrently
+                .parallel()
+                .runOn(Schedulers.parallel())
+                // Validate the volume and update the core EBS volume object
+                .flatMap(ebsVolume -> getEbsVolumeValidationResponse(ebsVolume)
+                        .flatMap(response -> sanitizeEbsVolume(ebsVolume, response))
+                        .doOnEach(response -> metrics.incrementValidationSuccess(ebsVolume.getVolumeId()))
+                        .doOnError(throwable -> metrics.incrementValidationError(ebsVolume.getVolumeId(), throwable.getMessage())))
+                .collectSortedList(Comparator.comparing(EbsVolume::getVolumeId))
+                // Update the job with sanitized ebs volume list
+                .map(JobEbsVolumeSanitizer::setEbsFunction)
+                .timeout(Duration.ofMillis(configuration.getJobEbsSanitizationTimeoutMs()));
+    }
+
+    private Mono<ComputeValidator.EbsVolumeValidationResponse> getEbsVolumeValidationResponse(EbsVolume ebsVolume) {
+        return validationClient.validateEbsVolume(
+                ComputeValidator.EbsVolumeValidationRequest.newBuilder()
+                        .setEbsVolumeId(ebsVolume.getVolumeId())
+                        .build())
+                .retry(RETRY_COUNT)
+                .onErrorMap(error -> {
+                    logger.warn("EBS volume validation failure: {}", error.getMessage());
+                    logger.debug("Stack trace", error);
+                    metrics.incrementValidationError(ebsVolume.getVolumeId(), error.getClass().getSimpleName());
+
+                    return new IllegalArgumentException(String.format("EBS volume validation error: bucket=%s, error=%s",
+                            ebsVolume.getVolumeId(),
+                            error.getMessage()
+                    ), error);
+                });
+    }
+
+    private Mono<EbsVolume> sanitizeEbsVolume(EbsVolume ebsVolume, ComputeValidator.EbsVolumeValidationResponse response) {
+        if (response.getResultCase() == ComputeValidator.EbsVolumeValidationResponse.ResultCase.FAILURES) {
+            List<ComputeValidator.ValidationFailure> failures = response.getFailures().getFailuresList();
+            if (!failures.isEmpty()) {
+                return Mono.error(JobManagerException.invalidContainerResources(ebsVolume, failures.get(0).getErrorMessage()));
+            }
+            return Mono.error(JobManagerException.invalidContainerResources(ebsVolume, "No failures reported"));
+        }
+
+        return Mono.just(ebsVolume.toBuilder()
+                .withVolumeAvailabilityZone(response.getSuccess().getEbsVolumeAvailabilityZone())
+                .withVolumeCapacityGB(response.getSuccess().getEbsVolumeCapacityGB())
+                .build());
+    }
+
+    private static UnaryOperator<JobDescriptor> setEbsFunction(List<EbsVolume> ebsVolumes) {
+        return entity -> entity.toBuilder()
+                .withContainer(entity.getContainer().toBuilder()
+                        .withContainerResources(entity.getContainer().getContainerResources().toBuilder()
+                                .withEbsVolumes(ebsVolumes)
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static JobDescriptor<?> skipSanitization(JobDescriptor<?> jobDescriptor) {
+        return JobFunctions.appendJobDescriptorAttribute(jobDescriptor,
+                JobAttributes.JOB_ATTRIBUTES_SANITIZATION_SKIPPED_EBS, true
+        );
+    }
+}

--- a/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizer.java
+++ b/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizer.java
@@ -112,7 +112,7 @@ public class JobEbsVolumeSanitizer implements AdmissionSanitizer<JobDescriptor> 
             if (!failures.isEmpty()) {
                 return Mono.error(JobManagerException.invalidContainerResources(ebsVolume, failures.get(0).getErrorMessage()));
             }
-            return Mono.error(JobManagerException.invalidContainerResources(ebsVolume, "No failures reported"));
+            return Mono.error(JobManagerException.invalidContainerResources(ebsVolume, "Failure reason unknown"));
         }
 
         return Mono.just(ebsVolume.toBuilder()

--- a/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizerConfiguration.java
+++ b/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,25 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.endpoint.admission;
+package com.netflix.titus.ext.jobvalidator.ebs;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
 import com.netflix.titus.common.model.admission.AdmissionValidatorConfiguration;
 import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 
-@Configuration(prefix = "titus.validate.job.image")
-public interface JobImageSanitizerConfiguration extends AdmissionValidatorConfiguration {
+@Configuration(prefix = "titus.validate.job.ebs")
+public interface JobEbsVolumeSanitizerConfiguration extends AdmissionValidatorConfiguration {
     @DefaultValue("true")
     boolean isEnabled();
 
     /**
-     * Since Image validations are on the job accept path the timeout value is aggressive.
-     * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()}.
+     * The aggregate timeout for the validation of all EBS volumes for a job. Since EBS volume
+     * validation is required to get correct EBS metadata and there may be multiple volumes for
+     * a job we want to provide sufficient time. However, since sanitization is on the job accept
+     * path the timeout should not be too large.
+     * This must be smaller than {@link TitusValidatorConfiguration#getTimeoutMs()} to be effective.
      */
     @DefaultValue("4500")
-    long getJobImageValidationTimeoutMs();
+    long getJobEbsSanitizationTimeoutMs();
 }

--- a/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/s3/ReactorValidationServiceClient.java
+++ b/titus-ext/job-validator/src/main/java/com/netflix/titus/ext/jobvalidator/s3/ReactorValidationServiceClient.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.ext.jobvalidator.s3;
 
+import com.netflix.compute.validator.protogen.ComputeValidator.EbsVolumeValidationRequest;
+import com.netflix.compute.validator.protogen.ComputeValidator.EbsVolumeValidationResponse;
 import com.netflix.compute.validator.protogen.ComputeValidator.IamRoleValidationRequest;
 import com.netflix.compute.validator.protogen.ComputeValidator.IamRoleValidationResponse;
 import com.netflix.compute.validator.protogen.ComputeValidator.ImageValidationRequest;
@@ -39,4 +41,7 @@ public interface ReactorValidationServiceClient {
 
     // Validates image.
     Mono<ImageValidationResponse> validateImage(ImageValidationRequest request);
+
+    // Validate EBS volume IDs.
+    Mono<EbsVolumeValidationResponse> validateEbsVolume(EbsVolumeValidationRequest request);
 }

--- a/titus-ext/job-validator/src/test/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizerTest.java
+++ b/titus-ext/job-validator/src/test/java/com/netflix/titus/ext/jobvalidator/ebs/JobEbsVolumeSanitizerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.ext.jobvalidator.ebs;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.netflix.compute.validator.protogen.ComputeValidator;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
+import com.netflix.titus.api.jobmanager.service.JobManagerException;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.ext.jobvalidator.s3.ReactorValidationServiceClient;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JobEbsVolumeSanitizerTest {
+
+    private static final EbsVolume EBS_VOLUME_A = EbsVolume.newBuilder()
+            .withVolumeId("vol-a")
+            .withMountPath("/a")
+            .withMountPermissions(EbsVolume.MountPerm.RW)
+            .withFsType("xfs")
+            .build();
+    private static final EbsVolume EBS_VOLUME_B = EbsVolume.newBuilder()
+            .withVolumeId("vol-b")
+            .withMountPath("/b")
+            .withMountPermissions(EbsVolume.MountPerm.RW)
+            .withFsType("xfs")
+            .build();
+    private static final List<EbsVolume> EBS_VOLUMES = Arrays.asList(EBS_VOLUME_A, EBS_VOLUME_B);
+    private static final JobDescriptor<?> JOB_WITH_NO_EBS_VOLUMES = JobDescriptorGenerator.oneTaskBatchJobDescriptor();
+    private static final JobDescriptor<?> JOB_WITH_DEFAULT_MULTIPLE_EBS_VOLUMES = JOB_WITH_NO_EBS_VOLUMES.toBuilder()
+            .withContainer(JOB_WITH_NO_EBS_VOLUMES.getContainer().toBuilder()
+                    .withContainerResources(JOB_WITH_NO_EBS_VOLUMES.getContainer().getContainerResources().toBuilder()
+                            .withEbsVolumes(EBS_VOLUMES)
+                            .build())
+                    .build())
+            .build();
+
+    private final ReactorValidationServiceClient validationClient = mock(ReactorValidationServiceClient.class);
+    private final JobEbsVolumeSanitizerConfiguration configuration = mock(JobEbsVolumeSanitizerConfiguration.class);
+
+    private final JobEbsVolumeSanitizer sanitizer = new JobEbsVolumeSanitizer(configuration, validationClient, TitusRuntimes.internal());
+
+    @Before
+    public void setUp() {
+        when(configuration.isEnabled()).thenReturn(true);
+        when(configuration.getJobEbsSanitizationTimeoutMs()).thenReturn(5_000L);
+    }
+
+    /**
+     * Tests that EBS volume metadata returned by the validator service gets set properly
+     * on the sanitized job.
+     */
+    @Test
+    public void testMetadataAdded() {
+        ComputeValidator.EbsVolumeValidationRequest request_a = ComputeValidator.EbsVolumeValidationRequest.newBuilder()
+                .setEbsVolumeId(EBS_VOLUME_A.getVolumeId())
+                .build();
+        String azA = "us-east-1a";
+        int sizeA = 5;
+        EbsVolume sanitizedEbsVolumeA = EBS_VOLUME_A.toBuilder()
+                .withVolumeAvailabilityZone(azA)
+                .withVolumeCapacityGB(sizeA)
+                .build();
+        ComputeValidator.EbsVolumeValidationResponse response_a = ComputeValidator.EbsVolumeValidationResponse.newBuilder()
+                .setSuccess(ComputeValidator.EbsVolumeValidationResponse.Success.newBuilder()
+                        .setEbsVolumeAvailabilityZone(azA)
+                        .setEbsVolumeCapacityGB(sizeA)
+                        .build())
+                .build();
+        ComputeValidator.EbsVolumeValidationRequest request_b = ComputeValidator.EbsVolumeValidationRequest.newBuilder()
+                .setEbsVolumeId(EBS_VOLUME_B.getVolumeId())
+                .build();
+        String azB = "us-east-1b";
+        int sizeB = 10;
+        EbsVolume sanitizedEbsVolumeB = EBS_VOLUME_B.toBuilder()
+                .withVolumeAvailabilityZone(azB)
+                .withVolumeCapacityGB(sizeB)
+                .build();
+        ComputeValidator.EbsVolumeValidationResponse response_b = ComputeValidator.EbsVolumeValidationResponse.newBuilder()
+                .setSuccess(ComputeValidator.EbsVolumeValidationResponse.Success.newBuilder()
+                        .setEbsVolumeAvailabilityZone(azB)
+                        .setEbsVolumeCapacityGB(sizeB)
+                        .build())
+                .build();
+
+        when(validationClient.validateEbsVolume(request_a)).thenReturn(Mono.just(response_a));
+        when(validationClient.validateEbsVolume(request_b)).thenReturn(Mono.just(response_b));
+
+        StepVerifier.create(sanitizer.sanitize(JOB_WITH_DEFAULT_MULTIPLE_EBS_VOLUMES))
+                .expectNextMatches(operator -> jobContainsVolumes(
+                        operator.apply(JOB_WITH_DEFAULT_MULTIPLE_EBS_VOLUMES),
+                        CollectionsExt.asSet(sanitizedEbsVolumeA, sanitizedEbsVolumeB)))
+                .verifyComplete();
+    }
+
+    /**
+     * Test that a job with no EBS volumes is properly handled.
+     */
+    @Test
+    public void testNoVolumes() {
+        StepVerifier.create(sanitizer.sanitize(JOB_WITH_NO_EBS_VOLUMES))
+                .expectNextMatches(operator -> operator.apply(JOB_WITH_NO_EBS_VOLUMES)
+                        .getContainer().getContainerResources().getEbsVolumes().isEmpty())
+                .verifyComplete();
+    }
+
+    /**
+     * Tests that validation service error responses are handled properly.
+     */
+    @Test
+    public void testValidatorError() {
+        when(validationClient.validateEbsVolume(any())).thenReturn(Mono.error(new StatusRuntimeException(Status.INTERNAL)));
+        StepVerifier.create(sanitizer.sanitize(JOB_WITH_DEFAULT_MULTIPLE_EBS_VOLUMES))
+                .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException &&
+                        throwable.getMessage().contains("EBS volume validation error"))
+                .verify();
+    }
+
+    /**
+     * Tests that validations that are unsuccessful/failures are handled properly.
+     */
+    @Test
+    public void testValidationFailure() {
+        ComputeValidator.EbsVolumeValidationResponse response = ComputeValidator.EbsVolumeValidationResponse.newBuilder()
+                .setFailures(ComputeValidator.ValidationFailures.newBuilder()
+                        .addFailures(ComputeValidator.ValidationFailure.newBuilder()
+                                .setErrorCode("notFound")
+                                .setErrorMessage("Volume not found")
+                                .build())
+                        .build())
+                .build();
+
+        when(validationClient.validateEbsVolume(any())).thenReturn(Mono.just(response));
+        StepVerifier.create(sanitizer.sanitize(JOB_WITH_DEFAULT_MULTIPLE_EBS_VOLUMES))
+                .expectErrorMatches(throwable -> throwable instanceof JobManagerException &&
+                        throwable.getMessage().contains("Job has invalid EBS volume"))
+                .verify();
+    }
+
+    private boolean jobContainsVolumes(JobDescriptor<?> jobDescriptor, Set<EbsVolume> ebsVolumeSet) {
+        return new HashSet<>(jobDescriptor.getContainer().getContainerResources().getEbsVolumes()).equals(ebsVolumeSet);
+    }
+}

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobEbsVolumeValidatorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobEbsVolumeValidatorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.gateway.service.v3.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
+import com.netflix.titus.common.model.sanitizer.ValidationError;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.runtime.endpoint.admission.JobEbsVolumeValidator;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import org.junit.Test;
+import reactor.test.StepVerifier;
+
+public class JobEbsVolumeValidatorTest {
+
+    private static final EbsVolume EBS_VOLUME_VALID = EbsVolume.newBuilder()
+            .withVolumeId("vol-valid")
+            .withMountPath("/valid")
+            .withMountPermissions(EbsVolume.MountPerm.RW)
+            .withFsType("xfs")
+            .withVolumeCapacityGB(5)
+            .withVolumeAvailabilityZone("us-east-1c")
+            .build();
+    private static final EbsVolume EBS_VOLUME_INVALID = EbsVolume.newBuilder()
+            .withVolumeId("vol-invalid")
+            .withMountPath("/invalid")
+            .withMountPermissions(EbsVolume.MountPerm.RW)
+            .withFsType("xfs")
+            .build();
+    private static final List<EbsVolume> INVALID_EBS_VOLUMES = Arrays.asList(EBS_VOLUME_VALID, EBS_VOLUME_INVALID);
+    private static final List<EbsVolume> VALID_EBS_VOLUMES = Collections.singletonList(EBS_VOLUME_VALID);
+
+    private static final JobDescriptor<?> JOB_WITH_NO_EBS_VOLUMES = JobDescriptorGenerator.oneTaskBatchJobDescriptor();
+    private static final JobDescriptor<?> JOB_WITH_INVALID_EBS_VOLUMES = JOB_WITH_NO_EBS_VOLUMES.toBuilder()
+            .withContainer(JOB_WITH_NO_EBS_VOLUMES.getContainer().toBuilder()
+                    .withContainerResources(JOB_WITH_NO_EBS_VOLUMES.getContainer().getContainerResources().toBuilder()
+                            .withEbsVolumes(INVALID_EBS_VOLUMES)
+                            .build())
+                    .build())
+            .build();
+    private static final JobDescriptor<?> JOB_WITH_VALID_EBS_VOLUMES = JOB_WITH_NO_EBS_VOLUMES.toBuilder()
+            .withContainer(JOB_WITH_NO_EBS_VOLUMES.getContainer().toBuilder()
+                    .withContainerResources(JOB_WITH_NO_EBS_VOLUMES.getContainer().getContainerResources().toBuilder()
+                            .withEbsVolumes(VALID_EBS_VOLUMES)
+                            .build())
+                    .build())
+            .build();
+
+    private final JobEbsVolumeValidator jobEbsVolumeValidator = new JobEbsVolumeValidator(() -> ValidationError.Type.HARD, TitusRuntimes.internal());
+
+    @Test
+    public void testJobWithInvalidEbsVolume() {
+        StepVerifier.create(jobEbsVolumeValidator.validate(JOB_WITH_INVALID_EBS_VOLUMES))
+                .expectNextMatches(violations -> violations.size() == 1)
+                .verifyComplete();
+    }
+
+    @Test
+    public void testJobWithValidEbsVolume() {
+        StepVerifier.create(jobEbsVolumeValidator.validate(JOB_WITH_VALID_EBS_VOLUMES))
+                .expectNextMatches(Set::isEmpty)
+                .verifyComplete();
+    }
+
+    @Test
+    public void testJobWithNoEbsVolumes() {
+        StepVerifier.create(jobEbsVolumeValidator.validate(JOB_WITH_NO_EBS_VOLUMES))
+                .expectNextMatches(Set::isEmpty)
+                .verifyComplete();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/TitusMasterModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/TitusMasterModule.java
@@ -34,6 +34,7 @@ import com.netflix.titus.master.config.CellInfoResolver;
 import com.netflix.titus.master.config.ConfigurableCellInfoResolver;
 import com.netflix.titus.master.config.MasterConfiguration;
 import com.netflix.titus.master.endpoint.MasterEndpointModule;
+import com.netflix.titus.master.endpoint.admission.JobCoordinatorAdmissionModule;
 import com.netflix.titus.master.endpoint.common.ContextResolver;
 import com.netflix.titus.master.endpoint.common.EmptyContextResolver;
 import com.netflix.titus.master.endpoint.v2.rest.JerseyModule;
@@ -120,6 +121,7 @@ public class TitusMasterModule extends AbstractModule {
             install(new JerseyModule());
         }
 
+        install(new JobCoordinatorAdmissionModule());
         install(new MasterEndpointModule());
         install(new HealthModule());
         install(new V3EndpointModule());

--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/admission/JobCoordinatorAdmissionModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/admission/JobCoordinatorAdmissionModule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.endpoint.admission;
+
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.admission.AdmissionSanitizer;
+import com.netflix.titus.common.model.admission.AdmissionValidator;
+import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
+
+public class JobCoordinatorAdmissionModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+    }
+
+    @Provides
+    @Singleton
+    public AdmissionSanitizer<JobDescriptor> getJobSanitizer() {
+        return new PassJobValidator();
+    }
+
+    @Provides
+    @Singleton
+    public AdmissionValidator<JobDescriptor> getJobValidator() {
+        return new PassJobValidator();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/V3EndpointModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/V3EndpointModule.java
@@ -18,10 +18,10 @@ package com.netflix.titus.master.jobmanager.endpoint.v3;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
+import com.netflix.titus.api.jobmanager.model.job.LogStorageInfo;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceImplBase;
 import com.netflix.titus.master.jobmanager.endpoint.v3.grpc.DefaultJobManagementServiceGrpc;
-import com.netflix.titus.api.jobmanager.model.job.LogStorageInfo;
 
 public class V3EndpointModule extends AbstractModule {
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
@@ -454,7 +454,7 @@ public class DefaultTaskToPodConverter implements TaskToPodConverter {
     }
 
     /**
-     * Builds the various objects needed to
+     * Builds the various objects needed to for PersistentVolume and Pod objects to use an volume.
      */
     @VisibleForTesting
     Optional<Pair<V1Volume, V1VolumeMount>> buildV1VolumeInfo(Job<?> job, Task task) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/KubeModelConverters.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/KubeModelConverters.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.mesos.kubeapiserver.direct;
+
+import java.util.Optional;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolumeUtils;
+import io.kubernetes.client.custom.Quantity;
+import io.kubernetes.client.openapi.models.V1AWSElasticBlockStoreVolumeSource;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PersistentVolume;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeSpec;
+import io.kubernetes.client.openapi.models.V1Volume;
+
+/**
+ * A collection of helper functions to convert core and Kube objects to other Kube model objects.
+ */
+public class KubeModelConverters {
+
+    private static final String KUBE_VOLUME_ACCESS_MODE = "ReadWriteOnce";
+    private static final String KUBE_VOLUME_VOLUME_MODE_FS = "Filesystem";
+    private static final String KUBE_VOLUME_RECLAIM_POLICY = "Retain";
+
+    private static final String KUBE_VOLUME_CAPACITY_KEY = "storage";
+
+    public static V1PersistentVolume toV1PersistentVolume(Job<?> job, Task task, V1Volume v1Volume) {
+        Optional<EbsVolume> optionalEbsVolume = EbsVolumeUtils.getEbsVolumeForTask(job, task);
+        if (!optionalEbsVolume.isPresent()) {
+            throw new IllegalStateException(String.format("Expected EBS volume for job %s and task %s", job, task));
+        }
+        EbsVolume ebsVolume = optionalEbsVolume.get();
+
+        V1ObjectMeta v1ObjectMeta = new V1ObjectMeta()
+                .name(v1Volume.getName());
+
+        V1PersistentVolumeSpec v1PersistentVolumeSpec = new V1PersistentVolumeSpec()
+                .addAccessModesItem(KUBE_VOLUME_ACCESS_MODE)
+                .volumeMode(KUBE_VOLUME_VOLUME_MODE_FS)
+                .persistentVolumeReclaimPolicy(KUBE_VOLUME_RECLAIM_POLICY)
+                .putCapacityItem(KUBE_VOLUME_CAPACITY_KEY, new Quantity(ebsVolume.getVolumeCapacityGB() + "Gi"));
+
+        if (null != v1Volume.getAwsElasticBlockStore()) {
+            v1PersistentVolumeSpec
+                    .awsElasticBlockStore(new V1AWSElasticBlockStoreVolumeSource()
+                            .volumeID(v1Volume.getAwsElasticBlockStore().getVolumeID())
+                            .fsType(v1Volume.getAwsElasticBlockStore().getFsType()));
+        }
+
+        return new V1PersistentVolume()
+                .apiVersion("v1")
+                .metadata(v1ObjectMeta)
+                .spec(v1PersistentVolumeSpec);
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobValidatorNegativeTest.java
@@ -29,7 +29,7 @@ import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.admission.AggregatingValidator;
 import com.netflix.titus.runtime.endpoint.admission.FailJobValidator;
 import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
-import com.netflix.titus.runtime.endpoint.admission.TitusValidatorConfiguration;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCell;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMasters;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizer.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.model.admission.AdmissionSanitizer;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.common.util.CollectionsExt;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidator.java
@@ -28,6 +28,7 @@ import javax.inject.Singleton;
 import com.netflix.spectator.api.Registry;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.admission.AdmissionValidator;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.common.model.admission.ValidatorMetrics;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
 import reactor.core.publisher.Mono;

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobEbsVolumeValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobEbsVolumeValidator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.endpoint.admission;
+
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.common.model.admission.AdmissionValidator;
+import com.netflix.titus.common.model.admission.ValidatorMetrics;
+import com.netflix.titus.common.model.sanitizer.ValidationError;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.StringExt;
+import reactor.core.publisher.Mono;
+
+/**
+ * This {@link com.netflix.titus.common.model.admission.AdmissionValidator} validates Job EBS volumes
+ * have all of the appropriate volume metadata set. This metadata should be set during a prior sanitization step.
+ */
+public class JobEbsVolumeValidator implements AdmissionValidator<JobDescriptor> {
+
+    private static final String REASON_MISSING_FIELD = "missingField";
+
+    private final Supplier<ValidationError.Type> validationErrorTypeProvider;
+    private final ValidatorMetrics metrics;
+
+    public JobEbsVolumeValidator(Supplier<ValidationError.Type> validationErrorTypeProvider,
+                                 TitusRuntime titusRuntime) {
+        this.validationErrorTypeProvider = validationErrorTypeProvider;
+        this.metrics = new ValidatorMetrics(JobEbsVolumeValidator.class.getSimpleName(), titusRuntime.getRegistry());
+    }
+
+    @Override
+    public Mono<Set<ValidationError>> validate(JobDescriptor jobDescriptor) {
+        return Mono.fromCallable(() -> jobDescriptor.getContainer().getContainerResources().getEbsVolumes().stream()
+                .filter(ebsVolume -> StringExt.isEmpty(ebsVolume.getVolumeAvailabilityZone()) ||
+                        ebsVolume.getVolumeCapacityGB() == 0)
+                .peek(ebsVolume -> metrics.incrementValidationError(ebsVolume.getVolumeId(), REASON_MISSING_FIELD))
+                .map(ebsVolume -> new ValidationError(
+                        JobAttributes.JOB_ATTRIBUTES_EBS_VOLUME_IDS,
+                        String.format("Required field missing from EBS volume %s", ebsVolume)))
+                .collect(Collectors.toSet()))
+                .doOnNext(validationErrors -> {
+                    if (validationErrors.isEmpty()) {
+                        metrics.incrementValidationSuccess(JobAttributes.JOB_ATTRIBUTES_EBS_VOLUME_IDS);
+                    }
+                });
+    }
+
+    @Override
+    public ValidationError.Type getErrorType() {
+        return validationErrorTypeProvider.get();
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobSecurityValidatorConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobSecurityValidatorConfiguration.java
@@ -20,6 +20,8 @@ package com.netflix.titus.runtime.endpoint.admission;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.titus.common.model.admission.AdmissionValidatorConfiguration;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 
 @Configuration(prefix = "titus.validate.job.security")
 public interface JobSecurityValidatorConfiguration extends AdmissionValidatorConfiguration {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/PassJobValidator.java
@@ -19,6 +19,7 @@ package com.netflix.titus.runtime.endpoint.admission;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.UnaryOperator;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
@@ -55,6 +56,6 @@ public class PassJobValidator implements AdmissionValidator<JobDescriptor>, Admi
 
     @Override
     public Mono<UnaryOperator<JobDescriptor>> sanitize(JobDescriptor entity) {
-        return Mono.empty();
+        return Mono.just(UnaryOperator.identity());
     }
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizerConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/ServiceMeshImageSanitizerConfiguration.java
@@ -18,6 +18,8 @@ package com.netflix.titus.runtime.endpoint.admission;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.titus.common.model.admission.AdmissionValidatorConfiguration;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 
 @Configuration(prefix = "titus.validate.serviceMesh.image")
 public interface ServiceMeshImageSanitizerConfiguration extends AdmissionValidatorConfiguration {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/TitusAdmissionModule.java
@@ -27,6 +27,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.admission.AdmissionSanitizer;
 import com.netflix.titus.common.model.admission.AdmissionValidator;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.runtime.TitusEntitySanitizerModule;
 
 /**

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingSanitizerTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.service.TitusServiceException;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
 import org.junit.Before;
 import org.junit.Test;

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidatorTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/admission/AggregatingValidatorTest.java
@@ -27,6 +27,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.common.model.admission.AdmissionValidator;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.common.model.sanitizer.ValidationError;
 import org.junit.Before;
 import org.junit.Test;

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
@@ -49,7 +49,7 @@ import com.netflix.titus.common.model.admission.AdmissionSanitizer;
 import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.admission.AggregatingSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
-import com.netflix.titus.runtime.endpoint.admission.TitusValidatorConfiguration;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.runtime.endpoint.common.rest.EmbeddedJettyModule;
 import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMaster;

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
@@ -50,6 +50,7 @@ import com.netflix.titus.api.audit.service.AuditLogService;
 import com.netflix.titus.api.connector.cloud.InstanceCloudConnector;
 import com.netflix.titus.api.connector.cloud.LoadBalancerConnector;
 import com.netflix.titus.api.connector.cloud.noop.NoOpLoadBalancerConnector;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.store.JobStore;
 import com.netflix.titus.api.json.ObjectMappers;
 import com.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerJobValidator;
@@ -58,6 +59,8 @@ import com.netflix.titus.api.loadbalancer.store.LoadBalancerStore;
 import com.netflix.titus.api.supervisor.service.LeaderActivator;
 import com.netflix.titus.api.supervisor.service.MasterDescription;
 import com.netflix.titus.api.supervisor.service.MasterMonitor;
+import com.netflix.titus.common.model.admission.AdmissionSanitizer;
+import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.archaius2.Archaius2ConfigurationLogger;
@@ -91,6 +94,7 @@ import com.netflix.titus.master.scheduler.SchedulingService;
 import com.netflix.titus.master.scheduler.opportunistic.OpportunisticCpuAvailability;
 import com.netflix.titus.master.scheduler.opportunistic.OpportunisticCpuAvailabilityProvider;
 import com.netflix.titus.master.supervisor.service.leader.LocalMasterMonitor;
+import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
 import com.netflix.titus.runtime.endpoint.common.rest.EmbeddedJettyModule;
 import com.netflix.titus.runtime.store.v3.memory.InMemoryJobStore;
 import com.netflix.titus.runtime.store.v3.memory.InMemoryLoadBalancerStore;
@@ -227,6 +231,18 @@ public class EmbeddedTitusMaster {
                                       bind(LoadBalancerConnector.class).to(NoOpLoadBalancerConnector.class);
                                       bind(LoadBalancerJobValidator.class).to(NoOpLoadBalancerJobValidator.class);
                                       bind(OpportunisticCpuAvailabilityProvider.class).toInstance(() -> new HashMap<>(opportunisticCpuAvailability));
+                                  }
+
+                                  @Provides
+                                  @Singleton
+                                  public AdmissionSanitizer<JobDescriptor> getJobSanitizer() {
+                                      return new PassJobValidator();
+                                  }
+
+                                  @Provides
+                                  @Singleton
+                                  public AdmissionValidator<JobDescriptor> getJobValidator() {
+                                      return new PassJobValidator();
                                   }
 
                                   @Provides

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/master/EmbeddedTitusMaster.java
@@ -50,7 +50,6 @@ import com.netflix.titus.api.audit.service.AuditLogService;
 import com.netflix.titus.api.connector.cloud.InstanceCloudConnector;
 import com.netflix.titus.api.connector.cloud.LoadBalancerConnector;
 import com.netflix.titus.api.connector.cloud.noop.NoOpLoadBalancerConnector;
-import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.store.JobStore;
 import com.netflix.titus.api.json.ObjectMappers;
 import com.netflix.titus.api.loadbalancer.model.sanitizer.LoadBalancerJobValidator;
@@ -59,8 +58,6 @@ import com.netflix.titus.api.loadbalancer.store.LoadBalancerStore;
 import com.netflix.titus.api.supervisor.service.LeaderActivator;
 import com.netflix.titus.api.supervisor.service.MasterDescription;
 import com.netflix.titus.api.supervisor.service.MasterMonitor;
-import com.netflix.titus.common.model.admission.AdmissionSanitizer;
-import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.archaius2.Archaius2ConfigurationLogger;
@@ -94,7 +91,6 @@ import com.netflix.titus.master.scheduler.SchedulingService;
 import com.netflix.titus.master.scheduler.opportunistic.OpportunisticCpuAvailability;
 import com.netflix.titus.master.scheduler.opportunistic.OpportunisticCpuAvailabilityProvider;
 import com.netflix.titus.master.supervisor.service.leader.LocalMasterMonitor;
-import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
 import com.netflix.titus.runtime.endpoint.common.rest.EmbeddedJettyModule;
 import com.netflix.titus.runtime.store.v3.memory.InMemoryJobStore;
 import com.netflix.titus.runtime.store.v3.memory.InMemoryLoadBalancerStore;
@@ -231,18 +227,6 @@ public class EmbeddedTitusMaster {
                                       bind(LoadBalancerConnector.class).to(NoOpLoadBalancerConnector.class);
                                       bind(LoadBalancerJobValidator.class).to(NoOpLoadBalancerJobValidator.class);
                                       bind(OpportunisticCpuAvailabilityProvider.class).toInstance(() -> new HashMap<>(opportunisticCpuAvailability));
-                                  }
-
-                                  @Provides
-                                  @Singleton
-                                  public AdmissionSanitizer<JobDescriptor> getJobSanitizer() {
-                                      return new PassJobValidator();
-                                  }
-
-                                  @Provides
-                                  @Singleton
-                                  public AdmissionValidator<JobDescriptor> getJobValidator() {
-                                      return new PassJobValidator();
                                   }
 
                                   @Provides


### PR DESCRIPTION
Partial feature support for EBS volumes. This PR depends on PR https://github.com/Netflix/titus-api-definitions/pull/127

This PR provides:

1. Internal EBS model/data types.
2. API support for EBS volumes specified as job attributes.
3. Validation of user provided EBS volumes.
4. Creation of Kube Persistent Volumes.
5. Pod configurations to use Persistent Volumes.

This PR does NOT provide to following which will be added in follow on PRs:
1. GC of previously created Persistent Volumes.
2. Integration testing with @solarkennedy 's specific CSI driver changes.
