### PR TITLE
Assign jobs belonging to KubeScheduler capacity groups to KubeScheduler always

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -267,6 +267,10 @@ public final class JobFunctions {
         return findConstraint(job.getJobDescriptor().getContainer().getHardConstraints(), name);
     }
 
+    public static <E extends JobDescriptorExt> Optional<String> findHardConstraint(JobDescriptor<E> jobDescriptor, String name) {
+        return findConstraint(jobDescriptor.getContainer().getHardConstraints(), name);
+    }
+
     /**
      * Constraint names are case insensitive.
      */

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/batch/BatchDifferenceResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/batch/BatchDifferenceResolver.java
@@ -66,7 +66,6 @@ import com.netflix.titus.master.jobmanager.service.common.action.task.KillInitia
 import com.netflix.titus.master.jobmanager.service.common.interceptor.RetryActionInterceptor;
 import com.netflix.titus.master.jobmanager.service.event.JobManagerReconcilerEvent;
 import com.netflix.titus.master.mesos.VirtualMachineMasterService;
-import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeApiServerIntegrator;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.DirectKubeConfiguration;
 import com.netflix.titus.master.scheduler.SchedulingService;
@@ -257,8 +256,7 @@ public class BatchDifferenceResolver implements ReconciliationEngine.DifferenceR
 
         JobDescriptor jobDescriptor = refJobView.getJob().getJobDescriptor();
         ApplicationSLA capacityGroupDescriptor = JobManagerUtil.getCapacityGroupDescriptor(jobDescriptor, capacityGroupService);
-        if (KubeUtil.findFarzoneId(kubeConfiguration, refJobView.getJob()).isPresent()
-                || kubeSchedulerPredicate.test(Pair.of(jobDescriptor, capacityGroupDescriptor))) {
+        if (JobManagerUtil.shouldAssignToKubeScheduler(refJobView.getJob(), capacityGroupDescriptor, kubeConfiguration, kubeSchedulerPredicate)) {
             taskContext = CollectionsExt.copyAndAdd(taskContext, TaskAttributes.TASK_ATTRIBUTES_OWNED_BY_KUBE_SCHEDULER, "true");
         }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/ServiceDifferenceResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/ServiceDifferenceResolver.java
@@ -279,7 +279,7 @@ public class ServiceDifferenceResolver implements ReconciliationEngine.Differenc
 
         JobDescriptor jobDescriptor = refJobView.getJob().getJobDescriptor();
         ApplicationSLA capacityGroupDescriptor = JobManagerUtil.getCapacityGroupDescriptor(jobDescriptor, capacityGroupService);
-        if (KubeUtil.findFarzoneId(kubeConfiguration, refJobView.getJob()).isPresent() || kubeSchedulerPredicate.test(Pair.of(jobDescriptor, capacityGroupDescriptor))) {
+        if (JobManagerUtil.shouldAssignToKubeScheduler(refJobView.getJob(), capacityGroupDescriptor, kubeConfiguration, kubeSchedulerPredicate)) {
             taskContext = CollectionsExt.copyAndAdd(taskContext, TaskAttributes.TASK_ATTRIBUTES_OWNED_BY_KUBE_SCHEDULER, "true");
         }
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/FeatureFlagModule.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/FeatureFlagModule.java
@@ -186,7 +186,7 @@ public class FeatureFlagModule extends AbstractModule {
         );
 
         Function<String, Matcher> enabledMachineTypes = RegExpExt.dynamicMatcher(configuration::getEnabledMachineTypes,
-                "titus.features.jobManager." + KUBE_SCHEDULER_FEATURE + "EnabledMachineTypes", Pattern.DOTALL, logger);
+                "titus.features.jobManager.kubeSchedulerFeature.enabledMachineTypes", Pattern.DOTALL, logger);
 
         return p -> {
             JobDescriptor<?> jobDescriptor = p.getLeft();

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/KubeSchedulerFeatureConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/KubeSchedulerFeatureConfiguration.java
@@ -29,38 +29,9 @@ public interface KubeSchedulerFeatureConfiguration {
     boolean isGpuEnabled();
 
     /**
-     * Enable container size limit check. Containers large than the limit are not be assigned to KubeScheduler.
+     * Jobs with machine type hard constraint which request machine types not allowed by this regexp pattern, will be
+     * assigned to Fenzo.
      */
-    @DefaultValue("true")
-    boolean isContainerSizeLimitEnabled();
-
-    /**
-     * Maximum CPU allocation managed by KubeScheduler.
-     */
-    @DefaultValue("16")
-    int getCpuLimit();
-
-    /**
-     * Maximum GPU allocation managed by KubeScheduler.
-     */
-    @DefaultValue("1")
-    int getGpuLimit();
-
-    /**
-     * Maximum memory allocation managed by KubeScheduler.
-     */
-    @DefaultValue("131072")
-    int getMemoryMBLimit();
-
-    /**
-     * Maximum disk allocation managed by KubeScheduler.
-     */
-    @DefaultValue("262144")
-    int getDiskMBLimit();
-
-    /**
-     * Maximum network allocation managed by KubeScheduler.
-     */
-    @DefaultValue("4000")
-    int getNetworkMbpsLimit();
+    @DefaultValue(".*")
+    String getEnabledMachineTypes();
 }


### PR DESCRIPTION
Assign jobs belonging to KubeScheduler capacity groups to KubeScheduler always.
Add machineType KubeScheduler routing rule
