### PR TITLE
Adding capability to mint new jobIds in federation

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -45,6 +45,12 @@ public final class JobAttributes {
     public static final String JOB_ATTRIBUTES_CELL = TITUS_ATTRIBUTE_PREFIX + "cell";
 
     /**
+     * Job id. When this attribute is present it signals the control plane that the id was created by federation
+     * and should be used instead of minting a new value for any CreateJob API calls.
+     */
+    public static final String JOB_ATTRIBUTES_FEDERATED_JOB_ID = TITUS_ATTRIBUTE_PREFIX + "federatedJobId";
+
+    /**
      * Set to true when sanitization for iam roles fails open
      */
     public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IAM = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.iam";

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -45,6 +45,11 @@ public final class JobAttributes {
     public static final String JOB_ATTRIBUTES_CELL = TITUS_ATTRIBUTE_PREFIX + "cell";
 
     /**
+     * This attribute specifies the destination cell the federation is configured to route the API request to.
+     */
+    public static final String JOB_ATTRIBUTE_ROUTING_CELL = TITUS_ATTRIBUTE_PREFIX + "routingCell";
+
+    /**
      * Job id. When this attribute is present it signals the control plane that the id was created by federation
      * and should be used instead of minting a new value for any CreateJob API calls.
      */

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationConfiguration.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationConfiguration.java
@@ -33,4 +33,7 @@ public interface TitusFederationConfiguration {
 
     @DefaultValue("cell1=(gpu.*)")
     String getInstanceTypeRoutingRules();
+
+    @DefaultValue("false")
+    boolean isFederationJobIdCreationEnabled();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -66,6 +66,7 @@ import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.ProtobufExt;
+import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.guice.ProxyType;
 import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.guice.annotation.ProxyConfiguration;
@@ -570,13 +571,15 @@ public class DefaultV3JobOperations implements V3JobOperations {
     }
 
     private <E extends JobDescriptor.JobDescriptorExt> Job<E> newJob(JobDescriptor<E> jobDescriptor) {
+        String federatedJobId = jobDescriptor.getAttributes().get(JobAttributes.JOB_ATTRIBUTES_FEDERATED_JOB_ID);
+        String jobId = (StringExt.isNotEmpty(federatedJobId) ? federatedJobId : UUID.randomUUID().toString());
         return Job.<E>newBuilder()
-                .withId(UUID.randomUUID().toString())
+                .withId(jobId)
                 .withJobDescriptor(jobDescriptor)
                 .withStatus(JobStatus.newBuilder()
-                                .withState(JobState.Accepted)
-                                .withReasonMessage("New Job created. Next tasks will be launched.")
-                                .build())
+                        .withState(JobState.Accepted)
+                        .withReasonMessage("New Job created. Next tasks will be launched.")
+                        .build())
                 .build();
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/JobSchedulingCommonTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/JobSchedulingCommonTest.java
@@ -16,10 +16,14 @@
 
 package com.netflix.titus.master.jobmanager.service.integration;
 
+import java.util.UUID;
+
+import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.TaskState;
 import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
 import com.netflix.titus.api.jobmanager.service.JobManagerException;
+import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.master.jobmanager.service.integration.scenario.JobsScenarioBuilder;
 import com.netflix.titus.master.jobmanager.service.integration.scenario.ScenarioTemplates;
 import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
@@ -39,6 +43,27 @@ public class JobSchedulingCommonTest {
     @Test
     public void testServiceJobWithTaskInAcceptedStateNotScheduledYet() {
         testJobWithTaskInAcceptedStateNotScheduledYet(JobDescriptorGenerator.oneTaskServiceJobDescriptor());
+    }
+
+    @Test
+    public void testBatchJobWithFederatedJobId() {
+        String federatedJobId = UUID.randomUUID().toString();
+        testJobWithTaskInAcceptedStateNotScheduledYetWithFederatedJobId(JobDescriptorGenerator.oneTaskBatchJobDescriptorWithAttributes(
+                CollectionsExt.<String, String>newHashMap().entry(JobAttributes.JOB_ATTRIBUTES_FEDERATED_JOB_ID, federatedJobId).build()),
+                federatedJobId);
+    }
+
+    @Test
+    public void testServiceJobWithFederatedJobId() {
+        String federatedJobId = UUID.randomUUID().toString();
+        testJobWithTaskInAcceptedStateNotScheduledYetWithFederatedJobId(JobDescriptorGenerator.oneTaskServiceJobDescriptorWithAttributes(
+                CollectionsExt.<String, String>newHashMap().entry(JobAttributes.JOB_ATTRIBUTES_FEDERATED_JOB_ID, federatedJobId).build()),
+                federatedJobId);
+    }
+
+    private void testJobWithTaskInAcceptedStateNotScheduledYetWithFederatedJobId(JobDescriptor<?> oneTaskJobDescriptor, String federatedJobId) {
+        jobsScenarioBuilder.scheduleJob(oneTaskJobDescriptor, jobScenario ->
+                jobScenario.expectJobEvent(job -> assertThat(job.getId()).isEqualTo(federatedJobId)));
     }
 
     /**

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobDescriptorGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobDescriptorGenerator.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.testkit.model.job;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -176,6 +177,14 @@ public final class JobDescriptorGenerator {
 
     public static JobDescriptor<BatchJobExt> batchJobDescriptor(int desired) {
         return JobFunctions.changeBatchJobSize(oneTaskBatchJobDescriptor(), desired);
+    }
+
+    public static JobDescriptor<BatchJobExt> oneTaskBatchJobDescriptorWithAttributes(Map<String, String> attributes) {
+        return JobFunctions.appendJobDescriptorAttributes(oneTaskBatchJobDescriptor(), attributes);
+    }
+
+    public static JobDescriptor<ServiceJobExt> oneTaskServiceJobDescriptorWithAttributes(Map<String, String> attributes) {
+        return JobFunctions.appendJobDescriptorAttributes(oneTaskServiceJobDescriptor(), attributes);
     }
 
     public static JobDescriptor<BatchJobExt> oneTaskBatchJobDescriptor() {


### PR DESCRIPTION
### Description of the Change

This work enables the concept of FederationJobs which could span across deployment cells/stacks. As a first step, we need to create the JobIds externally and then pass it the deployment stacks so the job records can be created in external storage specific to the stack.