### PR TITLE
Remove use of deprecated Reactor retryWhen

### DIFF
--- a/titus-common-ext/kube/src/main/java/com/netflix/titus/ext/kube/clustermembership/connector/KubeClusterMembershipConnector.java
+++ b/titus-common-ext/kube/src/main/java/com/netflix/titus/ext/kube/clustermembership/connector/KubeClusterMembershipConnector.java
@@ -34,6 +34,7 @@ import com.netflix.titus.api.clustermembership.model.event.LeaderElectionChangeE
 import com.netflix.titus.common.framework.simplereconciler.OneOffReconciler;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.rx.ReactorExt;
+import com.netflix.titus.common.util.rx.ReactorRetriers;
 import com.netflix.titus.ext.kube.clustermembership.connector.action.KubeLeaderElectionActions;
 import com.netflix.titus.ext.kube.clustermembership.connector.action.KubeRegistrationActions;
 import org.slf4j.Logger;
@@ -92,7 +93,7 @@ public class KubeClusterMembershipConnector implements ClusterMembershipConnecto
                     }
                     return Mono.empty();
                 })
-                .retryWhen(errors -> errors.flatMap(e -> {
+                .retryWhen(ReactorRetriers.reactorRetryer(e -> {
                     logger.info("Reconnecting membership event stream from Kubernetes terminated with an error: {}", e.getMessage());
                     logger.debug("Stack trace", e);
                     return Flux.interval(reconnectInterval).take(1);
@@ -123,7 +124,7 @@ public class KubeClusterMembershipConnector implements ClusterMembershipConnecto
                     }
                     return Mono.empty();
                 })
-                .retryWhen(errors -> errors.flatMap(e -> {
+                .retryWhen(ReactorRetriers.reactorRetryer(e -> {
                     logger.info("Reconnecting leadership event stream from Kubernetes terminated with an error: {}", e.getMessage());
                     logger.debug("Stack trace", e);
                     return Flux.interval(reconnectInterval).take(1);

--- a/titus-common/src/main/java/com/netflix/titus/common/framework/scheduler/internal/LocalSchedulerTransactionLogger.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/framework/scheduler/internal/LocalSchedulerTransactionLogger.java
@@ -32,7 +32,7 @@ import com.netflix.titus.common.framework.scheduler.model.event.ScheduleUpdateEv
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
-import reactor.core.publisher.Flux;
+import reactor.util.retry.Retry;
 
 import static com.netflix.titus.common.util.CollectionsExt.last;
 
@@ -44,7 +44,7 @@ class LocalSchedulerTransactionLogger {
 
     static Disposable logEvents(LocalScheduler localScheduler) {
         return localScheduler.events()
-                .retryWhen(error -> Flux.just(1).delayElements(RETRY_DELAY))
+                .retryWhen(Retry.fixedDelay(1, RETRY_DELAY))
                 .subscribe(
                         event -> {
                             boolean failure = event.getSchedule().getCurrentAction().getStatus().getError().isPresent();

--- a/titus-common/src/main/java/com/netflix/titus/common/util/rx/RetryHandlerBuilder.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/util/rx/RetryHandlerBuilder.java
@@ -31,6 +31,7 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import reactor.util.retry.Retry;
 import rx.Observable;
 import rx.Scheduler;
 import rx.functions.Action1;
@@ -219,6 +220,15 @@ public final class RetryHandlerBuilder {
                     }
                     return Flux.interval(Duration.ofMillis(expDelay), reactorScheduler).take(1);
                 });
+    }
+
+    public Retry buildRetryExponentialBackoff() {
+        return new Retry() {
+            @Override
+            public Publisher<?> generateCompanion(Flux<RetrySignal> retrySignals) {
+                return buildReactorExponentialBackoff().apply(retrySignals.map(RetrySignal::failure));
+            }
+        };
     }
 
     private long buildDelay(int retry) {

--- a/titus-common/src/test/java/com/netflix/titus/common/util/rx/ReactorRetryHandlerBuilderTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/rx/ReactorRetryHandlerBuilderTest.java
@@ -38,7 +38,7 @@ public class ReactorRetryHandlerBuilderTest {
         StepVerifier
                 .withVirtualTime(() ->
                         streamOf("A", new IOException("Error1"), "B", new IOException("Error2"), "C")
-                                .retryWhen(newRetryHandlerBuilder().buildReactorExponentialBackoff())
+                                .retryWhen(newRetryHandlerBuilder().buildRetryExponentialBackoff())
                 )
                 // Expect first item
                 .expectNext("A")
@@ -59,7 +59,7 @@ public class ReactorRetryHandlerBuilderTest {
         StepVerifier
                 .withVirtualTime(() ->
                         streamOf("A", new ServiceUnavailableException("Retry me"), "B", new IllegalArgumentException("Do not retry me."), "C")
-                                .retryWhen(newRetryHandlerBuilder().withRetryOnThrowable(ex -> ex instanceof ServiceUnavailableException).buildReactorExponentialBackoff())
+                                .retryWhen(newRetryHandlerBuilder().withRetryOnThrowable(ex -> ex instanceof ServiceUnavailableException).buildRetryExponentialBackoff())
                 )
                 .expectNext("A")
                 .expectNoEvent(Duration.ofSeconds(RETRY_DELAY_SEC))
@@ -77,7 +77,7 @@ public class ReactorRetryHandlerBuilderTest {
                         streamOf(new IOException("Error1"), new IOException("Error2"), new IOException("Error3"), "A")
                                 .retryWhen(newRetryHandlerBuilder()
                                         .withMaxDelay(RETRY_DELAY_SEC * 2, TimeUnit.SECONDS)
-                                        .buildReactorExponentialBackoff()
+                                        .buildRetryExponentialBackoff()
                                 )
                 )
                 .expectSubscription()
@@ -96,7 +96,7 @@ public class ReactorRetryHandlerBuilderTest {
                         streamOf(new IOException("Error1"), new IOException("Error2"), "A")
                                 .retryWhen(newRetryHandlerBuilder()
                                         .withRetryCount(1)
-                                        .buildReactorExponentialBackoff()
+                                        .buildRetryExponentialBackoff()
                                 )
                 )
                 .expectSubscription()

--- a/titus-common/src/test/java/com/netflix/titus/common/util/rx/RetryHandlerBuilderTest.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/util/rx/RetryHandlerBuilderTest.java
@@ -20,15 +20,14 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import javax.naming.ServiceUnavailableException;
 
 import com.netflix.titus.testkit.rx.ExtTestSubscriber;
 import io.reactivex.subscribers.TestSubscriber;
 import org.junit.Test;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.test.scheduler.VirtualTimeScheduler;
+import reactor.util.retry.Retry;
 import rx.Observable;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
@@ -159,10 +158,10 @@ public class RetryHandlerBuilderTest {
         TestSubscriber<String> testSubscriber = TestSubscriber.create();
         final VirtualTimeScheduler virtualTimeScheduler = VirtualTimeScheduler.create();
 
-        final Function<Flux<Throwable>, Publisher<?>> retryFun = builder.withUnlimitedRetries()
+        final Retry retryFun = builder.withUnlimitedRetries()
                 .withReactorScheduler(virtualTimeScheduler)
                 .withDelay(RETRY_DELAY_SEC, RETRY_DELAY_SEC * 4, TimeUnit.SECONDS)
-                .buildReactorExponentialBackoff();
+                .buildRetryExponentialBackoff();
 
         Flux.range(1, 100)
                 .map(i -> new RuntimeException("Error " + i))

--- a/titus-ext/eureka/src/main/java/com/netflix/titus/ext/eureka/containerhealth/EurekaContainerHealthService.java
+++ b/titus-ext/eureka/src/main/java/com/netflix/titus/ext/eureka/containerhealth/EurekaContainerHealthService.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -99,7 +98,7 @@ public class EurekaContainerHealthService implements ContainerHealthService {
     @Activator
     public void activate() {
         this.eventLoggerDisposable = healthStatuses
-                .retryWhen(ReactorRetriers.instrumentedRetryer("EurekaContainerHealthServiceEventLogger", RETRY_INTERVAL, logger))
+                .retryWhen(ReactorRetriers.instrumentedReactorRetryer("EurekaContainerHealthServiceEventLogger", RETRY_INTERVAL, logger))
                 .subscribeOn(Schedulers.parallel())
                 .subscribe(
                         event -> logger.info("Eureka health status update: {}", event),

--- a/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskPublisherRetryUtil.java
+++ b/titus-supplementary-component/tasks-publisher/src/main/java/com/netflix/titus/supplementary/taskspublisher/TaskPublisherRetryUtil.java
@@ -16,19 +16,17 @@
 package com.netflix.titus.supplementary.taskspublisher;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 import com.netflix.titus.common.util.rx.RetryHandlerBuilder;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
 
 public class TaskPublisherRetryUtil {
     public static final long INITIAL_RETRY_DELAY_MS = 500;
     public static final long MAX_RETRY_DELAY_MS = 2_000;
 
-    public static Function<Flux<Throwable>, Publisher<?>> buildRetryHandler(long initialRetryDelayMillis,
-                                                                            long maxRetryDelayMillis, int maxRetries) {
+    public static Retry buildRetryHandler(long initialRetryDelayMillis,
+                                          long maxRetryDelayMillis, int maxRetries) {
         RetryHandlerBuilder retryHandlerBuilder = RetryHandlerBuilder.retryHandler();
         if (maxRetries < 0) {
             retryHandlerBuilder.withUnlimitedRetries();
@@ -39,7 +37,7 @@ public class TaskPublisherRetryUtil {
         return retryHandlerBuilder
                 .withDelay(initialRetryDelayMillis, maxRetryDelayMillis, TimeUnit.MILLISECONDS)
                 .withReactorScheduler(Schedulers.elastic())
-                .buildReactorExponentialBackoff();
+                .buildRetryExponentialBackoff();
     }
 
 }


### PR DESCRIPTION
The reactor-core project removed the  `retryWhen(Function<Flux<Throwable>,? extends Publisher<?>> whenFactory)` method in its 3.4.0 release. This PR changes those usages to the supported `retryWhen(Retry retrySpec)` method, which allows projects depending on titus-control-plane libraries (e.g., CMB) AND using reactor-core > 3.4.X to work.