### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
         maven { url 'https://plugins.gradle.org/m2/' }
     }
@@ -30,15 +29,14 @@ allprojects {
     }
 
     repositories {
-        jcenter()
-        maven { url 'https://dl.bintray.com/netflixoss/oss-candidate/' }
+        mavenCentral()
+        maven { url 'https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-candidates' }
     }
 }
 
 subprojects {
     buildscript {
         repositories {
-            jcenter()
             mavenCentral()
             maven { url 'https://plugins.gradle.org/m2/' }
         }


### PR DESCRIPTION
Hi folks,

As you might be aware, JFrog is sunsetting Bintray and JCenter: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This is to use maven central instead of jcenter