### PR TITLE
Add remote federation capability for job create

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/federation/model/RemoteFederation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/federation/model/RemoteFederation.java
@@ -1,0 +1,13 @@
+package com.netflix.titus.api.federation.model;
+
+public final class RemoteFederation {
+    private final String address;
+
+    public RemoteFederation(String address) {
+        this.address = address;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultRemoteFederationConnector.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultRemoteFederationConnector.java
@@ -1,0 +1,43 @@
+package com.netflix.titus.federation.service;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.util.RoundRobinLoadBalancerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
+
+public class DefaultRemoteFederationConnector implements RemoteFederationConnector {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultRemoteFederationConnector.class);
+
+    private static final long SHUTDOWN_TIMEOUT_MS = 5_000;
+    private final ManagedChannel channel;
+
+    @Inject
+    public DefaultRemoteFederationConnector(RemoteFederationInfoResolver remoteFederationInfoResolver) {
+        channel = NettyChannelBuilder.forTarget(remoteFederationInfoResolver.resolve().getAddress())
+                .usePlaintext(true)
+                .loadBalancerFactory(RoundRobinLoadBalancerFactory.getInstance())
+                .build();
+    }
+
+    @Override
+    public ManagedChannel getChannel() {
+        return channel;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        logger.info("shutting down gRPC channels");
+        try {
+            channel.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            if (!channel.isTerminated()) {
+                channel.shutdownNow();
+            }
+        }
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultRemoteFederationInfoResolver.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/DefaultRemoteFederationInfoResolver.java
@@ -1,0 +1,21 @@
+package com.netflix.titus.federation.service;
+
+import com.netflix.titus.api.federation.model.RemoteFederation;
+import com.netflix.titus.federation.startup.TitusFederationConfiguration;
+
+import javax.inject.Inject;
+
+public class DefaultRemoteFederationInfoResolver implements RemoteFederationInfoResolver {
+
+    private final TitusFederationConfiguration configuration;
+
+    @Inject
+    public DefaultRemoteFederationInfoResolver(TitusFederationConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public RemoteFederation resolve() {
+        return new RemoteFederation(configuration.getRemoteFederation());
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/FallbackJobServiceGateway.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/FallbackJobServiceGateway.java
@@ -1,0 +1,64 @@
+package com.netflix.titus.federation.service;
+
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
+import com.netflix.titus.federation.startup.GrpcConfiguration;
+import com.netflix.titus.grpc.protogen.*;
+import com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil;
+import io.grpc.stub.StreamObserver;
+import rx.Observable;
+
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createRequestObservable;
+import static com.netflix.titus.runtime.endpoint.common.grpc.GrpcUtil.createWrappedStub;
+
+public class FallbackJobServiceGateway {
+    private final JobManagementServiceGrpc.JobManagementServiceStub primaryClient;
+    private final GrpcConfiguration grpcConfiguration;
+
+    public FallbackJobServiceGateway(
+            JobManagementServiceGrpc.JobManagementServiceStub primaryClient,
+            GrpcConfiguration grpcConfiguration) {
+        this.primaryClient = primaryClient;
+        this.grpcConfiguration = grpcConfiguration;
+    }
+
+    public Observable<String> createJob(
+            JobDescriptor jobDescriptor,
+            JobManagementServiceGrpc.JobManagementServiceStub secondaryClient,
+            CallMetadata callMetadata) {
+
+        Observable<String> primaryObservable = getCreateObservable(
+                primaryClient,
+                jobDescriptor,
+                callMetadata,
+                grpcConfiguration.getPrimaryFallbackTimeoutMs());
+        Observable<String> secondaryObservable = getCreateObservable(
+                secondaryClient,
+                jobDescriptor,
+                callMetadata,
+                grpcConfiguration.getRequestTimeoutMs());
+        return primaryObservable.onErrorResumeNext(secondaryObservable);
+    }
+
+    private Observable<String> getCreateObservable(
+            JobManagementServiceGrpc.JobManagementServiceStub client,
+            JobDescriptor jobDescriptor,
+            CallMetadata callMetadata,
+            long timeoutMs) {
+        return createRequestObservable(emitter -> {
+            StreamObserver<JobId> streamObserver = GrpcUtil.createClientResponseObserver(
+                    emitter,
+                    jobId -> emitter.onNext(jobId.getId()),
+                    emitter::onError,
+                    emitter::onCompleted
+            );
+            wrap(client, callMetadata, timeoutMs).createJob(jobDescriptor, streamObserver);
+        }, timeoutMs);
+    }
+
+    private JobManagementServiceGrpc.JobManagementServiceStub wrap(
+            JobManagementServiceGrpc.JobManagementServiceStub client,
+            CallMetadata callMetadata,
+            long timeoutMs) {
+        return createWrappedStub(client, callMetadata, timeoutMs);
+    }
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/RemoteFederationConnector.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/RemoteFederationConnector.java
@@ -1,0 +1,7 @@
+package com.netflix.titus.federation.service;
+
+import io.grpc.ManagedChannel;
+
+public interface RemoteFederationConnector {
+    ManagedChannel getChannel();
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/RemoteFederationInfoResolver.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/RemoteFederationInfoResolver.java
@@ -1,0 +1,7 @@
+package com.netflix.titus.federation.service;
+
+import com.netflix.titus.api.federation.model.RemoteFederation;
+
+public interface RemoteFederationInfoResolver {
+    RemoteFederation resolve();
+}

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/GrpcConfiguration.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/GrpcConfiguration.java
@@ -24,4 +24,7 @@ public interface GrpcConfiguration {
 
     @DefaultValue("10000")
     long getRequestTimeoutMs();
+
+    @DefaultValue("1000")
+    long getPrimaryFallbackTimeoutMs();
 }

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationConfiguration.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationConfiguration.java
@@ -22,6 +22,9 @@ import com.netflix.archaius.api.annotations.DefaultValue;
 @Configuration(prefix = "titus.federation")
 public interface TitusFederationConfiguration {
 
+    @DefaultValue("hostName1:7001")
+    String getRemoteFederation();
+
     @DefaultValue("cell1=hostName1:7001;cell2=hostName2:7002")
     String getCells();
 
@@ -36,4 +39,7 @@ public interface TitusFederationConfiguration {
 
     @DefaultValue("false")
     boolean isFederationJobIdCreationEnabled();
+
+    @DefaultValue("false")
+    boolean isRemoteFederationEnabled();
 }

--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationModule.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/startup/TitusFederationModule.java
@@ -48,6 +48,10 @@ import com.netflix.titus.federation.service.CellWebClientConnector;
 import com.netflix.titus.federation.service.DefaultCellConnector;
 import com.netflix.titus.federation.service.DefaultCellInfoResolver;
 import com.netflix.titus.federation.service.DefaultCellWebClientConnector;
+import com.netflix.titus.federation.service.DefaultRemoteFederationConnector;
+import com.netflix.titus.federation.service.DefaultRemoteFederationInfoResolver;
+import com.netflix.titus.federation.service.RemoteFederationConnector;
+import com.netflix.titus.federation.service.RemoteFederationInfoResolver;
 import com.netflix.titus.federation.service.ServiceModule;
 import com.netflix.titus.federation.service.SimpleWebClientFactory;
 import com.netflix.titus.federation.service.WebClientFactory;
@@ -77,9 +81,11 @@ public class TitusFederationModule extends AbstractModule {
 
         bind(HostCallerIdResolver.class).to(NoOpHostCallerIdResolver.class);
         bind(CellConnector.class).to(DefaultCellConnector.class);
+        bind(RemoteFederationConnector.class).to(DefaultRemoteFederationConnector.class);
         bind(CellWebClientConnector.class).to(DefaultCellWebClientConnector.class);
         bind(WebClientFactory.class).toInstance(SimpleWebClientFactory.getInstance());
         bind(CellInfoResolver.class).to(DefaultCellInfoResolver.class);
+        bind(RemoteFederationInfoResolver.class).to(DefaultRemoteFederationInfoResolver.class);
 
         install(new FederationEndpointModule());
         install(new ServiceModule());

--- a/titus-server-federation/src/test/java/com/netflix/titus/federation/service/RemoteFederationJobServices.java
+++ b/titus-server-federation/src/test/java/com/netflix/titus/federation/service/RemoteFederationJobServices.java
@@ -1,0 +1,36 @@
+package com.netflix.titus.federation.service;
+
+import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+abstract class RemoteJobManagementService extends JobManagementServiceGrpc.JobManagementServiceImplBase {
+    volatile public AtomicLong createCount = new AtomicLong(0);
+    public UUID id = UUID.randomUUID();
+}
+
+class RemoteJobManagementServiceWithUnimplementedInterface extends RemoteJobManagementService {
+    private static final Logger logger = LoggerFactory.getLogger(RemoteJobManagementServiceWithUnimplementedInterface.class);
+
+    // All interface methods on super class return UNIMPLEMENTED status.
+    public void createJob(com.netflix.titus.grpc.protogen.JobDescriptor request,
+                          io.grpc.stub.StreamObserver<com.netflix.titus.grpc.protogen.JobId> responseObserver) {
+        createCount.getAndIncrement();
+        logger.info("id: {} createJob called {} time(s)", id, createCount);
+        super.createJob(request, responseObserver);
+    }
+}
+
+class RemoteJobManagementServiceWithSlowMethods extends RemoteJobManagementService {
+    private static final Logger logger = LoggerFactory.getLogger(RemoteJobManagementServiceWithSlowMethods.class);
+
+    public void createJob(com.netflix.titus.grpc.protogen.JobDescriptor request,
+                          io.grpc.stub.StreamObserver<com.netflix.titus.grpc.protogen.JobId> responseObserver) {
+        // Increment call count, but never respond to the responseObserver
+        createCount.getAndIncrement();
+        logger.info("id: {} createJob called {} time(s)", id, createCount);
+    }
+}


### PR DESCRIPTION
### Description of the Change

If enabled and configured, create job requests to the
AggregatingJobServiceGateway can be redirected to a remote service.

If the remote service produces an error or times out, fallback to the
current cell based approach occurs.