### PR TITLE
Automatically adjust the desired size of service jobs when min and/or max are updated

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/Capacity.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/Capacity.java
@@ -23,7 +23,9 @@ import com.netflix.titus.common.model.sanitizer.ClassInvariant;
 
 @ClassInvariant.List({
         @ClassInvariant(condition = "min <= desired", message = "'min'(#{min}) must be <= 'desired'(#{desired})"),
-        @ClassInvariant(condition = "desired <= max", message = "'desired'(#{desired}) must be <= 'max'(#{max})")
+        @ClassInvariant(condition = "desired <= max", message = "'desired'(#{desired}) must be <= 'max'(#{max})"),
+        // needed because desired can be automatically adjusted based on min and max
+        @ClassInvariant(condition = "min <= max", message = "'min'(#{min}) must be <= 'max'(#{max})")
 })
 public class Capacity {
 

--- a/titus-api/src/main/java/com/netflix/titus/api/service/TitusServiceException.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/service/TitusServiceException.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.netflix.titus.common.model.sanitizer.ValidationError;
+import com.netflix.titus.common.util.StringExt;
 
 import static java.lang.String.format;
 
@@ -120,10 +121,17 @@ public class TitusServiceException extends RuntimeException {
     }
 
     public static TitusServiceException invalidArgument(Set<? extends ValidationError> validationErrors) {
+        return invalidArgument("", validationErrors);
+    }
+
+    public static TitusServiceException invalidArgument(String context, Set<? extends ValidationError> validationErrors) {
         String errors = validationErrors.stream()
                 .map(err -> String.format("{%s}", err))
                 .collect(Collectors.joining(", "));
         String errMsg = String.format("Invalid Argument: %s", errors);
+        if (StringExt.isNotEmpty(context)) {
+            errMsg = context + ". " + errMsg;
+        }
         return TitusServiceException.newBuilder(ErrorCode.INVALID_ARGUMENT, errMsg)
                 .withValidationErrors(validationErrors)
                 .build();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceJobActions.java
@@ -68,6 +68,10 @@ public class BasicServiceJobActions {
 
                     Capacity newCapacity = newCapacityBuilder.build();
 
+                    if (serviceJob.getJobDescriptor().getExtensions().getCapacity().equals(newCapacity)) {
+                        return Observable.empty();
+                    }
+
                     // model validation for capacity
                     Set<ValidationError> violations = entitySanitizer.validate(newCapacity);
                     if (!violations.isEmpty()) {
@@ -78,10 +82,6 @@ public class BasicServiceJobActions {
                     if (isDesiredCapacityInvalid(newCapacity, serviceJob)) {
                         return Observable.error(JobManagerException.invalidDesiredCapacity(serviceJob.getId(), newCapacity.getDesired(),
                                 serviceJob.getJobDescriptor().getExtensions().getServiceJobProcesses()));
-                    }
-
-                    if (serviceJob.getJobDescriptor().getExtensions().getCapacity().equals(newCapacity)) {
-                        return Observable.empty();
                     }
 
                     // ready to update job capacity

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobScalingTest.java
@@ -93,12 +93,32 @@ public class JobScalingTest extends BaseIntegrationTest {
     }
 
     @Test(timeout = TEST_TIMEOUT_MS)
+    public void testScaleUpAndDownServiceJobMinAdjustsDesired() throws Exception {
+        jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(1).withMax(5).build())
+                .expectAllTasksCreated()
+                .updateJobCapacityMin(2, 5, 2)
+        );
+    }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
     public void testScaleUpAndDownServiceJobMax() throws Exception {
         jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(2).withMax(5).build())
                 .expectAllTasksCreated()
                 .updateJobCapacityMax(4, 0, 2)
+        );
+    }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
+    public void testScaleUpAndDownServiceJobMaxAdjustsDesired() throws Exception {
+        jobsScenarioBuilder.schedule(newJob("testScaleUpAndDownServiceJob"), jobScenarioBuilder -> jobScenarioBuilder
+                .template(ScenarioTemplates.startTasksInNewJob())
+                .updateJobCapacity(JobModel.newCapacity().withMin(0).withDesired(4).withMax(5).build())
+                .expectAllTasksCreated()
+                .updateJobCapacityMax(2, 0, 2)
         );
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/scenario/JobScenarioBuilder.java
@@ -316,7 +316,7 @@ public class JobScenarioBuilder {
         return this;
     }
 
-    public JobScenarioBuilder updateJobCapacityMin(int min, int unchangedMax, int unchangedDesired) {
+    public JobScenarioBuilder updateJobCapacityMin(int min, int expectedMax, int expectedDesired) {
         logger.info("[{}] Changing job {} capacity min to {}...", discoverActiveTest(), jobId, min);
         Stopwatch stopWatch = Stopwatch.createStarted();
 
@@ -332,14 +332,14 @@ public class JobScenarioBuilder {
         expectJobUpdateEvent(job -> {
             ServiceJobExt ext = (ServiceJobExt) job.getJobDescriptor().getExtensions();
             Capacity capacity = ext.getCapacity();
-            return capacity.getMin() == min && capacity.getMax() == unchangedMax && capacity.getDesired() == unchangedDesired;
+            return capacity.getMin() == min && capacity.getMax() == expectedMax && capacity.getDesired() == expectedDesired;
         }, "Job capacity update did not complete in time");
 
         logger.info("[{}] Job {} scaled to new min size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));
         return this;
     }
 
-    public JobScenarioBuilder updateJobCapacityMax(int max, int unchangedMin, int unchangedDesired) {
+    public JobScenarioBuilder updateJobCapacityMax(int max, int expectedMin, int expectedDesired) {
         logger.info("[{}] Changing job {} capacity max to {}...", discoverActiveTest(), jobId, max);
         Stopwatch stopWatch = Stopwatch.createStarted();
 
@@ -355,7 +355,7 @@ public class JobScenarioBuilder {
         expectJobUpdateEvent(job -> {
             ServiceJobExt ext = (ServiceJobExt) job.getJobDescriptor().getExtensions();
             Capacity capacity = ext.getCapacity();
-            return capacity.getMax() == max && capacity.getMin() == unchangedMin && capacity.getDesired() == unchangedDesired;
+            return capacity.getMax() == max && capacity.getMin() == expectedMin && capacity.getDesired() == expectedDesired;
         }, "Job capacity update did not complete in time");
 
         logger.info("[{}] Job {} scaled to new max size in {}ms", discoverActiveTest(), jobId, stopWatch.elapsed(TimeUnit.MILLISECONDS));


### PR DESCRIPTION
Matching the behavior of Autoscaling Groups on AWS: https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_UpdateAutoScalingGroup.html

More specifically:

> If you specify a new value for MinSize without specifying a value for DesiredCapacity, and the new MinSize is larger than the current size of the group, this sets the group's DesiredCapacity to the new MinSize value.
> 
> If you specify a new value for MaxSize without specifying a value for DesiredCapacity, and the new MaxSize is smaller than the current size of the group, this sets the group's DesiredCapacity to the new MaxSize value.