### PR TITLE
Apply AZ constraint to pods with Static IPs

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/IpAddressAllocationUtils.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/IpAddressAllocationUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job.vpc;
+
+import java.util.Optional;
+
+import com.netflix.titus.api.jobmanager.TaskAttributes;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.common.util.code.CodeInvariants;
+
+/**
+ * Helper utilities for processing Static IP related info.
+ */
+public class IpAddressAllocationUtils {
+
+    public static Optional<String> getIpAllocationId(Task task) {
+        return Optional.ofNullable(task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_IP_ALLOCATION_ID));
+    }
+
+    public static Optional<String> getIpAllocationZoneForId(String ipAllocationId, JobDescriptor<?> jobDescriptor, CodeInvariants codeInvariants) {
+        for (SignedIpAddressAllocation signedIpAddressAllocation : jobDescriptor.getContainer().getContainerResources().getSignedIpAddressAllocations()) {
+            if (signedIpAddressAllocation.getIpAddressAllocation().getAllocationId().equals(ipAllocationId)) {
+                return Optional.of(signedIpAddressAllocation.getIpAddressAllocation().getIpAddressLocation().getAvailabilityZone());
+            }
+        }
+
+        codeInvariants.inconsistent("Unable to find zone for IP allocation ID {} in job allocations {}",
+                ipAllocationId, jobDescriptor.getContainer().getContainerResources().getSignedIpAddressAllocations());
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the zone if the task has an assigned IP address allocation.
+     */
+    public static Optional<String> getIpAllocationZoneForTask(JobDescriptor<?> jobDescriptor, Task task, CodeInvariants codeInvariants) {
+        return getIpAllocationId(task)
+                .flatMap(ipAllocationId -> getIpAllocationZoneForId(ipAllocationId, jobDescriptor, codeInvariants));
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobIpAllocationsTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobIpAllocationsTest.java
@@ -18,6 +18,7 @@ package com.netflix.titus.master.integration.v3.job;
 
 import java.util.AbstractMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -26,6 +27,7 @@ import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
+import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
 import com.netflix.titus.grpc.protogen.JobChangeNotification;
 import com.netflix.titus.grpc.protogen.JobId;
 import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
@@ -284,15 +286,15 @@ public class JobIpAllocationsTest extends BaseIntegrationTest {
     }
 
     private static Function<JobDescriptor<BatchJobExt>, JobDescriptor<BatchJobExt>> batchOfSizeAndIps(int size) {
+        List<SignedIpAddressAllocation> ipAllocations = JobIpAllocationGenerator.jobIpAllocations(size).toList();
         return jd -> JobFunctions.changeBatchJobSize(jd, size)
-                .but(j -> j.getContainer()
-                        .but(c -> c.getContainerResources().toBuilder().withSignedIpAddressAllocations(JobIpAllocationGenerator.jobIpAllocations(size).getValues(size)).build()));
+                .but(d -> JobFunctions.jobWithIpAllocations(d, ipAllocations));
     }
 
     private static Function<JobDescriptor<ServiceJobExt>, JobDescriptor<ServiceJobExt>> serviceOfSizeAndIps(int size) {
+        List<SignedIpAddressAllocation> ipAllocations = JobIpAllocationGenerator.jobIpAllocations(size).toList();
         return jd -> JobFunctions.changeServiceJobCapacity(jd, size)
-                .but(j -> j.getContainer()
-                        .but(c -> c.getContainerResources().toBuilder().withSignedIpAddressAllocations(JobIpAllocationGenerator.jobIpAllocations(size).getValues(size)).build()));
+                .but(d -> JobFunctions.jobWithIpAllocations(d, ipAllocations));
     }
 
     private static String getIpAllocationIdFromJob(int idx, JobDescriptor<?> jobDescriptor) {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobEbsVolumeGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobEbsVolumeGenerator.java
@@ -23,6 +23,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.netflix.titus.api.jobmanager.JobAttributes;
+import com.netflix.titus.api.jobmanager.TaskAttributes;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.common.data.generator.DataGenerator;
 import com.netflix.titus.testkit.model.PrimitiveValueGenerators;
@@ -67,5 +70,9 @@ public class JobEbsVolumeGenerator {
         ebsAttributes.put(JobAttributes.JOB_ATTRIBUTES_EBS_FS_TYPE, ebsVolumes.stream().findFirst().map(EbsVolume::getFsType).orElse("xfs"));
 
         return ebsAttributes;
+    }
+
+    public static Task appendEbsVolumeAttribute(Task task, String ebsVolumeId) {
+        return JobFunctions.appendTaskContext(task, TaskAttributes.TASK_ATTRIBUTES_EBS_VOLUME_ID, ebsVolumeId);
     }
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobIpAllocationGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobIpAllocationGenerator.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.netflix.titus.api.jobmanager.TaskAttributes;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressAllocation;
 import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressLocation;
 import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
@@ -75,5 +78,9 @@ public final class JobIpAllocationGenerator {
                     .build());
         }
         return DataGenerator.items(signedIpAddressAllocationList);
+    }
+
+    public static Task appendIpAllocationAttribute(Task task, String ipAllocationId) {
+        return JobFunctions.appendTaskContext(task, TaskAttributes.TASK_ATTRIBUTES_IP_ALLOCATION_ID, ipAllocationId);
     }
 }


### PR DESCRIPTION
Apply AZ node selector to pods with Static IPs for use with Kube Scheduler. Previously Static IP to AZ constraint mapping was handled by Fenzo.