### PR TITLE
Add GRPC fallback test

### DIFF
--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/GrpcFallbackTest.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/GrpcFallbackTest.java
@@ -1,0 +1,115 @@
+package com.netflix.titus.federation.service;
+
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+import com.netflix.titus.grpc.protogen.JobId;
+import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcServerRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import rx.Observable;
+
+import java.util.Optional;
+
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createRequestObservable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JobManagementServiceWithUnimplementedInterface extends JobManagementServiceGrpc.JobManagementServiceImplBase {
+    // All interface methods return UNIMPLEMENTED status.
+}
+
+class JobManagementServiceWithSlowMethods extends JobManagementServiceGrpc.JobManagementServiceImplBase {
+    public long createCount = 0;
+
+    public void createJob(com.netflix.titus.grpc.protogen.JobDescriptor request,
+                          io.grpc.stub.StreamObserver<com.netflix.titus.grpc.protogen.JobId> responseObserver) {
+        // Increment call count, but never respond to the responseObserver
+        createCount++;
+    }
+}
+
+public class GrpcFallbackTest {
+    private static final String appName = "app";
+    private static final String cellName = "cell001";
+    private static final long GRPC_REQUEST_TIMEOUT_MS = 1_000L;
+
+    @Rule
+    public GrpcServerRule federationRule = new GrpcServerRule().directExecutor();
+
+    @Rule
+    public GrpcServerRule cellRule = new GrpcServerRule().directExecutor();
+
+    @BeforeEach
+    void init() {
+        federationRule = new GrpcServerRule().directExecutor();
+        cellRule = new GrpcServerRule().directExecutor();
+    }
+
+    @Test
+    public void unimplementedFallback() {
+        CellWithCachedJobsService cachedJobsService = new CellWithCachedJobsService(cellName);
+        cellRule.getServiceRegistry().addService(cachedJobsService);
+        federationRule.getServiceRegistry().addService(new JobManagementServiceWithUnimplementedInterface());
+
+        JobDescriptor jobDescriptor = JobDescriptor.newBuilder()
+                .setApplicationName(appName)
+                .build();
+        Observable<String> fallbackObservbale = createJobWithFallback(jobDescriptor);
+
+        String jobId = fallbackObservbale.toBlocking().first();
+        Optional<JobDescriptor> createdJob = cachedJobsService.getCachedJob(jobId);
+        assertThat(createdJob).isPresent();
+    }
+
+    @Test
+    public void timeoutFallback() {
+        CellWithCachedJobsService cachedJobsService = new CellWithCachedJobsService(cellName);
+        JobManagementServiceWithSlowMethods slowJobsService = new JobManagementServiceWithSlowMethods();
+        cellRule.getServiceRegistry().addService(cachedJobsService);
+        federationRule.getServiceRegistry().addService(slowJobsService);
+
+        JobDescriptor jobDescriptor = JobDescriptor.newBuilder()
+                .setApplicationName(appName)
+                .build();
+
+        long initialCreatecount = slowJobsService.createCount;
+        assertThat(initialCreatecount).isEqualTo(0);
+
+        Observable<String> fallbackObservable = createJobWithFallback(jobDescriptor);
+        String jobId = fallbackObservable.toBlocking().first();
+        Optional<JobDescriptor> createdJob = cachedJobsService.getCachedJob(jobId);
+        assertThat(createdJob).isPresent();
+
+        assertThat(slowJobsService.createCount).isEqualTo(initialCreatecount + 1);
+    }
+
+    private Observable<String> createJobWithFallback(JobDescriptor jobDescriptor) {
+        JobManagementServiceGrpc.JobManagementServiceStub fedClient = JobManagementServiceGrpc.newStub(federationRule.getChannel());
+        JobManagementServiceGrpc.JobManagementServiceStub cellClient = JobManagementServiceGrpc.newStub(cellRule.getChannel());
+
+        Observable<String> fedObservable = createRequestObservable(emitter -> {
+            StreamObserver<JobId> streamObserver = GrpcUtil.createClientResponseObserver(
+                    emitter,
+                    jobId -> emitter.onNext(jobId.getId()),
+                    emitter::onError,
+                    emitter::onCompleted
+            );
+            fedClient.createJob(jobDescriptor, streamObserver);
+        }, GRPC_REQUEST_TIMEOUT_MS);
+
+        Observable<String> cellObservable = createRequestObservable(emitter -> {
+            StreamObserver<JobId> streamObserver = GrpcUtil.createClientResponseObserver(
+                    emitter,
+                    jobId -> emitter.onNext(jobId.getId()),
+                    emitter::onError,
+                    emitter::onCompleted
+            );
+            cellClient.createJob(jobDescriptor, streamObserver);
+        }, GRPC_REQUEST_TIMEOUT_MS);
+
+        return fedObservable.onErrorResumeNext(cellObservable);
+    }
+}
+


### PR DESCRIPTION
### Description of the Change

In order to slowly and safely introduce redirecting calls to the new federation service, a first step should be to dual write a subset of requests to the current and new services simultaneously.  In the initial commit presented here we see a couple tests illustrating the proposed approach.  Thanks to @corindwyer for originally suggesting this "fallback" style.  The core rx.java primitive used to implement the fallback is the `onErrorResumeNext` method.

Today the new service returns an `UNIMPLEMENTED` status code for all JobService methods and will continue to do so until it takes over responsibility for portions of the interface.  So the `unimplementedFallback` test demonstrates that a federation service returning `UNIMPLEMENTED` falls back to the current cellular interface.

The `timeoutFallback` test illustrates the case in which a new federation service instance becomes either slow or entirely unresponsive to API calls.  Again we demonstrate fallback to the cellular interface.

Essentially the proposal is that for `create`, `update`, and `delete` calls on Jobs, dual writes will occur, with fallback to the cellular interface being the primary execution path.  The new federation service will perform operations on FederatedJobDescriptor CRDs, but will always return `UNIMPLEMENTED` to ensure that the current code path is executed.  

In this way we can start to observe the performance characteristics of the new federation service as well as determine what it _would have done_ to ensure functional correctness in comparison to the current system.

Before I make the rest of the changes to plumb in communication with the new federation service, I wanted to make sure we're aligned on the core "dual write" primitive.