### PR TITLE
Make the titus-relocation kill reasons more verbose

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -472,8 +472,9 @@ public class DefaultV3JobOperations implements V3JobOperations {
                         }
                         reasonCode = TaskStatus.REASON_SCALED_DOWN;
                     }
-                    String reason = String.format("%s %s(shrink=%s)", Evaluators.getOrDefault(CallMetadataUtils.getFirstCallerId(callMetadata), "<no_caller>"),
-                            Evaluators.getOrDefault(callMetadata.getCallReason(), "<no_reason>"), shrink);
+                    String reason = String.format("%s %s shrink=%s", Evaluators.getOrDefault(callMetadata.getCallReason(), "No reason specified"),
+                            Evaluators.getOrDefault(CallMetadataUtils.getFirstCallerId(callMetadata), "<no_caller>"),
+                            shrink);
                     ChangeAction killAction = KillInitiatedActions.userInitiateTaskKillAction(
                             engineChildPair.getLeft(), vmService, kubeApiServerIntegrator, store, task.getId(), shrink, preventMinSizeUpdate, reasonCode, reason, titusRuntime, callMetadata
                     );

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/util/RelocationPredicates.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/util/RelocationPredicates.java
@@ -57,23 +57,23 @@ public class RelocationPredicates {
         }
 
         if (isRelocationRequired(task)) {
-            return Optional.of("Task tagged for relocation");
+            return Optional.of("Task terminated because it was marked for relocation, and this was a safe time per this job's Disruption Budget");
         }
 
         if (isRelocationRequiredBy(job, task)) {
             long jobTimestamp = getJobTimestamp(job, RelocationAttributes.RELOCATION_REQUIRED_BY);
             long taskTimestamp = getTaskCreateTimestamp(task);
             if (jobTimestamp >= taskTimestamp) {
-                return Optional.of("Job tagged for relocation for tasks created before " + DateTimeExt.toUtcDateTimeString(jobTimestamp));
+                return Optional.of("Task terminated because tasks before " + DateTimeExt.toUtcDateTimeString(jobTimestamp) + " were marked for relocation");
             }
         }
 
         if (instance.isRelocationRequired()) {
-            return Optional.of("Agent instance tagged for eviction");
+            return Optional.of("Task terminated because the underlying Titus Agent was tagged for eviction, and this was a safe time per this job's Disruption Budget");
         }
 
         if (instance.isServerGroupRelocationRequired()) {
-            return Optional.of("Agent instance group tagged for eviction");
+            return Optional.of("Task terminated because the underlying Titus Agent instance group tagged for eviction, and this was a safe time per this job's Disruption Budget");
         }
 
         return Optional.empty();
@@ -81,15 +81,15 @@ public class RelocationPredicates {
 
     public static Optional<Pair<RelocationTrigger, String>> checkIfMustBeRelocatedImmediately(Job<?> job, Task task, Node instance) {
         if (instance.isRelocationRequiredImmediately()) {
-            return Optional.of(Pair.of(RelocationTrigger.Instance, "Agent instance tagged for immediate eviction"));
+            return Optional.of(Pair.of(RelocationTrigger.Instance, "Task terminated because the underlying Titus Agent was tagged for immediate eviction, regardless of the Disruption Budget"));
         }
 
         if (isRelocationRequiredImmediately(task)) {
-            return Optional.of(Pair.of(RelocationTrigger.Task, "Task marked for immediate eviction"));
+            return Optional.of(Pair.of(RelocationTrigger.Task, "Task terminated because the it was marked for immediate eviction, regardless of the Disruption Budget"));
         }
 
         if (isRelocationRequiredByImmediately(job, task)) {
-            return Optional.of(Pair.of(RelocationTrigger.Job, "Job marked for immediate eviction"));
+            return Optional.of(Pair.of(RelocationTrigger.Job, "Task terminated because the whole job was marked for immediate eviction, regardless of the Disruption Budget"));
         }
 
         return Optional.empty();
@@ -97,12 +97,12 @@ public class RelocationPredicates {
 
     public static Optional<Pair<RelocationTrigger, String>> checkIfRelocationRequired(Job<?> job, Task task) {
         if (isRelocationRequired(task)) {
-            return Optional.of(Pair.of(RelocationTrigger.Task, "Task marked for eviction"));
+            return Optional.of(Pair.of(RelocationTrigger.Task, "Task terminated because the it was marked for eviction, and this was a safe time per this job's Disruption Budget"));
         }
 
         if (isRelocationRequiredBy(job, task)) {
             long timestamp = getJobTimestamp(job, RelocationAttributes.RELOCATION_REQUIRED_BY);
-            return Optional.of(Pair.of(RelocationTrigger.Job, String.format("Job tasks created before %s marked for eviction", DateTimeExt.toUtcDateTimeString(timestamp))));
+            return Optional.of(Pair.of(RelocationTrigger.Job, String.format("Job's tasks terminated because tasks launched before %s were marked for relocation", DateTimeExt.toUtcDateTimeString(timestamp))));
         }
 
         return Optional.empty();
@@ -110,7 +110,7 @@ public class RelocationPredicates {
 
     public static Optional<Pair<RelocationTrigger, String>> checkIfRelocationRequired(Job<?> job, Task task, Node instance) {
         if (instance.isRelocationRequired()) {
-            return Optional.of(Pair.of(RelocationTrigger.Instance, "Agent tagged for eviction"));
+            return Optional.of(Pair.of(RelocationTrigger.Instance, "Task terminated because the underlying Titus Agent was tagged for eviction, and this was a safe time per this job's Disruption Budget"));
         }
         return checkIfRelocationRequired(job, task);
     }

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/step/TaskEvictionStep.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/step/TaskEvictionStep.java
@@ -87,7 +87,7 @@ public class TaskEvictionStep {
                 .collect(Collectors.toMap(
                         TaskRelocationPlan::getTaskId,
                         p -> {
-                            String message = String.format("%s: reasonCode=%s, plannedRelocationTime=%s",
+                            String message = String.format("%s reasonCode=%s plannedRelocationTime=%s",
                                     p.getReasonMessage(), p.getReason(), DateTimeExt.toUtcDateTimeString(p.getRelocationTime())
                             );
                             return evictionServiceClient.terminateTask(p.getTaskId(), message).timeout(EVICTION_TIMEOUT);

--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
@@ -118,7 +118,7 @@ public class DefaultDeschedulerServiceTest {
             TaskRelocationPlan plan = result.getTaskRelocationPlan();
             assertThat(plan.getReason()).isEqualTo(TaskRelocationReason.TaskMigration);
             if (isImmediateJobMigration) {
-                assertThat(plan.getReasonMessage()).containsSequence("Job marked for immediate eviction");
+                assertThat(plan.getReasonMessage()).containsSequence("Task terminated because the whole job was marked for immediate eviction, regardless of the Disruption Budget");
             } else {
                 assertThat(plan.getReasonMessage()).containsSequence("Enough quota to migrate the task");
             }


### PR DESCRIPTION
This does 2 things:

1. Makes the reason front and center in the message.
Previously this kinda looked like a k=v pairs.
2. Makes the messages more verbose.
Hopefully that is a good thing.
My main goal is to always actually say "why", where the
why needs have something about the disruption budget.

I tried to make it clear when we were respecting the jobs budget, and when we can't.
Hopefully that will make things less confusing for our users, and maybe a tad more sympathetic.