### PR TITLE
GRPC findJobs/findTasks optimizations

### DIFF
--- a/titus-common-api/src/main/java/com/netflix/titus/api/model/IdAndTimestampKey.java
+++ b/titus-common-api/src/main/java/com/netflix/titus/api/model/IdAndTimestampKey.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.model;
+
+import com.google.common.base.Preconditions;
+
+public class IdAndTimestampKey<T> implements PaginableEntityKey<T> {
+
+    private final T entity;
+    private final String id;
+    private final long timestamp;
+
+    public IdAndTimestampKey(T entity, String id, long timestamp) {
+        Preconditions.checkNotNull(entity, "entity null");
+        Preconditions.checkNotNull(id, "entity id null");
+
+        this.entity = entity;
+        this.id = id;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public T getEntity() {
+        return entity;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public int compareTo(PaginableEntityKey<T> other) {
+        Preconditions.checkArgument(other instanceof IdAndTimestampKey);
+
+        IdAndTimestampKey<T> otherKey = (IdAndTimestampKey<T>) other;
+        int cmp = Long.compare(timestamp, otherKey.timestamp);
+        if (cmp != 0) {
+            return cmp;
+        }
+        return id.compareTo(otherKey.id);
+    }
+}

--- a/titus-common-api/src/main/java/com/netflix/titus/api/model/IdAndTimestampKey.java
+++ b/titus-common-api/src/main/java/com/netflix/titus/api/model/IdAndTimestampKey.java
@@ -16,6 +16,8 @@
 
 package com.netflix.titus.api.model;
 
+import java.util.Objects;
+
 import com.google.common.base.Preconditions;
 
 public class IdAndTimestampKey<T> implements PaginableEntityKey<T> {
@@ -48,7 +50,7 @@ public class IdAndTimestampKey<T> implements PaginableEntityKey<T> {
 
     @Override
     public int compareTo(PaginableEntityKey<T> other) {
-        Preconditions.checkArgument(other instanceof IdAndTimestampKey);
+        Preconditions.checkArgument(other instanceof IdAndTimestampKey, "Key of a different type passed to the comparator");
 
         IdAndTimestampKey<T> otherKey = (IdAndTimestampKey<T>) other;
         int cmp = Long.compare(timestamp, otherKey.timestamp);
@@ -56,5 +58,30 @@ public class IdAndTimestampKey<T> implements PaginableEntityKey<T> {
             return cmp;
         }
         return id.compareTo(otherKey.id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdAndTimestampKey<?> that = (IdAndTimestampKey<?>) o;
+        return timestamp == that.timestamp && Objects.equals(entity, that.entity) && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entity, id, timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "IdAndTimestampKey{" +
+                "id='" + id + '\'' +
+                ", timestamp=" + timestamp +
+                '}';
     }
 }

--- a/titus-common-api/src/main/java/com/netflix/titus/api/model/PaginableEntityKey.java
+++ b/titus-common-api/src/main/java/com/netflix/titus/api/model/PaginableEntityKey.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A key representation of an entity. Useful when the key is not the entity attribute and must be computed.
+ */
+public interface PaginableEntityKey<T> extends Comparable<PaginableEntityKey<T>> {
+
+    T getEntity();
+
+    static <T> List<T> sort(List<T> items, Function<T, PaginableEntityKey<T>> keyExtractor) {
+        List<PaginableEntityKey<T>> keys = new ArrayList<>();
+        for (T item : items) {
+            keys.add(keyExtractor.apply(item));
+        }
+        keys.sort(Comparable::compareTo);
+        List<T> sortedItems = new ArrayList<>();
+        for (PaginableEntityKey<T> key : keys) {
+            sortedItems.add(key.getEntity());
+        }
+        return sortedItems;
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
@@ -382,7 +382,7 @@ public class AggregatingJobServiceGateway implements JobServiceGateway {
                             combinedResults.getItemsList(),
                             combinedResults.getPagination(),
                             JobManagerCursors.taskCursorOrderComparator(),
-                            JobManagerCursors::newCursorFrom
+                            JobManagerCursors::newTaskCursorFrom
                     );
 
                     if (!CollectionsExt.isNullOrEmpty(fields)) {

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithFixedTasksService.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/CellWithFixedTasksService.java
@@ -72,7 +72,7 @@ class CellWithFixedTasksService extends JobManagementServiceGrpc.JobManagementSe
                 getTasksList(),
                 JobManagerCursors.taskCursorOrderComparator(),
                 JobManagerCursors::taskIndexOf,
-                JobManagerCursors::newCursorFrom
+                JobManagerCursors::newTaskCursorFrom
         );
         Set<String> fieldsFilter = new HashSet<>(request.getFieldsList());
         if (!fieldsFilter.isEmpty()) {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
@@ -315,7 +315,7 @@ public class GatewayJobServiceGateway extends JobServiceGatewayDelegate {
                 tasks,
                 JobManagerCursors.taskCursorOrderComparator(),
                 JobManagerCursors::taskIndexOf,
-                JobManagerCursors::newCursorFrom
+                JobManagerCursors::newTaskCursorFrom
         );
 
         // Fix pagination result, as the total items count does not include all active tasks.

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/NeedsMigrationQueryHandler.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/NeedsMigrationQueryHandler.java
@@ -95,7 +95,7 @@ class NeedsMigrationQueryHandler {
                 matchingTasks,
                 JobManagerCursors.taskCursorOrderComparator(),
                 JobManagerCursors::taskIndexOf,
-                JobManagerCursors::newCursorFrom
+                JobManagerCursors::newTaskCursorFrom
         );
 
         return PageResult.pageOf(paginationPair.getLeft(), paginationPair.getRight());

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/JobComparators.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/JobComparators.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.jobmanager;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobState;
+import com.netflix.titus.api.jobmanager.model.job.JobStatus;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
+import com.netflix.titus.api.model.IdAndTimestampKey;
+
+public class JobComparators {
+
+    private static final JobTimestampComparator JOB_TIMESTAMP_COMPARATOR = new JobTimestampComparator();
+
+    private static final TaskTimestampComparator TASK_TIMESTAMP_COMPARATOR = new TaskTimestampComparator();
+
+    /**
+     * Compare two job entities by the creation time (first), and a job id (second).
+     */
+    public static Comparator<Job<?>> getJobTimestampComparator() {
+        return JOB_TIMESTAMP_COMPARATOR;
+    }
+
+    /**
+     * Compare two task entities by the creation time (first), and a task id (second).
+     */
+    public static Comparator<Task> getTaskTimestampComparator() {
+        return TASK_TIMESTAMP_COMPARATOR;
+    }
+
+    private static class JobTimestampComparator implements Comparator<Job<?>> {
+        @Override
+        public int compare(Job first, Job second) {
+            long firstTimestamp = getJobCreateTimestamp(first);
+            long secondTimestamp = getJobCreateTimestamp(second);
+            int cmp = Long.compare(firstTimestamp, secondTimestamp);
+            if (cmp != 0) {
+                return cmp;
+            }
+            return first.getId().compareTo(second.getId());
+        }
+    }
+
+    private static class TaskTimestampComparator implements Comparator<Task> {
+        @Override
+        public int compare(Task first, Task second) {
+            long firstTimestamp = getTaskCreateTimestamp(first);
+            long secondTimestamp = getTaskCreateTimestamp(second);
+            int cmp = Long.compare(firstTimestamp, secondTimestamp);
+            if (cmp != 0) {
+                return cmp;
+            }
+            return first.getId().compareTo(second.getId());
+        }
+    }
+
+    public static long getJobCreateTimestamp(Job job) {
+        List<JobStatus> statusHistory = job.getStatusHistory();
+        int historySize = statusHistory.size();
+
+        // Fast path
+        if (historySize == 0) {
+            return job.getStatus().getTimestamp();
+        }
+        JobStatus first = statusHistory.get(0);
+        if (historySize == 1 || first.getState() == JobState.Accepted) {
+            return first.getTimestamp();
+        }
+        // Slow path
+        for (int i = 1; i < historySize; i++) {
+            JobStatus next = statusHistory.get(i);
+            if (next.getState() == JobState.Accepted) {
+                return next.getTimestamp();
+            }
+        }
+        // No Accepted state
+        return job.getStatus().getTimestamp();
+    }
+
+    public static long getTaskCreateTimestamp(Task task) {
+        List<TaskStatus> statusHistory = task.getStatusHistory();
+        int historySize = statusHistory.size();
+
+        // Fast path
+        if (historySize == 0) {
+            return task.getStatus().getTimestamp();
+        }
+        com.netflix.titus.api.jobmanager.model.job.TaskStatus first = statusHistory.get(0);
+        if (historySize == 1 || first.getState() == TaskState.Accepted) {
+            return first.getTimestamp();
+        }
+        // Slow path
+        for (int i = 1; i < historySize; i++) {
+            com.netflix.titus.api.jobmanager.model.job.TaskStatus next = statusHistory.get(i);
+            if (next.getState() == TaskState.Accepted) {
+                return next.getTimestamp();
+            }
+        }
+        // No Accepted state
+        return task.getStatus().getTimestamp();
+    }
+
+    public static IdAndTimestampKey<Job<?>> createJobKeyOf(Job<?> job) {
+        return new IdAndTimestampKey<>(job, job.getId(), getJobCreateTimestamp(job));
+    }
+
+    public static IdAndTimestampKey<Task> createTaskKeyOf(Task task) {
+        return new IdAndTimestampKey<>(task, task.getId(), getTaskCreateTimestamp(task));
+    }
+}

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/jobmanager/JobComparatorsTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/jobmanager/JobComparatorsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.jobmanager;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobState;
+import com.netflix.titus.api.jobmanager.model.job.JobStatus;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskState;
+import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
+import com.netflix.titus.api.model.IdAndTimestampKey;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JobComparatorsTest {
+
+    @Test
+    public void testGetJobTimestampComparator() {
+        List<Job<?>> jobs = Arrays.asList(
+                newJob("job3", 10),
+                newJob("job2", 5),
+                newJob("job1", 10)
+        );
+        jobs.sort(JobComparators.getJobTimestampComparator());
+
+        assertThat(jobs.get(0).getId()).isEqualTo("job2");
+        assertThat(jobs.get(1).getId()).isEqualTo("job1");
+        assertThat(jobs.get(2).getId()).isEqualTo("job3");
+    }
+
+    @Test
+    public void testGetTaskTimestampComparator() {
+        List<Task> tasks = Arrays.asList(
+                newTask("task3", 10),
+                newTask("task2", 5),
+                newTask("task1", 10)
+        );
+        tasks.sort(JobComparators.getTaskTimestampComparator());
+
+        assertThat(tasks.get(0).getId()).isEqualTo("task2");
+        assertThat(tasks.get(1).getId()).isEqualTo("task1");
+        assertThat(tasks.get(2).getId()).isEqualTo("task3");
+    }
+
+    @Test
+    public void testCreateJobKeyOf() {
+        IdAndTimestampKey<Job<?>> key = JobComparators.createJobKeyOf(newJob("job1", 100));
+        assertThat(key.getId()).isEqualTo("job1");
+        assertThat(key.getTimestamp()).isEqualTo(100);
+    }
+
+    @Test
+    public void testCreateTaskKeyOf() {
+        IdAndTimestampKey<Task> key = JobComparators.createTaskKeyOf(newTask("task1", 100));
+        assertThat(key.getId()).isEqualTo("task1");
+        assertThat(key.getTimestamp()).isEqualTo(100);
+    }
+
+    private Job<?> newJob(String jobId, long timestamp) {
+        return JobGenerator.oneBatchJob().toBuilder()
+                .withId(jobId)
+                .withStatus(JobStatus.newBuilder()
+                        .withState(JobState.Accepted)
+                        .withTimestamp(timestamp)
+                        .build()
+                )
+                .build();
+    }
+
+    private Task newTask(String taskId, long timestamp) {
+        return JobGenerator.oneBatchTask().toBuilder()
+                .withId(taskId)
+                .withStatus(TaskStatus.newBuilder()
+                        .withState(TaskState.Accepted)
+                        .withTimestamp(timestamp)
+                        .build()
+                )
+                .build();
+    }
+}


### PR DESCRIPTION
Java stream API and collection sorting is expensive. These changes gave 30% performance gain with 30K running tasks.