### PR TITLE
Fix PVC usage to prevent concurrent PV assignment

### DIFF
--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
@@ -23,6 +23,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1Pod;
 
 public interface KubeApiFacade {
@@ -38,6 +39,8 @@ public interface KubeApiFacade {
     SharedIndexInformer<V1Pod> getPodInformer();
 
     SharedIndexInformer<V1PersistentVolume> getPersistentVolumeInformer();
+
+    SharedIndexInformer<V1PersistentVolumeClaim> getPersistentVolumeClaimInformer();
 
     /**
      * Provide information about how up to date the pod informer data is. If the pod informer is connected, and synced

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/NoOpKubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/NoOpKubeApiFacade.java
@@ -23,6 +23,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1Pod;
 
 public class NoOpKubeApiFacade implements KubeApiFacade {
@@ -54,6 +55,11 @@ public class NoOpKubeApiFacade implements KubeApiFacade {
 
     @Override
     public SharedIndexInformer<V1PersistentVolume> getPersistentVolumeInformer() {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public SharedIndexInformer<V1PersistentVolumeClaim> getPersistentVolumeClaimInformer() {
         throw new IllegalStateException("Kubernetes not supported");
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/KubeControllerModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/KubeControllerModule.java
@@ -25,6 +25,8 @@ import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
 
 import static com.netflix.titus.master.kubernetes.controller.NodeGcController.NODE_GC_CONTROLLER;
+import static com.netflix.titus.master.kubernetes.controller.PersistentVolumeClaimGcController.PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER;
+import static com.netflix.titus.master.kubernetes.controller.PersistentVolumeReclaimController.PERSISTENT_VOLUME_RECLAIM_CONTROLLER;
 import static com.netflix.titus.master.kubernetes.controller.PersistentVolumeUnassociatedGcController.PERSISTENT_VOLUME_UNASSOCIATED_GC_CONTROLLER;
 import static com.netflix.titus.master.kubernetes.controller.PodDeletionGcController.POD_DELETION_GC_CONTROLLER;
 import static com.netflix.titus.master.kubernetes.controller.PodOnUnknownNodeGcController.POD_ON_UNKNOWN_NODE_GC_CONTROLLER;
@@ -41,6 +43,8 @@ public class KubeControllerModule extends AbstractModule {
         bind(PodTerminalGcController.class).asEagerSingleton();
         bind(PodUnknownGcController.class).asEagerSingleton();
         bind(PersistentVolumeUnassociatedGcController.class).asEagerSingleton();
+        bind(PersistentVolumeClaimGcController.class).asEagerSingleton();
+        bind(PersistentVolumeReclaimController.class).asEagerSingleton();
     }
 
     @Provides
@@ -131,5 +135,33 @@ public class KubeControllerModule extends AbstractModule {
     @Named(PERSISTENT_VOLUME_UNASSOCIATED_GC_CONTROLLER)
     public ControllerConfiguration getPersistentVolumeUnassociatedGcControllerConfiguration(ConfigProxyFactory factory) {
         return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + PERSISTENT_VOLUME_UNASSOCIATED_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER)
+    public FixedIntervalTokenBucketConfiguration getPersistentVolumeClaimGcControllerTokenBucketConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(FixedIntervalTokenBucketConfiguration.class, "titus.kubernetes.controller." + PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER)
+    public ControllerConfiguration getPersistentVolumeClaimGcControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(PERSISTENT_VOLUME_RECLAIM_CONTROLLER)
+    public FixedIntervalTokenBucketConfiguration getPersistentVolumeReclaimControllerTokenBucketConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(FixedIntervalTokenBucketConfiguration.class, "titus.kubernetes.controller." + PERSISTENT_VOLUME_RECLAIM_CONTROLLER);
+    }
+
+    @Provides
+    @Singleton
+    @Named(PERSISTENT_VOLUME_RECLAIM_CONTROLLER)
+    public ControllerConfiguration getPersistentVolumeReclaimControllerConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(ControllerConfiguration.class, "titus.kubernetes.controller." + PERSISTENT_VOLUME_RECLAIM_CONTROLLER);
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.master.mesos.kubeapiserver.direct.KubeModelConverters;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.netflix.titus.api.jobmanager.model.job.TaskState.isTerminalState;
+import static com.netflix.titus.master.mesos.kubeapiserver.KubeObjectFormatter.formatPvcEssentials;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.DEFAULT_NAMESPACE;
+import static com.netflix.titus.runtime.kubernetes.KubeConstants.NOT_FOUND;
+
+/**
+ * Garbage collects persistent volume claims that are not associated with active/non-terminal tasks.
+ */
+@Singleton
+public class PersistentVolumeClaimGcController extends BaseGcController<V1PersistentVolumeClaim> {
+
+    private static final Logger logger = LoggerFactory.getLogger(PersistentVolumeClaimGcController.class);
+
+    public static final String PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER = "persistentVolumeClaimGcController";
+    public static final String PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER_DESCRIPTION = "GC persistent volume claims that are no longer associated with active tasks.";
+
+    private final KubeApiFacade kubeApiFacade;
+    private final V3JobOperations v3JobOperations;
+
+    @Inject
+    public PersistentVolumeClaimGcController(TitusRuntime titusRuntime,
+                                             LocalScheduler scheduler,
+                                             @Named(PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER) FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+                                             @Named(PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER) ControllerConfiguration controllerConfiguration,
+                                             KubeApiFacade kubeApiFacade,
+                                             V3JobOperations v3JobOperations) {
+        super(
+                PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER,
+                PERSISTENT_VOLUME_CLAIM_GC_CONTROLLER_DESCRIPTION,
+                titusRuntime,
+                scheduler,
+                tokenBucketConfiguration,
+                controllerConfiguration
+        );
+
+        this.kubeApiFacade = kubeApiFacade;
+        this.v3JobOperations = v3JobOperations;
+    }
+
+    @Override
+    public boolean shouldGc() {
+        return kubeApiFacade.getPersistentVolumeInformer().hasSynced();
+    }
+
+    @Override
+    public List<V1PersistentVolumeClaim> getItemsToGc() {
+        return kubeApiFacade.getPersistentVolumeClaimInformer().getIndexer().list();
+    }
+
+    @Override
+    public boolean gcItem(V1PersistentVolumeClaim pvc) {
+        // Extract the task ID embedded in the PVC's name
+        String taskId = KubeModelConverters.getTaskIdFromPvc(pvc);
+
+        Optional<Pair<Job<?>, Task>> optionalJobTaskPair = v3JobOperations.findTaskById(taskId);
+        if (!optionalJobTaskPair.isPresent()) {
+            // If we could not find a task for the PVC, GC it.
+            logger.info("Did not find task {} for pvc {}", taskId, formatPvcEssentials(pvc));
+            return gcPersistentVolumeClaim(pvc);
+        }
+        // If the task is terminal, GC it.
+        return isTerminalState(optionalJobTaskPair.get().getRight().getStatus().getState()) && gcPersistentVolumeClaim(pvc);
+    }
+
+    private boolean gcPersistentVolumeClaim(V1PersistentVolumeClaim pvc) {
+        String volumeClaimName = KubeUtil.getMetadataName(pvc.getMetadata());
+        try {
+            // If the PVC is deleted while still in use by a pod (though that is not expected), the PVC
+            // will not be removed until no pod is using it.
+            // https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection
+            kubeApiFacade.getCoreV1Api().deleteNamespacedPersistentVolumeClaim(
+                    volumeClaimName,
+                    DEFAULT_NAMESPACE,
+                    null,
+                    null,
+                    0,
+                    null,
+                    null,
+                    null
+            );
+            logger.info("Successfully deleted persistent volume claim {}", formatPvcEssentials(pvc));
+            return true;
+        } catch (ApiException e) {
+            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+                // If we did not find the PVC return true as it is removed
+                logger.info("Delete for persistent volume claim {} not found", formatPvcEssentials(pvc));
+                return true;
+            }
+            logger.error("Failed to delete persistent volume claim: {} with error: ", formatPvcEssentials(pvc), e);
+        } catch (Exception e) {
+            logger.error("Failed to delete persistent volume claim: {} with error: ", formatPvcEssentials(pvc), e);
+        }
+        return false;
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeReclaimController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeReclaimController.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import io.kubernetes.client.openapi.models.V1PersistentVolume;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeBuilder;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeSpec;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeSpecBuilder;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.netflix.titus.master.mesos.kubeapiserver.KubeObjectFormatter.formatPvEssentials;
+
+/**
+ * Reclaims persistent volumes that are released from persistent volume claims that no longer exist.
+ */
+@Singleton
+public class PersistentVolumeReclaimController extends BaseGcController<V1PersistentVolume> {
+
+    private static final Logger logger = LoggerFactory.getLogger(PersistentVolumeReclaimController.class);
+
+    public static final String PERSISTENT_VOLUME_RECLAIM_CONTROLLER = "persistentVolumeReclaimController";
+    public static final String PERSISTENT_VOLUME_RECLAIM_CONTROLLER_DESCRIPTION = "GC persistent volumes that are no longer associated with active jobs.";
+
+    private final KubeApiFacade kubeApiFacade;
+
+    @Inject
+    public PersistentVolumeReclaimController(TitusRuntime titusRuntime,
+                                             LocalScheduler scheduler,
+                                             @Named(PERSISTENT_VOLUME_RECLAIM_CONTROLLER) FixedIntervalTokenBucketConfiguration tokenBucketConfiguration,
+                                             @Named(PERSISTENT_VOLUME_RECLAIM_CONTROLLER) ControllerConfiguration controllerConfiguration,
+                                             KubeApiFacade kubeApiFacade) {
+        super(
+                PERSISTENT_VOLUME_RECLAIM_CONTROLLER,
+                PERSISTENT_VOLUME_RECLAIM_CONTROLLER_DESCRIPTION,
+                titusRuntime,
+                scheduler,
+                tokenBucketConfiguration,
+                controllerConfiguration
+        );
+
+        this.kubeApiFacade = kubeApiFacade;
+    }
+
+    @Override
+    public boolean shouldGc() {
+        return kubeApiFacade.getPersistentVolumeInformer().hasSynced();
+    }
+
+    @Override
+    public List<V1PersistentVolume> getItemsToGc() {
+        return kubeApiFacade.getPersistentVolumeInformer().getIndexer().list().stream()
+                // Only consider PVs that have been Released (i.e., the PVC in its claimRef has been deleted).
+                .filter(this::isPvReleased)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean gcItem(V1PersistentVolume v1PersistentVolume) {
+        logger.info("Reclaiming pv {}", formatPvEssentials(v1PersistentVolume));
+
+        V1PersistentVolumeSpec spec = v1PersistentVolume.getSpec() == null ? new V1PersistentVolumeSpec() : v1PersistentVolume.getSpec();
+        // Reclaim the pv by removing the claimRef.
+        V1PersistentVolume updatedPv = new V1PersistentVolumeBuilder(v1PersistentVolume)
+                .withSpec(new V1PersistentVolumeSpecBuilder(spec).build().claimRef(null))
+                .build();
+        try {
+            kubeApiFacade.getCoreV1Api().replacePersistentVolume(
+                    KubeUtil.getMetadataName(updatedPv.getMetadata()),
+                    updatedPv,
+                    null,
+                    null,
+                    null
+            );
+            logger.info("Successfully reclaimed pv {}", formatPvEssentials(updatedPv));
+        } catch (Exception e) {
+            logger.error("Failed to reclaim pv {} with error: ", formatPvEssentials(v1PersistentVolume), e);
+            return false;
+        }
+
+        return true;
+    }
+
+    @VisibleForTesting
+    boolean isPvReleased(V1PersistentVolume v1PersistentVolume) {
+        V1PersistentVolumeStatus status = v1PersistentVolume.getStatus() == null
+                ? new V1PersistentVolumeStatus()
+                : v1PersistentVolume.getStatus();
+        return status.getPhase() == null || status.getPhase().equalsIgnoreCase("Released");
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultDirectKubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultDirectKubeApiServerIntegrator.java
@@ -248,7 +248,7 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
         // Create a persistent volume followed by a claim for that volume
         // If the attempt to create the PVC fails, the PV will be subsequently garbage collected
         return launchEbsPersistentVolume(ebsVolume, coreV1Api)
-                .flatMap(v1PersistentVolume -> launchPersistentVolumeClaim(v1PersistentVolume, coreV1Api))
+                .flatMap(v1PersistentVolume -> launchPersistentVolumeClaim(v1PersistentVolume, v1Pod, coreV1Api))
                 .then();
     }
 
@@ -277,11 +277,11 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
         });
     }
 
-    private Mono<V1PersistentVolumeClaim> launchPersistentVolumeClaim(V1PersistentVolume v1PersistentVolume, CoreV1Api coreV1Api) {
+    private Mono<V1PersistentVolumeClaim> launchPersistentVolumeClaim(V1PersistentVolume v1PersistentVolume, V1Pod v1Pod, CoreV1Api coreV1Api) {
         return Mono.defer(() -> {
             Stopwatch timer = Stopwatch.createStarted();
 
-            V1PersistentVolumeClaim v1PersistentVolumeClaim = KubeModelConverters.toV1PersistentVolumeClaim(v1PersistentVolume);
+            V1PersistentVolumeClaim v1PersistentVolumeClaim = KubeModelConverters.toV1PersistentVolumeClaim(v1PersistentVolume, v1Pod);
             logger.info("Creating persistent volume claim {}", v1PersistentVolumeClaim);
 
             try {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverter.java
@@ -470,7 +470,7 @@ public class DefaultTaskToPodConverter implements TaskToPodConverter {
                             // The resource name matches the volume ID so that the resource is independent of the job.
                             .name(ebsVolume.getVolumeId())
                             .persistentVolumeClaim(new V1PersistentVolumeClaimVolumeSource()
-                                    .claimName(ebsVolume.getVolumeId()));
+                                    .claimName(KubeModelConverters.toPvcName(ebsVolume.getVolumeId(), task.getId())));
 
                     V1VolumeMount v1VolumeMount = new V1VolumeMount()
                             // The mount refers to the V1Volume being mounted

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcControllerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.controller;
+
+import java.util.Optional;
+
+import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.framework.scheduler.LocalScheduler;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PersistentVolumeClaimGcControllerTest {
+
+    private static final String PERSISTENT_VOLUME_NAME = "vol-1";
+    private static final Job<BatchJobExt> BATCH_JOB = JobGenerator.oneBatchJob();
+    private static final BatchJobTask BATCH_TASK = JobGenerator.batchTasks(BATCH_JOB).getValue();
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test();
+    private final FixedIntervalTokenBucketConfiguration tokenBucketConfiguration = mock(FixedIntervalTokenBucketConfiguration.class);
+    private final ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
+    private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
+    private final LocalScheduler scheduler = mock(LocalScheduler.class);
+    private final V3JobOperations v3JobOperations = mock(V3JobOperations.class);
+    private final CoreV1Api coreV1Api = mock(CoreV1Api.class);
+
+    private final PersistentVolumeClaimGcController pvcGcController = new PersistentVolumeClaimGcController(
+            titusRuntime,
+            scheduler,
+            tokenBucketConfiguration,
+            controllerConfiguration,
+            kubeApiFacade,
+            v3JobOperations
+    );
+
+    @Before
+    public void setUp() {
+        when(kubeApiFacade.getCoreV1Api()).thenReturn(coreV1Api);
+    }
+
+    /**
+     * Tests that a PVC that is Bound is not GC'd.
+     */
+    @Test
+    public void testBoundPvc() {
+        String taskId = BATCH_TASK.getId();
+        V1PersistentVolumeClaim v1PersistentVolumeClaim = new V1PersistentVolumeClaim()
+                .metadata(new V1ObjectMeta()
+                        .name(PERSISTENT_VOLUME_NAME + "." + taskId))
+                .status(new V1PersistentVolumeClaimStatus()
+                        .phase("Bound"));
+
+        when(v3JobOperations.findTaskById(taskId)).thenReturn(Optional.of(Pair.of(BATCH_JOB, BATCH_TASK)));
+
+        assertThat(pvcGcController.gcItem(v1PersistentVolumeClaim)).isFalse();
+    }
+
+    /**
+     * Tests that a PVC that is released is GC'd.
+     */
+    @Test
+    public void testReleasedPvc() {
+        String taskId = BATCH_TASK.getId();
+        V1PersistentVolumeClaim v1PersistentVolumeClaim = new V1PersistentVolumeClaim()
+                .metadata(new V1ObjectMeta()
+                        .name(PERSISTENT_VOLUME_NAME + "." + taskId))
+                .status(new V1PersistentVolumeClaimStatus()
+                        .phase("Bound"));
+
+        when(v3JobOperations.findTaskById(taskId)).thenReturn(Optional.empty());
+
+        assertThat(pvcGcController.gcItem(v1PersistentVolumeClaim)).isTrue();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverterTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultTaskToPodConverterTest.java
@@ -215,6 +215,7 @@ public class DefaultTaskToPodConverterTest {
                 .addToTaskContext(TaskAttributes.TASK_ATTRIBUTES_EBS_VOLUME_ID, volName2)
                 .build();
 
+        String pvcName = KubeModelConverters.toPvcName(volName2, task.getId());
         assertThat(converter.buildV1VolumeInfo(job, task))
                 .isPresent()
                 .hasValueSatisfying(pair -> {
@@ -222,7 +223,7 @@ public class DefaultTaskToPodConverterTest {
                     V1VolumeMount v1VolumeMount = pair.getRight();
 
                     assertThat(v1Volume.getName()).isEqualTo(volName2);
-                    assertThat(v1Volume.getPersistentVolumeClaim().getClaimName()).isEqualTo(volName2);
+                    assertThat(v1Volume.getPersistentVolumeClaim().getClaimName()).isEqualTo(pvcName);
 
                     assertThat(v1VolumeMount.getName()).isEqualTo(volName2);
                     assertThat(v1VolumeMount.getMountPath()).isEqualTo(mountPath);


### PR DESCRIPTION
This PR fixes an issue with how PVCs were used that allowed a PV to be used by more than one pod at a time. With this change:

1. Each PVC is specific to the PV/pod pair and is not shared across tasks/pods. This prevent concurrent use of the PV.
2. PVCs are GC'd when the task/pod they are bound is terminal.
3. PVs are reclaimed (made available for reuse) when their PVCs are deleted.

Though less relevant if we choose to go with a less "Kubernetes-native" EBS approach, this is still useful because it fixes that Kubernetes-native feature that already exists.