### PR TITLE
Upgrade to modern Gradle/Nebula to replace Bintray publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
 }
 
 plugins {
-    id 'nebula.netflixoss' version '8.7.0'
-    id 'nebula.ospackage' version '8.1.0'
+    id 'nebula.netflixoss' version '9.1.0'
+    id 'nebula.ospackage' version '8.5.6'
 }
 
 ext.useMavenLocal = project.hasProperty('useMavenLocal') ? project.getProperty('useMavenLocal').toBoolean() : false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scripts/ci/circleci/publish-release
+++ b/scripts/ci/circleci/publish-release
@@ -12,12 +12,12 @@ fi
 
 case "$tag" in
 *-rc\.*)
-  ./gradlew -Prelease.useLastTag=true -PbintrayUser="${bintrayUser:-}" -PbintrayKey="${bintrayKey:-}" \
-    -PsonatypeUsername="${sonatypeUsername:-}" -PsonatypePassword="${sonatypePassword:-}" candidate -x test --stacktrace
+  ./gradlew -Prelease.useLastTag=true -PnetflixOssUsername="${netflixOssRepoUsername:-}" -PnetflixOssPassword="${netflixOssRepoPassword:-}" \
+    -PsonatypeUsername="${sonatypeUsername:-}" -PsonatypePassword="${sonatypePassword:-}" -PsigningKey="${sonatypeUsername:-}" -PsigningPassword="${sonatypePassword:-}" candidate -x test --stacktrace
   ;;
 *)
-  ./gradlew -Prelease.useLastTag=true -PbintrayUser="${bintrayUser:-}" -PbintrayKey="${bintrayKey:-}" \
-    -PsonatypeUsername="${sonatypeUsername:-}" -PsonatypePassword="${sonatypePassword:-}" final -x test --stacktrace
+  ./gradlew -Prelease.useLastTag=true -PnetflixOssUsername="${netflixOssRepoUsername:-}" -PnetflixOssPassword="${netflixOssRepoPassword:-}" \
+    -PsonatypeUsername="${sonatypeUsername:-}" -PsonatypePassword="${sonatypePassword:-}" -PsigningKey="${sonatypeUsername:-}" -PsigningPassword="${sonatypePassword:-}" final -x test --stacktrace
   ;;
 esac
 


### PR DESCRIPTION
Hi folks,

As you might be aware, JFrog is sunsetting Bintray and JCenter: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This upgrades to Nebula NetflixOSS which will publish to Nebula's OSS repos and Maven Central.

Repositories based on status:

* https://netflixoss.jfrog.io/artifactory/maven-oss-snapshots
* https://netflixoss.jfrog.io/artifactory/maven-oss-candidates
* https://netflixoss.jfrog.io/artifactory/maven-oss-releases

I went ahead and added the environment variables in https://app.circleci.com/settings/project/github/Netflix/titus-control-plane/environment-variables 

Please verify the change when trying to publish. Since we don't support CircleCI, we haven't try it out with other projects

We are also starting to recommend folks to use Github Actions. If you would like to migrate, please reach out the CI team at Netflix
