### PR TITLE
rechecking agent status if not found in cache

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/agent/service/AgentManagementService.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/agent/service/AgentManagementService.java
@@ -28,6 +28,7 @@ import com.netflix.titus.api.agent.model.event.AgentEvent;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.tuple.Either;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -140,6 +141,6 @@ public interface AgentManagementService extends ReadOnlyAgentOperations {
      * @param instanceId of the agent
      * @return Observable of AgentInstance
      */
-    Observable<AgentInstance> getAgentInstanceAsync(String instanceId);
+    Mono<AgentInstance> getAgentInstanceAsync(String instanceId);
 
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/agent/service/AgentManagementService.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/agent/service/AgentManagementService.java
@@ -32,7 +32,6 @@ import rx.Completable;
 import rx.Observable;
 
 public interface AgentManagementService extends ReadOnlyAgentOperations {
-
     /**
      * Returns true if the agent instance group is owned by Fenzo. Only Fenzo owned instance groups are scaled
      * by the capacity management and cluster operations components.
@@ -134,4 +133,13 @@ public interface AgentManagementService extends ReadOnlyAgentOperations {
      * event for each instance group or agent instance change (add/update/remove).
      */
     Observable<AgentEvent> events(boolean includeSnapshot);
+
+    /**
+     * Looks up agent instance by its ID, asynchronously
+     *
+     * @param instanceId of the agent
+     * @return Observable of AgentInstance
+     */
+    Observable<AgentInstance> getAgentInstanceAsync(String instanceId);
+
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/connector/cloud/InstanceCloudConnector.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/connector/cloud/InstanceCloudConnector.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.common.util.tuple.Either;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -56,6 +57,12 @@ public interface InstanceCloudConnector {
      * Get detailed information about instances with the given ids.
      */
     Observable<List<Instance>> getInstances(List<String> instanceIds);
+
+
+    /**
+     * Get detailed information about a given instance ID
+     */
+    Mono<Instance> getInstance(String instanceId);
 
     /**
      * Get detailed information about instances with the given instance group id.

--- a/titus-api/src/main/java/com/netflix/titus/api/connector/cloud/noop/NoOpInstanceCloudConnector.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/connector/cloud/noop/NoOpInstanceCloudConnector.java
@@ -27,6 +27,7 @@ import com.netflix.titus.api.connector.cloud.InstanceGroup;
 import com.netflix.titus.api.connector.cloud.InstanceLaunchConfiguration;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.common.util.tuple.Either;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -55,6 +56,11 @@ public class NoOpInstanceCloudConnector implements InstanceCloudConnector {
     @Override
     public Observable<List<Instance>> getInstances(List<String> instanceIds) {
         return Observable.empty();
+    }
+
+    @Override
+    public Mono<Instance> getInstance(String instanceId) {
+        return Mono.empty();
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.master.agent.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,7 @@ import com.netflix.titus.common.util.tuple.Either;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.agent.ServerInfo;
 import com.netflix.titus.master.agent.service.cache.AgentCache;
+import com.netflix.titus.master.agent.service.cache.DataConverters;
 import com.netflix.titus.master.agent.service.server.ServerInfoResolver;
 import rx.Completable;
 import rx.Observable;
@@ -123,6 +125,13 @@ public class DefaultAgentManagementService implements AgentManagementService {
     @Override
     public AgentInstance getAgentInstance(String instanceId) {
         return agentCache.getAgentInstance(instanceId);
+    }
+
+    @Override
+    public Observable<AgentInstance> getAgentInstanceAsync(String instanceId) {
+        return instanceCloudConnector.getInstances(Collections.singletonList(instanceId))
+                .filter(instances -> !instances.isEmpty())
+                .map(instances -> DataConverters.toAgentInstance(instances.get(0)));
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/DefaultAgentManagementService.java
@@ -17,7 +17,6 @@
 package com.netflix.titus.master.agent.service;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +51,7 @@ import com.netflix.titus.master.agent.ServerInfo;
 import com.netflix.titus.master.agent.service.cache.AgentCache;
 import com.netflix.titus.master.agent.service.cache.DataConverters;
 import com.netflix.titus.master.agent.service.server.ServerInfoResolver;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -128,10 +128,8 @@ public class DefaultAgentManagementService implements AgentManagementService {
     }
 
     @Override
-    public Observable<AgentInstance> getAgentInstanceAsync(String instanceId) {
-        return instanceCloudConnector.getInstances(Collections.singletonList(instanceId))
-                .filter(instances -> !instances.isEmpty())
-                .map(instances -> DataConverters.toAgentInstance(instances.get(0)));
+    public Mono<AgentInstance> getAgentInstanceAsync(String instanceId) {
+        return instanceCloudConnector.getInstance(instanceId).map(DataConverters::toAgentInstance);
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DataConverters.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/agent/service/cache/DataConverters.java
@@ -32,7 +32,7 @@ import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.Evaluators;
 
-class DataConverters {
+public class DataConverters {
 
     static AgentInstanceGroup toAgentInstanceGroup(InstanceGroup instanceGroup,
                                                    ResourceDimension instanceResourceDimension) {
@@ -75,7 +75,7 @@ class DataConverters {
                 .build();
     }
 
-    static AgentInstance toAgentInstance(Instance instance) {
+    public static AgentInstance toAgentInstance(Instance instance) {
         AgentInstance.Builder builder = AgentInstance.newBuilder();
         return updateInstanceAttributes(builder, instance, Collections.emptyMap())
                 .withId(instance.getId())

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
@@ -153,16 +153,15 @@ public class NodeGcController extends BaseGcController<V1Node> {
             // recheck with agent service to find an instance.
             // It is a blocking call that is bound by the timeout defined in
             // {@link com.netflix.titus.ext.aws.AwsConfiguration#getAwsRequestTimeoutMs()}
-            AgentInstance agentInstance = null;
             try {
-                agentInstance = agentManagementService.getAgentInstanceAsync(nodeName).block();
-                if (agentInstance == null) {
+                AgentInstance agent = agentManagementService.getAgentInstanceAsync(nodeName).block();
+                if (agent == null) {
                     // Assuming the instance is gone from AWS
                     return true;
                 }
-                if (agentInstance.getLifecycleStatus() != null) {
-                    logger.info("Rechecked node {} to get status {}", nodeName, agentInstance.getLifecycleStatus().getState());
-                    return agentInstance.getLifecycleStatus().getState() == InstanceLifecycleState.Stopped;
+                if (agent.getLifecycleStatus() != null) {
+                    logger.info("Rechecked node {} to get status {}", nodeName, agent.getLifecycleStatus().getState());
+                    return agent.getLifecycleStatus().getState() == InstanceLifecycleState.Stopped;
                 }
             } catch (Exception e) {
                 logger.warn("Exception getting instance status for {}", nodeName, e);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
@@ -99,6 +99,9 @@ public class NodeGcController extends BaseGcController<V1Node> {
 
     @Override
     public boolean gcItem(V1Node item) {
+        if (item.getMetadata() != null) {
+            logger.info("Deleting node {}", item.getMetadata().getName());
+        }
         return GcControllerUtil.deleteNode(kubeApiFacade, logger, item);
     }
 
@@ -151,7 +154,8 @@ public class NodeGcController extends BaseGcController<V1Node> {
             AgentInstance agentInstance = agentManagementService.getAgentInstanceAsync(nodeName)
                     .toBlocking()
                     .firstOrDefault(null);
-            if (agentInstance != null) {
+            if (agentInstance != null && agentInstance.getLifecycleStatus() != null) {
+                logger.info("Rechecked node {} to get status {}", nodeName, agentInstance.getLifecycleStatus().getState());
                 return agentInstance.getLifecycleStatus().getState() == InstanceLifecycleState.Stopped;
             }
             return false;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/NodeGcController.java
@@ -150,13 +150,22 @@ public class NodeGcController extends BaseGcController<V1Node> {
 
         Optional<AgentInstance> agentInstanceOpt = agentManagementService.findAgentInstance(nodeName);
         if (!agentInstanceOpt.isPresent()) {
-            // re-check with agent service to find an instance
-            AgentInstance agentInstance = agentManagementService.getAgentInstanceAsync(nodeName)
-                    .toBlocking()
-                    .firstOrDefault(null);
-            if (agentInstance != null && agentInstance.getLifecycleStatus() != null) {
-                logger.info("Rechecked node {} to get status {}", nodeName, agentInstance.getLifecycleStatus().getState());
-                return agentInstance.getLifecycleStatus().getState() == InstanceLifecycleState.Stopped;
+            // recheck with agent service to find an instance.
+            // It is a blocking call that is bound by the timeout defined in
+            // {@link com.netflix.titus.ext.aws.AwsConfiguration#getAwsRequestTimeoutMs()}
+            AgentInstance agentInstance = null;
+            try {
+                agentInstance = agentManagementService.getAgentInstanceAsync(nodeName).block();
+                if (agentInstance == null) {
+                    // Assuming the instance is gone from AWS
+                    return true;
+                }
+                if (agentInstance.getLifecycleStatus() != null) {
+                    logger.info("Rechecked node {} to get status {}", nodeName, agentInstance.getLifecycleStatus().getState());
+                    return agentInstance.getLifecycleStatus().getState() == InstanceLifecycleState.Stopped;
+                }
+            } catch (Exception e) {
+                logger.warn("Exception getting instance status for {}", nodeName, e);
             }
             return false;
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/VmOperationsInstanceCloudConnector.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/VmOperationsInstanceCloudConnector.java
@@ -35,6 +35,7 @@ import com.netflix.titus.api.connector.cloud.InstanceGroup;
 import com.netflix.titus.api.connector.cloud.InstanceLaunchConfiguration;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.common.util.tuple.Either;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -85,6 +86,12 @@ public class VmOperationsInstanceCloudConnector implements InstanceCloudConnecto
         return Observable.fromCallable(() -> internalGetInstances().stream()
                 .filter(instance -> instanceIds.contains(instance.getId()))
                 .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Mono<Instance> getInstance(String instanceId) {
+        Optional<Instance> instOpt = internalGetInstances().stream().filter(instance -> instance.getId().equals(instanceId)).findAny();
+        return instOpt.map(Mono::just).orElseGet(Mono::empty);
     }
 
     @Override

--- a/titus-server-master/src/test/java/com/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
@@ -33,6 +33,7 @@ import com.netflix.titus.api.agent.model.event.AgentInstanceGroupRemovedEvent;
 import com.netflix.titus.api.agent.model.event.AgentInstanceGroupUpdateEvent;
 import com.netflix.titus.api.agent.model.event.AgentInstanceRemovedEvent;
 import com.netflix.titus.api.agent.model.event.AgentInstanceUpdateEvent;
+import com.netflix.titus.api.connector.cloud.Instance;
 import com.netflix.titus.api.connector.cloud.InstanceCloudConnector;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.Tier;
@@ -332,5 +333,22 @@ public class DefaultAgentManagementServiceTest {
         agentCacheEventSubject.onNext(new CacheUpdateEvent(CacheUpdateType.Instance, id));
         AgentEvent event = eventSubscriber.takeNext();
         assertThat(event).isInstanceOf(AgentInstanceRemovedEvent.class);
+    }
+
+    @Test
+    public void getAgentInstanceAsync() {
+        String cloudInstanceId = "ci-1";
+        Instance cloudInstance = Instance.newBuilder()
+                .withId(cloudInstanceId)
+                .withInstanceGroupId("cg-1")
+                .withIpAddress("ip-1")
+                .withAttributes(
+                        Collections.emptyMap())
+                .withInstanceState(Instance.InstanceState.Terminated).build();
+        when(connector.getInstances(Collections.singletonList(cloudInstanceId)))
+                .thenReturn(Observable.just(Collections.singletonList(cloudInstance)));
+        ExtTestSubscriber<AgentInstance> testSubscriber = new ExtTestSubscriber<>();
+        service.getAgentInstanceAsync(cloudInstanceId).subscribe(testSubscriber);
+        assertThat(testSubscriber.isError()).isFalse();
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
@@ -51,6 +51,7 @@ import com.netflix.titus.master.model.ResourceDimensions;
 import com.netflix.titus.testkit.rx.ExtTestSubscriber;
 import org.junit.Before;
 import org.junit.Test;
+import reactor.test.StepVerifier;
 import rx.Completable;
 import rx.Observable;
 import rx.Single;
@@ -347,8 +348,8 @@ public class DefaultAgentManagementServiceTest {
                 .withInstanceState(Instance.InstanceState.Terminated).build();
         when(connector.getInstances(Collections.singletonList(cloudInstanceId)))
                 .thenReturn(Observable.just(Collections.singletonList(cloudInstance)));
-        ExtTestSubscriber<AgentInstance> testSubscriber = new ExtTestSubscriber<>();
-        service.getAgentInstanceAsync(cloudInstanceId).subscribe(testSubscriber);
-        assertThat(testSubscriber.isError()).isFalse();
+        StepVerifier.create(service.getAgentInstanceAsync(cloudInstanceId))
+                .assertNext(agentInstance -> assertThat(agentInstance.getId()).isEqualTo(cloudInstanceId))
+                .verifyComplete();
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/agent/service/DefaultAgentManagementServiceTest.java
@@ -51,6 +51,7 @@ import com.netflix.titus.master.model.ResourceDimensions;
 import com.netflix.titus.testkit.rx.ExtTestSubscriber;
 import org.junit.Before;
 import org.junit.Test;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import rx.Completable;
 import rx.Observable;
@@ -346,8 +347,8 @@ public class DefaultAgentManagementServiceTest {
                 .withAttributes(
                         Collections.emptyMap())
                 .withInstanceState(Instance.InstanceState.Terminated).build();
-        when(connector.getInstances(Collections.singletonList(cloudInstanceId)))
-                .thenReturn(Observable.just(Collections.singletonList(cloudInstance)));
+        when(connector.getInstance(cloudInstanceId))
+                .thenReturn(Mono.just(cloudInstance));
         StepVerifier.create(service.getAgentInstanceAsync(cloudInstanceId))
                 .assertNext(agentInstance -> assertThat(agentInstance.getId()).isEqualTo(cloudInstanceId))
                 .verifyComplete();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/NodeGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/NodeGcControllerTest.java
@@ -40,6 +40,7 @@ import org.assertj.core.api.Assertions;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import rx.Observable;
 
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.NODE_LABEL_ACCOUNT_ID;
@@ -150,8 +151,8 @@ public class NodeGcControllerTest {
                 .spec(new V1NodeSpec())
                 .status(new V1NodeStatus().addConditionsItem(readyCondition));
         when(agentManagementService.findAgentInstance(NODE_NAME)).thenReturn(Optional.empty());
-        when(agentManagementService.getAgentInstanceAsync(NODE_NAME)).thenReturn(Observable.empty());
-        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isFalse();
+        when(agentManagementService.getAgentInstanceAsync(NODE_NAME)).thenReturn(Mono.empty());
+        Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isTrue();
     }
 
     /**
@@ -174,7 +175,7 @@ public class NodeGcControllerTest {
                 .withId(NODE_NAME)
                 .withDeploymentStatus(InstanceLifecycleStatus.newBuilder().withState(InstanceLifecycleState.Stopped).build())
                 .build();
-        when(agentManagementService.getAgentInstanceAsync(NODE_NAME)).thenReturn(Observable.just(agentInstance));
+        when(agentManagementService.getAgentInstanceAsync(NODE_NAME)).thenReturn(Mono.just(agentInstance));
         Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isTrue();
 
         // instance state != stopped
@@ -182,7 +183,7 @@ public class NodeGcControllerTest {
                 .withId(NODE_NAME)
                 .withDeploymentStatus(InstanceLifecycleStatus.newBuilder().withState(InstanceLifecycleState.Launching).build())
                 .build();
-        when(agentManagementService.getAgentInstanceAsync(NODE_NAME)).thenReturn(Observable.just(agentInstance2));
+        when(agentManagementService.getAgentInstanceAsync(NODE_NAME)).thenReturn(Mono.just(agentInstance2));
         Assertions.assertThat(nodeGcController.isNodeEligibleForGc(node)).isFalse();
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/connector/local/SimulatedLocalInstanceCloudConnector.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/connector/local/SimulatedLocalInstanceCloudConnector.java
@@ -37,6 +37,7 @@ import com.netflix.titus.master.model.ResourceDimensions;
 import com.netflix.titus.testkit.embedded.cloud.SimulatedCloud;
 import com.netflix.titus.testkit.embedded.cloud.agent.SimulatedTitusAgent;
 import com.netflix.titus.testkit.embedded.cloud.agent.SimulatedTitusAgentCluster;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -96,6 +97,11 @@ public class SimulatedLocalInstanceCloudConnector implements InstanceCloudConnec
     @Override
     public Observable<List<Instance>> getInstances(List<String> instanceIds) {
         return Observable.fromCallable(() -> instanceIds.stream().map(id -> toInstance(cloud.getAgentInstance(id))).collect(Collectors.toList()));
+    }
+
+    @Override
+    public Mono<Instance> getInstance(String instanceId) {
+        return Mono.fromCallable(() -> toInstance(cloud.getAgentInstance(instanceId)));
     }
 
     @Override

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/StubbedAgentManagementService.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/StubbedAgentManagementService.java
@@ -36,6 +36,7 @@ import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.tuple.Either;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.model.ResourceDimensions;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -164,8 +165,8 @@ class StubbedAgentManagementService implements AgentManagementService {
     }
 
     @Override
-    public Observable<AgentInstance> getAgentInstanceAsync(String instanceId) {
-        return Observable.just(stubbedAgentData.getInstance(instanceId));
+    public Mono<AgentInstance> getAgentInstanceAsync(String instanceId) {
+        return Mono.just(stubbedAgentData.getInstance(instanceId));
     }
 
     @Override

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/StubbedAgentManagementService.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/agent/StubbedAgentManagementService.java
@@ -164,6 +164,11 @@ class StubbedAgentManagementService implements AgentManagementService {
     }
 
     @Override
+    public Observable<AgentInstance> getAgentInstanceAsync(String instanceId) {
+        return Observable.just(stubbedAgentData.getInstance(instanceId));
+    }
+
+    @Override
     public List<AgentInstanceGroup> getInstanceGroups() {
         return stubbedAgentData.getInstanceGroups();
     }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/stub/connector/cloud/TestableInstanceCloudConnector.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/stub/connector/cloud/TestableInstanceCloudConnector.java
@@ -35,6 +35,7 @@ import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.tuple.Either;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.common.util.tuple.Triple;
+import reactor.core.publisher.Mono;
 import rx.Completable;
 import rx.Observable;
 
@@ -88,6 +89,16 @@ public class TestableInstanceCloudConnector implements InstanceCloudConnector {
                 .map(id -> instancesById.get(id).getLeft())
                 .collect(Collectors.toList())
         );
+    }
+
+    @Override
+    public Mono<Instance> getInstance(String instanceId) {
+        return Mono.fromCallable(() -> {
+            if (instancesById.containsKey(instanceId)) {
+                return instancesById.get(instanceId).getLeft();
+            }
+            return null;
+        });
     }
 
     @Override


### PR DESCRIPTION
It contains the following updates to the Kubernetes Node GC controller behavior

1. If node not found in AgentManagementService Cache, EC2 service call is made to fetch the instance status. 
2. If node status not found in the Cache or from the EC2 service call, then it's ignored for GC