### PR TITLE
Job attribute for security auth context

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -141,6 +141,20 @@ public final class JobAttributes {
      */
     public static final String JOB_PARAMETER_TERMINATE_ON_BAD_AGENT = TITUS_PARAMETER_ATTRIBUTE_PREFIX + "terminateContainerOnBadAgent";
 
+    /*
+     * Job security attributes.
+     */
+
+    /**
+     * Prefix for attributes derived from Job Metatron details.
+     */
+    public static final String METATRON_ATTRIBUTE_PREFIX = "metatron.";
+
+    /**
+     * The Metatron auth context received from Metatron for the metatron signed job.
+     */
+    public static final String JOB_SECURITY_ATTRIBUTE_METATRON_AUTH_CONTEXT = METATRON_ATTRIBUTE_PREFIX + "authContext";
+
     // Container Attributes
 
     /**

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -512,6 +512,30 @@ public final class JobFunctions {
         return input.toBuilder().withJobDescriptor(jobDescriptor.toBuilder().withAttributes(updatedAttributes).build()).build();
     }
 
+    public static <E extends JobDescriptorExt> JobDescriptor<E> appendJobSecurityAttributes(JobDescriptor<E> input, Map<String, String> attributes) {
+        SecurityProfile securityProfile = input.getContainer().getSecurityProfile();
+        Map<String, String> updatedAttributes = CollectionsExt.merge(securityProfile.getAttributes(), attributes);
+        return input.toBuilder()
+                .withContainer(input.getContainer().toBuilder()
+                        .withSecurityProfile(securityProfile.toBuilder()
+                                .withAttributes(updatedAttributes)
+                                .build())
+                        .build())
+                .build();
+    }
+
+    public static <E extends JobDescriptorExt> JobDescriptor<E> deleteJobSecurityAttributes(JobDescriptor<E> input, Set<String> keys) {
+        SecurityProfile securityProfile = input.getContainer().getSecurityProfile();
+        Map<String, String> updatedAttributes = CollectionsExt.copyAndRemove(securityProfile.getAttributes(), keys);
+        return input.toBuilder()
+                .withContainer(input.getContainer().toBuilder()
+                        .withSecurityProfile(securityProfile.toBuilder()
+                                .withAttributes(updatedAttributes)
+                                .build())
+                        .build())
+                .build();
+    }
+
     public static Optional<Long> getTimeInState(Task task, TaskState checkedState, Clock clock) {
         return findTaskStatus(task, checkedState).map(checkedStatus -> {
             TaskState currentState = task.getStatus().getState();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/KubePodUtilTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/KubePodUtilTest.java
@@ -18,8 +18,10 @@ package com.netflix.titus.master.kubernetes.pod;
 
 import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import com.netflix.titus.testkit.model.job.JobGenerator;
 import org.junit.Test;
@@ -37,4 +39,14 @@ public class KubePodUtilTest {
         assertThat(KubePodUtil.createPodAnnotationsFromJobParameters(job)).containsEntry(KubeConstants.POD_LABEL_SUBNETS, "subnet1,subnet2");
     }
 
+    @Test
+    public void testFilterPodAnnotations() {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob();
+        JobDescriptor<BatchJobExt> jobDescriptor = JobFunctions.appendJobSecurityAttributes(
+                job.getJobDescriptor(),
+                CollectionsExt.asMap(JobAttributes.JOB_SECURITY_ATTRIBUTE_METATRON_AUTH_CONTEXT, "someAuthContext")
+        );
+        assertThat(KubePodUtil.filterPodJobDescriptor(jobDescriptor).getContainer().getSecurityProfile().getAttributes().containsKey(JobAttributes.JOB_SECURITY_ATTRIBUTE_METATRON_AUTH_CONTEXT))
+                .isFalse();
+    }
 }


### PR DESCRIPTION
This PR adds functionality in support of TITUS-4938. The feature uses Metatron auth context information for more secure/granular authz. This PR adds common attribute fields and removes them from created pods to avoid wasting space (the attributes are similarly not in ContainerInfo).