### PR TITLE
Add pod annotations for EBS volumes and disable PV/PVC creation

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -67,6 +67,10 @@ public class KubePodUtil {
                 task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_OPPORTUNISTIC_CPU_ALLOCATION),
                 id -> annotations.put(KubeConstants.OPPORTUNISTIC_ID, id)
         );
+        Evaluators.acceptNotNull(
+                task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_IP_ALLOCATION_ID),
+                id -> annotations.put(KubeConstants.STATIC_IP_ALLOCATION_ID, id)
+        );
 
         annotations.putAll(createEbsPodAnnotations(job, task));
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -17,7 +17,9 @@
 package com.netflix.titus.master.kubernetes.pod;
 
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -26,6 +28,7 @@ import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.grpc.protogen.JobDescriptor;
@@ -65,6 +68,8 @@ public class KubePodUtil {
                 id -> annotations.put(KubeConstants.OPPORTUNISTIC_ID, id)
         );
 
+        annotations.putAll(createEbsPodAnnotations(job, task));
+
         if (includeJobDescriptor) {
             JobDescriptor grpcJobDescriptor = GrpcJobManagementModelConverters.toGrpcJobDescriptor(job.getJobDescriptor());
             try {
@@ -91,6 +96,29 @@ public class KubePodUtil {
                 containerAttributes.get(JobAttributes.JOB_CONTAINER_ATTRIBUTE_SUBNETS),
                 accountId -> annotations.put(KubeConstants.POD_LABEL_SUBNETS, accountId)
         );
+        return annotations;
+    }
+
+    public static Map<String, String> createEbsPodAnnotations(Job<?> job, Task task) {
+        Map<String, String> annotations = new HashMap<>();
+
+        List<EbsVolume> ebsVolumes = job.getJobDescriptor().getContainer().getContainerResources().getEbsVolumes();
+        if (ebsVolumes.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        EbsVolume ebsVolume = job.getJobDescriptor().getContainer().getContainerResources().getEbsVolumes().get(0);
+
+        String ebsVolumeId = task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_EBS_VOLUME_ID);
+        if (ebsVolumeId == null) {
+            logger.error("Expected to find assigned EBS volume ID to task {} from volumes {}", task.getId(), ebsVolumes);
+            return Collections.emptyMap();
+        }
+
+        annotations.put(KubeConstants.EBS_VOLUME_ID, ebsVolumeId);
+        annotations.put(KubeConstants.EBS_MOUNT_PERMISSIONS, ebsVolume.getMountPermissions().toString());
+        annotations.put(KubeConstants.EBS_MOUNT_PATH, ebsVolume.getMountPath());
+        annotations.put(KubeConstants.EBS_FS_TYPE, ebsVolume.getFsType());
+
         return annotations;
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/PodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/PodFactory.java
@@ -21,5 +21,5 @@ import com.netflix.titus.api.jobmanager.model.job.Task;
 import io.kubernetes.client.openapi.models.V1Pod;
 
 public interface PodFactory {
-    V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler);
+    V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler, boolean useKubePv);
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -155,7 +155,7 @@ public class V0SpecPodFactory implements PodFactory {
     }
 
     @Override
-    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler) {
+    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler, boolean useKubePv) {
         String taskId = task.getId();
         TitanProtos.ContainerInfo containerInfo = buildContainerInfo(job, task);
         Map<String, String> annotations = KubePodUtil.createPodAnnotations(job, task, containerInfo.toByteArray(),
@@ -210,9 +210,8 @@ public class V0SpecPodFactory implements PodFactory {
         if (!useKubeScheduler) {
             spec.setNodeName(task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID));
         }
-
         Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildV1VolumeInfo(job, task);
-        if (optionalEbsVolumeInfo.isPresent()) {
+        if (useKubePv && optionalEbsVolumeInfo.isPresent()) {
             spec.addVolumesItem(optionalEbsVolumeInfo.get().getLeft());
             container.addVolumeMountsItem(optionalEbsVolumeInfo.get().getRight());
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -562,7 +562,7 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
     }
 
     private V1Pod newTaskInfoToPod(TaskInfoRequest taskInfoRequest) {
-        return podFactory.buildV1Pod(taskInfoRequest.getJob(), taskInfoRequest.getTask(), false);
+        return podFactory.buildV1Pod(taskInfoRequest.getJob(), taskInfoRequest.getTask(), false, directKubeConfiguration.isEbsVolumePvEnabled());
     }
 
     private V1Pod oldTaskInfoToPod(TaskInfoRequest taskInfoRequest) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DirectKubeConfiguration.java
@@ -64,4 +64,10 @@ public interface DirectKubeConfiguration extends KubeConnectorConfiguration {
      */
     @DefaultValue("false")
     boolean isKubeApiServerIntegratorOldPodCreationEnabled();
+
+    /**
+     * Set to true to enable EBS PV and PVC management.
+     */
+    @DefaultValue("false")
+    boolean isEbsVolumePvEnabled();
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactoryTest.java
@@ -258,7 +258,7 @@ public class V0SpecPodFactoryTest {
         when(jobCoordinatorConfiguration.isContainerInfoEnvEnabled()).thenReturn(false);
         when(podAffinityFactory.buildV1Affinity(job, batchJobTask)).thenReturn(Pair.of(new V1Affinity(), new HashMap<>()));
 
-        V1Pod v1Pod = podFactory.buildV1Pod(job, batchJobTask, true);
+        V1Pod v1Pod = podFactory.buildV1Pod(job, batchJobTask, true, false);
         String encodedContainerInfo = v1Pod.getMetadata().getAnnotations().get("containerInfo");
         ContainerInfo containerInfo = ContainerInfo.parseFrom(Base64.getDecoder().decode(encodedContainerInfo.getBytes()));
         assertThat(containerInfo.getUserProvidedEnvMap()).isEmpty();
@@ -282,7 +282,7 @@ public class V0SpecPodFactoryTest {
         );
 
         when(podAffinityFactory.buildV1Affinity(job, task)).thenReturn(Pair.of(new V1Affinity(), new HashMap<>()));
-        V1Pod pod = podFactory.buildV1Pod(job, task, true);
+        V1Pod pod = podFactory.buildV1Pod(job, task, true, false);
 
         assertThat(pod.getMetadata().getLabels()).containsEntry(
                 KubeConstants.LABEL_CAPACITY_GROUP, "mygroup"

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -43,6 +43,8 @@ public final class KubeConstants {
     /**
      * Common prefix for Titus node annotations/labels and taints.
      */
+    public static final String NETFLIX_DOMAIN = "netflix.com/";
+
     public static final String TITUS_DOMAIN = "titus.netflix.com/";
 
     public static final String TITUS_NODE_DOMAIN = "node.titus.netflix.com/";
@@ -179,4 +181,14 @@ public final class KubeConstants {
      * Reconciler Event Constants
      */
     public static final String NODE_LOST = "NodeLost";
+
+    /**
+     * Volume annotations.
+     */
+    public static final String VOLUME_DOMAIN = "volume." + NETFLIX_DOMAIN;
+    public static final String EBS_DOMAIN = "ebs." + VOLUME_DOMAIN;
+    public static final String EBS_VOLUME_ID = EBS_DOMAIN + "volumeId";
+    public static final String EBS_MOUNT_PERMISSIONS = EBS_DOMAIN + "mountPerm";
+    public static final String EBS_MOUNT_PATH = EBS_DOMAIN + "mountPath";
+    public static final String EBS_FS_TYPE = EBS_DOMAIN + "fsType";
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -187,8 +187,8 @@ public final class KubeConstants {
      */
     public static final String VOLUME_DOMAIN = "volume." + NETFLIX_DOMAIN;
     public static final String EBS_DOMAIN = "ebs." + VOLUME_DOMAIN;
-    public static final String EBS_VOLUME_ID = EBS_DOMAIN + "volumeId";
-    public static final String EBS_MOUNT_PERMISSIONS = EBS_DOMAIN + "mountPerm";
-    public static final String EBS_MOUNT_PATH = EBS_DOMAIN + "mountPath";
-    public static final String EBS_FS_TYPE = EBS_DOMAIN + "fsType";
+    public static final String EBS_VOLUME_ID = EBS_DOMAIN + "volume-id";
+    public static final String EBS_MOUNT_PERMISSIONS = EBS_DOMAIN + "mount-perm";
+    public static final String EBS_MOUNT_PATH = EBS_DOMAIN + "mount-path";
+    public static final String EBS_FS_TYPE = EBS_DOMAIN + "fs-type";
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -191,4 +191,10 @@ public final class KubeConstants {
     public static final String EBS_MOUNT_PERMISSIONS = EBS_DOMAIN + "mount-perm";
     public static final String EBS_MOUNT_PATH = EBS_DOMAIN + "mount-path";
     public static final String EBS_FS_TYPE = EBS_DOMAIN + "fs-type";
+
+    /**
+     * Network annotations.
+     */
+    public static final String NETWORK_DOMAIN = "network." + NETFLIX_DOMAIN;
+    public static final String STATIC_IP_ALLOCATION_ID = NETWORK_DOMAIN + "static-ip-allocation-uuid";
 }


### PR DESCRIPTION
Adds the following pod annotations to a pod for EBS configuration:
```
"ebs.volume.netflix.com/fsType": "xfs",
"ebs.volume.netflix.com/mountPath": "/ebs_mnt",
"ebs.volume.netflix.com/mountPerm": "RW",
"ebs.volume.netflix.com/volumeId": "vol-09a13c88ebc5c3597",
```

And disable creation of EBS PV and PVCs.