### PR TITLE
RFC: Added more verbose and human-friendly reason messages for task updates

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -573,7 +573,10 @@ public class DefaultV3JobOperations implements V3JobOperations {
         return Job.<E>newBuilder()
                 .withId(UUID.randomUUID().toString())
                 .withJobDescriptor(jobDescriptor)
-                .withStatus(JobStatus.newBuilder().withState(JobState.Accepted).build())
+                .withStatus(JobStatus.newBuilder()
+                                .withState(JobState.Accepted)
+                                .withReasonMessage("New Job created. Next tasks will be launched.")
+                                .build())
                 .build();
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -209,7 +209,7 @@ public final class JobManagerUtil {
             TaskStatus taskStatus = JobModel.newTaskStatus()
                     .withState(TaskState.Launched)
                     .withReasonCode("scheduled")
-                    .withReasonMessage("Fenzo task placement")
+                    .withReasonMessage("Fenzo task placement on node " + TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID + ". Next it needs to start.")
                     .withTimestamp(titusRuntime.getClock().wallTime())
                     .build();
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
@@ -170,7 +170,7 @@ public class KubeNotificationProcessor {
 
         TaskStatus newTaskStatus = newTaskStatusOrError.getValue();
         if (TaskStatus.areEquivalent(task.getStatus(), newTaskStatus)) {
-            logger.info("Pod change notification does not change task status: taskId={}, status={}", task.getId(), newTaskStatus);
+            logger.info("Pod change notification does not change task status: taskId={}, status={}", task.getId (), newTaskStatus);
         } else {
             logger.info("Pod notification changes task status: taskId={}, fromStatus={}, toStatus={}", task.getId(),
                     task.getStatus(), newTaskStatus);
@@ -182,7 +182,7 @@ public class KubeNotificationProcessor {
                 task.getId(),
                 current -> updateTaskStatus(podWrapper, newTaskStatus, executorDetailsOpt, node, current),
                 V3JobOperations.Trigger.Kube,
-                "Kube pod notification",
+                "Pod status updated from kubernetes node (k8s pod phase is now '" + event.getPod().getStatus().getPhase() + "')",
                 KUBE_CALL_METADATA
         ));
     }
@@ -205,7 +205,7 @@ public class KubeNotificationProcessor {
                     return Optional.of(updatedTask);
                 },
                 V3JobOperations.Trigger.Kube,
-                "Kube pod notification",
+                "Pod status updated from kubernetes node, it couldn't find the pod " + task.getId(),
                 KUBE_CALL_METADATA
         ));
     }
@@ -319,7 +319,7 @@ public class KubeNotificationProcessor {
 
         TaskStatus.Builder statusTemplate = TaskStatus.newBuilder()
                 .withReasonCode(TaskStatus.REASON_STATE_MISSING)
-                .withReasonMessage("Filled in")
+                .withReasonMessage("Filled in missing state update that was missed previously")
                 .withTimestamp(startAtTimestamp);
 
         List<TaskStatus> missingStatuses = new ArrayList<>();
@@ -355,7 +355,7 @@ public class KubeNotificationProcessor {
         newStatusHistory.add(TaskStatus.newBuilder()
                 .withState(TaskState.Launched)
                 .withReasonCode(TaskStatus.REASON_STATE_MISSING)
-                .withReasonMessage("Filled in")
+                .withReasonMessage("Filled in missing state update that was missed previously due to container setup failure")
                 .withTimestamp(startAtTimestamp)
                 .build()
         );

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/task/BasicTaskActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/task/BasicTaskActions.java
@@ -251,7 +251,7 @@ public class BasicTaskActions {
                                 TaskStatus taskStatus = JobModel.newTaskStatus()
                                         .withState(TaskState.Accepted)
                                         .withReasonCode(TaskStatus.REASON_POD_CREATED)
-                                        .withReasonMessage("Created pod in Kube")
+                                        .withReasonMessage("Created pod in Kubernetes via KubeScheduler. Needs to be scheduled on a node.")
                                         .withTimestamp(titusRuntime.getClock().wallTime())
                                         .build();
                                 Task taskWithPod = task.toBuilder()

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -776,13 +776,13 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
             Optional<TaskStatus> startInitiatedOpt = JobFunctions.findTaskStatus(task, StartInitiated);
             if (!startInitiatedOpt.isPresent()) {
                 logger.debug("Publishing missing task status: StartInitiated for task: {}", taskId);
-                publishContainerEvent(taskId, StartInitiated, TaskStatus.REASON_NORMAL, "",
+                publishContainerEvent(taskId, StartInitiated, TaskStatus.REASON_NORMAL, "(Filling in missed event)",
                         executorDetailsOpt, timestampOpt);
             }
             Optional<TaskStatus> startedOpt = JobFunctions.findTaskStatus(task, Started);
             if (!startedOpt.isPresent()) {
                 logger.debug("Publishing missing task status: Started for task: {}", taskId);
-                publishContainerEvent(taskId, Started, TaskStatus.REASON_NORMAL, "",
+                publishContainerEvent(taskId, Started, TaskStatus.REASON_NORMAL, "(Filling in missed event)",
                         executorDetailsOpt, timestampOpt);
             }
         }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
@@ -141,7 +141,7 @@ public class KubeNotificationProcessorTest {
         podEvents.onNext(PodEvent.onUpdate(oldPod, updatedPod, Optional.empty()));
 
         verify(jobOperations, times(1)).updateTask(eq(TASK.getId()), changeFunctionCaptor.capture(), eq(V3JobOperations.Trigger.Kube),
-                eq("Kube pod notification"), any());
+                eq("Pod status updated from kubernetes node (k8s pod phase is now 'Pending')"), any());
 
         Function<Task, Optional<Task>> changeFunction = changeFunctionCaptor.getValue();
         assertThat(changeFunction).isNotNull();
@@ -207,7 +207,7 @@ public class KubeNotificationProcessorTest {
         podEvents.onNext(PodEvent.onAdd(pod));
 
         verify(jobOperations, times(1)).updateTask(eq(TASK.getId()), changeFunctionCaptor.capture(), eq(V3JobOperations.Trigger.Kube),
-                eq("Kube pod notification"), any());
+                eq("Pod status updated from kubernetes node (k8s pod phase is now 'Failed')"), any());
     }
 
     @Test


### PR DESCRIPTION
The real reason I started on this PR was because I couldn't remember how to tell if something was scheduled via kubescheduler.

Then I thought how nice it would be if in the reason message it was more explicit about how thing are going. Like what is the "real" state of things, and what is going to happen next (if applicable).

After all, what does "accepted" really mean? 

I was unable to track down where `created`, `running`, and `<not_given>` (no reason message) came from.

Anyway, seemed like it would be a nice to have, and better messages can assure our users (me) that the thing is working (or not). I'm not super familiar with this codebase or java.