### PR TITLE
TITUS-4588 Add support for EBS persistent volume claims

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
@@ -126,8 +126,11 @@ public class PersistentVolumeUnassociatedGcController extends BaseGcController<V
             return true;
         } catch (ApiException e) {
             if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
-                logger.error("Failed to delete persistent volume: {} with error: ", volumeName, e);
+                // If we did not find the PV return true as it is removed
+                logger.info("Delete for persistent volume {} not found", volumeName);
+                return true;
             }
+            logger.error("Failed to delete persistent volume: {} with error: ", volumeName, e);
         } catch (Exception e) {
             logger.error("Failed to delete persistent volume: {} with error: ", volumeName, e);
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultDirectKubeApiServerIntegratorMetrics.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultDirectKubeApiServerIntegratorMetrics.java
@@ -37,6 +37,7 @@ class DefaultDirectKubeApiServerIntegratorMetrics {
 
     private static final String ROOT = MetricConstants.METRIC_KUBERNETES + "directKubeApiServerIntegrator.";
     private static final String PV_ROOT = ROOT + "persistentVolume.";
+    private static final String PVC_ROOT = ROOT + "persistentVolumeClaim.";
 
     private final Registry registry;
 
@@ -45,6 +46,7 @@ class DefaultDirectKubeApiServerIntegratorMetrics {
     private final Id terminateCounterId;
     private final Id eventCounterId;
     private final Id persistentVolumeCreateCounterId;
+    private final Id persistentVolumeClaimCreateCounterId;
 
     private final BucketCounter podSizeMetrics;
 
@@ -55,6 +57,7 @@ class DefaultDirectKubeApiServerIntegratorMetrics {
         this.terminateCounterId = registry.createId(ROOT + "terminates");
         this.eventCounterId = registry.createId(ROOT + "events");
         this.persistentVolumeCreateCounterId = registry.createId(PV_ROOT + "create");
+        this.persistentVolumeClaimCreateCounterId = registry.createId(PVC_ROOT + "create");
 
         this.podSizeMetrics = BucketCounter.get(
                 registry,
@@ -77,7 +80,18 @@ class DefaultDirectKubeApiServerIntegratorMetrics {
 
     void persistentVolumeCreateError(Throwable error, long elapsedMs) {
         registry.timer(persistentVolumeCreateCounterId.withTags(
-                "status", "success",
+                "status", "error",
+                "error", error.getClass().getSimpleName()
+        )).record(elapsedMs, TimeUnit.MILLISECONDS);
+    }
+
+    void persistentVolumeClaimCreateSuccess(long elapsedMs) {
+        registry.timer(persistentVolumeClaimCreateCounterId.withTag("status", "success")).record(elapsedMs, TimeUnit.MILLISECONDS);
+    }
+
+    void persistentVolumeClaimCreateError(Throwable error, long elapsedMs) {
+        registry.timer(persistentVolumeClaimCreateCounterId.withTags(
+                "status", "error",
                 "error", error.getClass().getSimpleName()
         )).record(elapsedMs, TimeUnit.MILLISECONDS);
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
@@ -61,11 +61,11 @@ import com.netflix.titus.master.mesos.kubeapiserver.direct.taint.TaintToleration
 import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobManagementModelConverters;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import io.kubernetes.client.custom.Quantity;
-import io.kubernetes.client.openapi.models.V1AWSElasticBlockStoreVolumeSource;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimVolumeSource;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
@@ -454,9 +454,9 @@ public class DefaultTaskToPodConverter implements TaskToPodConverter {
                     V1Volume v1Volume = new V1Volume()
                             // The resource name matches the volume ID so that the resource is independent of the job.
                             .name(ebsVolume.getVolumeId())
-                            .awsElasticBlockStore(new V1AWSElasticBlockStoreVolumeSource()
-                                    .volumeID(ebsVolume.getVolumeId())
-                                    .fsType(ebsVolume.getFsType()));
+                            .persistentVolumeClaim(new V1PersistentVolumeClaimVolumeSource()
+                                    .claimName(ebsVolume.getVolumeId()));
+
                     V1VolumeMount v1VolumeMount = new V1VolumeMount()
                             // The mount refers to the V1Volume being mounted
                             .name(ebsVolume.getVolumeId())

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverterTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverterTest.java
@@ -205,8 +205,7 @@ public class DefaultTaskToPodConverterTest {
                     V1VolumeMount v1VolumeMount = pair.getRight();
 
                     assertThat(v1Volume.getName()).isEqualTo(volName2);
-                    assertThat(v1Volume.getAwsElasticBlockStore().getVolumeID()).isEqualTo(volName2);
-                    assertThat(v1Volume.getAwsElasticBlockStore().getFsType()).isEqualTo(fsType);
+                    assertThat(v1Volume.getPersistentVolumeClaim().getClaimName()).isEqualTo(volName2);
 
                     assertThat(v1VolumeMount.getName()).isEqualTo(volName2);
                     assertThat(v1VolumeMount.getMountPath()).isEqualTo(mountPath);


### PR DESCRIPTION
This PR changes how EBS persistent volumes are being used. Persistent volumes directly specify the CSI driver rather than the legacy AWS block store and expecting Kube CSI migration to do the mapping. Also, Persistent volume claims are used rather than the specifying the persistent volume directly on the pod.