### PR TITLE
System disruption window override support

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -396,6 +396,10 @@ public final class JobFunctions {
         return job -> job.toBuilder().withId(jobId).build();
     }
 
+    public static <E extends JobDescriptorExt> Function<Job<E>, Job<E>> withApplicationName(String appName) {
+        return job -> job.toBuilder().withJobDescriptor(job.getJobDescriptor().toBuilder().withApplicationName(appName).build()).build();
+    }
+
     public static Function<JobDescriptor<BatchJobExt>, JobDescriptor<BatchJobExt>> ofBatchSize(int size) {
         return jd -> JobFunctions.changeBatchJobSize(jd, size);
     }

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/EvictionConfiguration.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/EvictionConfiguration.java
@@ -11,7 +11,7 @@ public interface EvictionConfiguration {
      * Pattern identifying application names that will be exempt from system disruption budget constraints
      */
     @DefaultValue("titusOps")
-    String getAppsExemptFromSystemDisruptionBudget();
+    String getAppsExemptFromSystemDisruptionWindow();
 }
 
 

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/EvictionConfiguration.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/EvictionConfiguration.java
@@ -1,0 +1,17 @@
+package com.netflix.titus.runtime.connector.eviction;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Configuration(prefix = "titus.eviction")
+public interface EvictionConfiguration {
+    /**
+     * Pattern identifying application names that will be exempt from system disruption budget constraints
+     */
+    @DefaultValue("titusOps")
+    String getAppsExemptFromSystemDisruptionBudget();
+}
+
+

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/EvictionRejectionReasons.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/EvictionRejectionReasons.java
@@ -1,0 +1,16 @@
+package com.netflix.titus.runtime.connector.eviction;
+
+public enum EvictionRejectionReasons {
+    LIMIT_EXCEEDED("System eviction quota limit exceeded"),
+    SYSTEM_WINDOW_CLOSED("Outside system time window");
+
+    private String reasonMessage;
+
+    EvictionRejectionReasons(String reasonMessage) {
+        this.reasonMessage = reasonMessage;
+    }
+
+    public String getReasonMessage() {
+        return reasonMessage;
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/EvictionServiceModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/EvictionServiceModule.java
@@ -25,6 +25,7 @@ import com.netflix.titus.master.eviction.service.quota.job.ArchaiusEffectiveJobD
 import com.netflix.titus.master.eviction.service.quota.job.EffectiveJobDisruptionBudgetResolver;
 import com.netflix.titus.master.eviction.service.quota.system.ArchaiusSystemDisruptionBudgetResolver;
 import com.netflix.titus.master.eviction.service.quota.system.SystemDisruptionBudgetResolver;
+import com.netflix.titus.runtime.connector.eviction.EvictionConfiguration;
 
 public class EvictionServiceModule extends AbstractModule {
     @Override
@@ -38,5 +39,11 @@ public class EvictionServiceModule extends AbstractModule {
     @Singleton
     public EvictionServiceConfiguration getEvictionServiceConfiguration(ConfigProxyFactory factory) {
         return factory.newProxy(EvictionServiceConfiguration.class);
+    }
+
+    @Provides
+    @Singleton
+    public EvictionConfiguration getEvictionConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(EvictionConfiguration.class);
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaConsumptionResults.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaConsumptionResults.java
@@ -1,7 +1,9 @@
 package com.netflix.titus.master.eviction.service.quota.system;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.netflix.titus.master.eviction.service.quota.ConsumptionResult;
+import com.netflix.titus.runtime.connector.eviction.EvictionRejectionReasons;
 
 public class SystemQuotaConsumptionResults {
-	private static final Logger logger = LoggerFactory.getLogger(SystemQuotaConsumptionResults.class);
+    public static final ConsumptionResult QUOTA_LIMIT_EXCEEDED = ConsumptionResult.rejected(EvictionRejectionReasons.LIMIT_EXCEEDED.getReasonMessage());
+    public static final ConsumptionResult OUTSIDE_SYSTEM_TIME_WINDOW = ConsumptionResult.rejected(EvictionRejectionReasons.SYSTEM_WINDOW_CLOSED.getReasonMessage());
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaConsumptionResults.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaConsumptionResults.java
@@ -1,0 +1,7 @@
+package com.netflix.titus.master.eviction.service.quota.system;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SystemQuotaConsumptionResults {
+	private static final Logger logger = LoggerFactory.getLogger(SystemQuotaConsumptionResults.class);
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/eviction/service/quota/system/SystemQuotaController.java
@@ -40,6 +40,8 @@ import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 
 import static com.netflix.titus.common.util.rx.ReactorRetriers.instrumentedRetryer;
+import static com.netflix.titus.master.eviction.service.quota.system.SystemQuotaConsumptionResults.OUTSIDE_SYSTEM_TIME_WINDOW;
+import static com.netflix.titus.master.eviction.service.quota.system.SystemQuotaConsumptionResults.QUOTA_LIMIT_EXCEEDED;
 
 @Singleton
 public class SystemQuotaController implements QuotaController<Void> {
@@ -50,10 +52,6 @@ public class SystemQuotaController implements QuotaController<Void> {
     private static final Duration DEFAULT_RETRY_INTERVAL = Duration.ofSeconds(5);
 
     private static final String NAME = "system";
-
-    private static final ConsumptionResult QUOTA_LIMIT_EXCEEDED = ConsumptionResult.rejected("System eviction quota limit exceeded");
-    private static final ConsumptionResult OUTSIDE_SYSTEM_TIME_WINDOW = ConsumptionResult.rejected("Outside system time window");
-
     private final TitusRuntime titusRuntime;
 
     private final SystemQuotaMetrics metrics;

--- a/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/TitusQuotasManagerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/TitusQuotasManagerTest.java
@@ -62,14 +62,14 @@ public class TitusQuotasManagerTest {
         when(config1.getAppsExemptFromSystemDisruptionBudget()).thenReturn("app1.*");
         TitusQuotasManager titusQuotasManager = new TitusQuotasManager(null, null, null, null,
                 config1, null);
-        boolean jobExemptFromSystemDisruptionBudget = titusQuotasManager.isJobExemptFromSystemDisruptionBudget(job1);
+        boolean jobExemptFromSystemDisruptionBudget = titusQuotasManager.isJobExemptFromSystemDisruptionWindow(job1);
         assertThat(jobExemptFromSystemDisruptionBudget).isTrue();
 
         EvictionConfiguration config2 = mock(EvictionConfiguration.class);
         when(config2.getAppsExemptFromSystemDisruptionBudget()).thenReturn("app2.*");
         TitusQuotasManager titusQuotasManager2 = new TitusQuotasManager(null, null, null, null,
                 config2, null);
-        boolean jobExemptFromSystemDisruptionBudget2 = titusQuotasManager2.isJobExemptFromSystemDisruptionBudget(job1);
+        boolean jobExemptFromSystemDisruptionBudget2 = titusQuotasManager2.isJobExemptFromSystemDisruptionWindow(job1);
         assertThat(jobExemptFromSystemDisruptionBudget2).isFalse();
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/TitusQuotasManagerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/TitusQuotasManagerTest.java
@@ -1,0 +1,69 @@
+package com.netflix.titus.master.eviction.service.quota;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.master.eviction.service.quota.job.JobQuotaController;
+import com.netflix.titus.master.eviction.service.quota.system.SystemQuotaController;
+import com.netflix.titus.runtime.connector.eviction.EvictionConfiguration;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Test;
+
+import static com.netflix.titus.api.jobmanager.model.job.JobFunctions.withApplicationName;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TitusQuotasManagerTest {
+    @Test
+    public void tryConsumeSystemAndJobQuota() {
+        String taskId = "job1Task1";
+        String jobQuotaRejectionReason = "Job does not allow any more terminations";
+        String systemQuotaRejectionReason = "System is on fire";
+
+        Job<BatchJobExt> job1 = JobGenerator.oneBatchJob().but(withApplicationName("app1Test"));
+        EvictionConfiguration config1 = mock(EvictionConfiguration.class);
+        when(config1.getAppsExemptFromSystemDisruptionBudget()).thenReturn("foo.*");
+        SystemQuotaController systemQuotaController = mock(SystemQuotaController.class);
+        when(systemQuotaController.consume(taskId)).thenReturn(ConsumptionResult.approved());
+        JobQuotaController jobQuotaController = mock(JobQuotaController.class);
+        when(jobQuotaController.consume(taskId)).thenReturn(ConsumptionResult.rejected(jobQuotaRejectionReason));
+
+        TitusQuotasManager titusQuotasManager = new TitusQuotasManager(null, null, null, systemQuotaController,
+                config1, null);
+
+        ConsumptionResult consumptionResult = titusQuotasManager.tryConsumeSystemAndJobQuota(jobQuotaController, job1, taskId);
+        assertThat(consumptionResult.isApproved()).isFalse();
+        assertThat(consumptionResult.getRejectionReason()).isPresent();
+        assertThat(consumptionResult.getRejectionReason().get()).isEqualTo(jobQuotaRejectionReason);
+
+        JobQuotaController jobQuotaController2 = mock(JobQuotaController.class);
+        when(jobQuotaController2.consume(taskId)).thenReturn(ConsumptionResult.approved());
+        ConsumptionResult consumptionResult2 = titusQuotasManager.tryConsumeSystemAndJobQuota(jobQuotaController2, job1, taskId);
+        assertThat(consumptionResult2.isApproved()).isTrue();
+
+        when(systemQuotaController.consume(taskId)).thenReturn(ConsumptionResult.rejected(systemQuotaRejectionReason));
+        ConsumptionResult consumptionResult3 = titusQuotasManager.tryConsumeSystemAndJobQuota(jobQuotaController2, job1, taskId);
+        assertThat(consumptionResult3.isApproved()).isFalse();
+        assertThat(consumptionResult3.getRejectionReason()).isPresent();
+        assertThat(consumptionResult3.getRejectionReason().get()).isEqualTo(systemQuotaRejectionReason);
+    }
+
+    @Test
+    public void isJobExemptFromSystemDisruptionBudget() {
+        Job<BatchJobExt> job1 = JobGenerator.oneBatchJob().but(withApplicationName("app1Test"));
+
+        EvictionConfiguration config1 = mock(EvictionConfiguration.class);
+        when(config1.getAppsExemptFromSystemDisruptionBudget()).thenReturn("app1.*");
+        TitusQuotasManager titusQuotasManager = new TitusQuotasManager(null, null, null, null,
+                config1, null);
+        boolean jobExemptFromSystemDisruptionBudget = titusQuotasManager.isJobExemptFromSystemDisruptionBudget(job1);
+        assertThat(jobExemptFromSystemDisruptionBudget).isTrue();
+
+        EvictionConfiguration config2 = mock(EvictionConfiguration.class);
+        when(config2.getAppsExemptFromSystemDisruptionBudget()).thenReturn("app2.*");
+        TitusQuotasManager titusQuotasManager2 = new TitusQuotasManager(null, null, null, null,
+                config2, null);
+        boolean jobExemptFromSystemDisruptionBudget2 = titusQuotasManager2.isJobExemptFromSystemDisruptionBudget(job1);
+        assertThat(jobExemptFromSystemDisruptionBudget2).isFalse();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/TitusQuotasManagerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/eviction/service/quota/TitusQuotasManagerTest.java
@@ -22,7 +22,7 @@ public class TitusQuotasManagerTest {
 
         Job<BatchJobExt> job1 = JobGenerator.oneBatchJob().but(withApplicationName("app1Test"));
         EvictionConfiguration config1 = mock(EvictionConfiguration.class);
-        when(config1.getAppsExemptFromSystemDisruptionBudget()).thenReturn("app1.*");
+        when(config1.getAppsExemptFromSystemDisruptionWindow()).thenReturn("app1.*");
         SystemQuotaController systemQuotaController = mock(SystemQuotaController.class);
         when(systemQuotaController.consume(taskId)).thenReturn(ConsumptionResult.approved());
         JobQuotaController jobQuotaController = mock(JobQuotaController.class);
@@ -55,18 +55,18 @@ public class TitusQuotasManagerTest {
     }
 
     @Test
-    public void isJobExemptFromSystemDisruptionBudget() {
+    public void isJobExemptFromSystemDisruptionWindow() {
         Job<BatchJobExt> job1 = JobGenerator.oneBatchJob().but(withApplicationName("app1Test"));
 
         EvictionConfiguration config1 = mock(EvictionConfiguration.class);
-        when(config1.getAppsExemptFromSystemDisruptionBudget()).thenReturn("app1.*");
+        when(config1.getAppsExemptFromSystemDisruptionWindow()).thenReturn("app1.*");
         TitusQuotasManager titusQuotasManager = new TitusQuotasManager(null, null, null, null,
                 config1, null);
         boolean jobExemptFromSystemDisruptionBudget = titusQuotasManager.isJobExemptFromSystemDisruptionWindow(job1);
         assertThat(jobExemptFromSystemDisruptionBudget).isTrue();
 
         EvictionConfiguration config2 = mock(EvictionConfiguration.class);
-        when(config2.getAppsExemptFromSystemDisruptionBudget()).thenReturn("app2.*");
+        when(config2.getAppsExemptFromSystemDisruptionWindow()).thenReturn("app2.*");
         TitusQuotasManager titusQuotasManager2 = new TitusQuotasManager(null, null, null, null,
                 config2, null);
         boolean jobExemptFromSystemDisruptionBudget2 = titusQuotasManager2.isJobExemptFromSystemDisruptionWindow(job1);

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
@@ -35,6 +35,7 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.time.Clock;
 import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.runtime.connector.eviction.EvictionConfiguration;
 import com.netflix.titus.supplementary.relocation.connector.Node;
 import com.netflix.titus.supplementary.relocation.connector.NodeDataResolver;
 import com.netflix.titus.supplementary.relocation.model.DeschedulingFailure;
@@ -51,16 +52,19 @@ public class DefaultDeschedulerService implements DeschedulerService {
     private final NodeDataResolver nodeDataResolver;
 
     private final TitusRuntime titusRuntime;
+    private final EvictionConfiguration evictionConfiguration;
     private final Clock clock;
 
     @Inject
     public DefaultDeschedulerService(ReadOnlyJobOperations jobOperations,
                                      ReadOnlyEvictionOperations evictionOperations,
                                      NodeDataResolver nodeDataResolver,
+                                     EvictionConfiguration evictionConfiguration,
                                      TitusRuntime titusRuntime) {
         this.jobOperations = jobOperations;
         this.evictionOperations = evictionOperations;
         this.nodeDataResolver = nodeDataResolver;
+        this.evictionConfiguration = evictionConfiguration;
         this.clock = titusRuntime.getClock();
         this.titusRuntime = titusRuntime;
     }
@@ -77,7 +81,12 @@ public class DefaultDeschedulerService implements DeschedulerService {
         EvictionQuotaTracker evictionQuotaTracker = new EvictionQuotaTracker(evictionOperations, jobs);
 
         TaskMigrationDescheduler taskMigrationDescheduler = new TaskMigrationDescheduler(
-                plannedAheadTaskRelocationPlans, evacuatedAgentsAllocationTracker, evictionQuotaTracker, jobs, tasksById, titusRuntime
+                plannedAheadTaskRelocationPlans,
+                evacuatedAgentsAllocationTracker,
+                evictionQuotaTracker,
+                evictionConfiguration,
+                jobs, tasksById,
+                titusRuntime
         );
 
         Map<String, DeschedulingResult> requestedImmediateEvictions = taskMigrationDescheduler.findAllImmediateEvictions();

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DeschedulerComponent.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DeschedulerComponent.java
@@ -19,6 +19,7 @@ package com.netflix.titus.supplementary.relocation.descheduler;
 import com.netflix.titus.api.eviction.service.ReadOnlyEvictionOperations;
 import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
 import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.runtime.connector.eviction.EvictionConfiguration;
 import com.netflix.titus.supplementary.relocation.connector.NodeDataResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,7 +31,8 @@ public class DeschedulerComponent {
     public DeschedulerService getDeschedulerService(ReadOnlyJobOperations jobOperations,
                                                     ReadOnlyEvictionOperations evictionOperations,
                                                     NodeDataResolver nodeDataResolver,
+                                                    EvictionConfiguration evictionConfiguration,
                                                     TitusRuntime titusRuntime) {
-        return new DefaultDeschedulerService(jobOperations, evictionOperations, nodeDataResolver, titusRuntime);
+        return new DefaultDeschedulerService(jobOperations, evictionOperations, nodeDataResolver, evictionConfiguration, titusRuntime);
     }
 }

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/TaskRelocationWorkflowComponent.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/TaskRelocationWorkflowComponent.java
@@ -19,6 +19,7 @@ package com.netflix.titus.supplementary.relocation.workflow;
 import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.archaius2.Archaius2Ext;
+import com.netflix.titus.runtime.connector.eviction.EvictionConfiguration;
 import com.netflix.titus.runtime.connector.eviction.EvictionDataReplicator;
 import com.netflix.titus.runtime.connector.eviction.EvictionServiceClient;
 import com.netflix.titus.runtime.connector.jobmanager.JobDataReplicator;
@@ -37,6 +38,11 @@ public class TaskRelocationWorkflowComponent {
     @Bean
     public RelocationConfiguration getRelocationConfiguration(Environment environment) {
         return Archaius2Ext.newConfiguration(RelocationConfiguration.class, environment);
+    }
+
+    @Bean
+    public EvictionConfiguration getEvictionConfiguration(Environment environment) {
+        return Archaius2Ext.newConfiguration(EvictionConfiguration.class, environment);
     }
 
     @Bean
@@ -66,11 +72,11 @@ public class TaskRelocationWorkflowComponent {
 
     @Bean
     public NodeConditionController getNodeConditionCtrl(RelocationConfiguration configuration,
-                                                               NodeDataResolver nodeDataResolver,
-                                                               JobDataReplicator jobDataReplicator,
-                                                               ReadOnlyJobOperations readOnlyJobOperations,
-                                                               JobManagementClient jobManagementClient,
-                                                               TitusRuntime titusRuntime) {
+                                                        NodeDataResolver nodeDataResolver,
+                                                        JobDataReplicator jobDataReplicator,
+                                                        ReadOnlyJobOperations readOnlyJobOperations,
+                                                        JobManagementClient jobManagementClient,
+                                                        TitusRuntime titusRuntime) {
         return new DefaultNodeConditionController(configuration, nodeDataResolver,
                 jobDataReplicator, readOnlyJobOperations, jobManagementClient, titusRuntime);
     }

--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
@@ -34,6 +34,7 @@ import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.time.TestClock;
 import com.netflix.titus.runtime.RelocationAttributes;
 import com.netflix.titus.runtime.connector.agent.AgentDataReplicator;
+import com.netflix.titus.runtime.connector.eviction.EvictionConfiguration;
 import com.netflix.titus.supplementary.relocation.RelocationConfiguration;
 import com.netflix.titus.supplementary.relocation.RelocationConnectorStubs;
 import com.netflix.titus.supplementary.relocation.TestDataFactory;
@@ -87,6 +88,7 @@ public class DefaultDeschedulerServiceTest {
             new AgentManagementNodeDataResolver(dataGenerator.getAgentOperations(), agentDataReplicator, instance -> true,
                     mock(RelocationConfiguration.class),
                     TestDataFactory.mockKubeApiFacade()),
+            () -> "foo|bar",
             titusRuntime
     );
 

--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/TaskMigrationDeschedulerTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/TaskMigrationDeschedulerTest.java
@@ -61,7 +61,6 @@ import static com.netflix.titus.testkit.model.eviction.DisruptionBudgetGenerator
 import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskServiceJobDescriptor;
 import static com.netflix.titus.testkit.model.job.JobTestFunctions.toTaskMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
### Support for system disruption override for applications

Titus-relocation service processes task relocations / migrations based on 
1. System disruption quota (rate limit)
2. System disruption window (configurable)
3. Job disruption budget

There are use-cases where an application would want to override the default behavior of when their containers can get migrated with respect to System disruption window. For applications who would want to be exempt from subjecting to System Disruption window could now be configured with "titus.eviction.appsExemptFromSystemDisruptionWindow" property.

The apps configured with this property are still subject to system level rate limit (quota) as long as the system disruption window is open. But when it's closed, these apps will ONLY be subject to job level eviction quota configured through disruption budget from the job description.