### PR TITLE
add a default kill wait timeout per job type instead of a global default

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoRequestFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/DefaultV3TaskInfoRequestFactory.java
@@ -161,7 +161,13 @@ public class DefaultV3TaskInfoRequestFactory implements TaskInfoRequestFactory {
         String attributeKillWaitSeconds = containerAttributes.get(JOB_PARAMETER_ATTRIBUTES_KILL_WAIT_SECONDS);
         Integer killWaitSeconds = attributeKillWaitSeconds == null ? null : Ints.tryParse(attributeKillWaitSeconds);
         if (killWaitSeconds == null || killWaitSeconds < mesosConfiguration.getMinKillWaitSeconds() || killWaitSeconds > mesosConfiguration.getMaxKillWaitSeconds()) {
-            killWaitSeconds = mesosConfiguration.getDefaultKillWaitSeconds();
+            if (JobFunctions.isBatchJob(job)) {
+                killWaitSeconds = mesosConfiguration.getBatchDefaultKillWaitSeconds();
+            } else if (JobFunctions.isServiceJob(job)) {
+                killWaitSeconds = mesosConfiguration.getServiceDefaultKillWaitSeconds();
+            } else {
+                killWaitSeconds = mesosConfiguration.getMinKillWaitSeconds();
+            }
         }
         containerInfoBuilder.setKillWaitSeconds(killWaitSeconds);
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/MesosConfiguration.java
@@ -76,10 +76,16 @@ public interface MesosConfiguration {
     int getMaxKillWaitSeconds();
 
     /**
-     * @return maximum amount of seconds to wait before forcefully terminating a container.
+     * @return maximum amount of seconds to wait before forcefully terminating a batch job container.
      */
     @DefaultValue("10")
-    int getDefaultKillWaitSeconds();
+    int getBatchDefaultKillWaitSeconds();
+
+    /**
+     * @return maximum amount of seconds to wait before forcefully terminating a service job container.
+     */
+    @DefaultValue("120")
+    int getServiceDefaultKillWaitSeconds();
 
     /**
      * @return whether or not to override the executor URI on an agent.

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
@@ -271,7 +271,13 @@ public class DefaultTaskToPodConverter implements TaskToPodConverter {
         String attributeKillWaitSeconds = containerAttributes.get(JOB_PARAMETER_ATTRIBUTES_KILL_WAIT_SECONDS);
         Integer killWaitSeconds = attributeKillWaitSeconds == null ? null : Ints.tryParse(attributeKillWaitSeconds);
         if (killWaitSeconds == null || killWaitSeconds < configuration.getMinKillWaitSeconds() || killWaitSeconds > configuration.getMaxKillWaitSeconds()) {
-            killWaitSeconds = configuration.getDefaultKillWaitSeconds();
+            if (JobFunctions.isBatchJob(job)) {
+                killWaitSeconds = configuration.getBatchDefaultKillWaitSeconds();
+            } else if (JobFunctions.isServiceJob(job)) {
+                killWaitSeconds = configuration.getServiceDefaultKillWaitSeconds();
+            } else {
+                killWaitSeconds = configuration.getMinKillWaitSeconds();
+            }
         }
         containerInfoBuilder.setKillWaitSeconds(killWaitSeconds);
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
@@ -53,10 +53,16 @@ public interface DirectKubeConfiguration extends KubeConnectorConfiguration {
     int getMaxKillWaitSeconds();
 
     /**
-     * @return maximum amount of seconds to wait before forcefully terminating a container.
+     * @return maximum amount of seconds to wait before forcefully terminating a batch job container.
      */
     @DefaultValue("10")
-    int getDefaultKillWaitSeconds();
+    int getBatchDefaultKillWaitSeconds();
+
+    /**
+     * @return maximum amount of seconds to wait before forcefully terminating a service job container.
+     */
+    @DefaultValue("120")
+    int getServiceDefaultKillWaitSeconds();
 
     /**
      * Thread pool size for handling Kube apiClient calls.


### PR DESCRIPTION
### Description of the Change

* Add a default kill wait timeout per job type instead of a global default.