### PR TITLE
Support for a separate kube-scheduler profile for activating bin packing on reserved tier

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
@@ -87,6 +87,14 @@ public interface KubePodConfiguration {
     String getReservedCapacityKubeSchedulerName();
 
     /**
+     * This string corresponds to a kube-scheduler profile name which implements exact same set of scheduler plugins as
+     * the standard reserved capacity scheduler (titus-kube-scheduler-reserved) except
+     * the bin-packing behavior based on security group affinity.
+     */
+    @DefaultValue("titus-kube-scheduler-reserved")
+    String getReservedCapacityKubeSchedulerNameForBinPacking();
+
+    /**
      * The grace period on the pod object to use when the pod is created.
      */
     @DefaultValue("600")

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactoryTest.java
@@ -48,6 +48,7 @@ import com.netflix.titus.master.kubernetes.pod.env.TitusProvidedContainerEnvFact
 import com.netflix.titus.master.kubernetes.pod.env.UserProvidedContainerEnvFactory;
 import com.netflix.titus.master.kubernetes.pod.taint.TaintTolerationFactory;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.KubeModelConverters;
+import com.netflix.titus.master.scheduler.SchedulerConfiguration;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import com.netflix.titus.testkit.model.job.JobGenerator;
@@ -77,6 +78,8 @@ public class V0SpecPodFactoryTest {
 
     private final MasterConfiguration jobCoordinatorConfiguration = mock(MasterConfiguration.class);
 
+    private final SchedulerConfiguration schedulerConfiguration = mock(SchedulerConfiguration.class);
+
     private final ApplicationSlaManagementService capacityGroupManagement = mock(ApplicationSlaManagementService.class);
 
     private final PodAffinityFactory podAffinityFactory = mock(PodAffinityFactory.class);
@@ -99,7 +102,8 @@ public class V0SpecPodFactoryTest {
             podAffinityFactory,
             taintTolerationFactory,
             defaultAggregatingContainerEnvFactory,
-            logStorageInfo
+            logStorageInfo,
+            schedulerConfiguration
     );
 
     @Test


### PR DESCRIPTION
### Description of the Change

Added a new scheduler configuration that controls how `pod.spec.schedulerName` for Critical tier pods is set when we are in failover. Its default value is the current scheduler name used by the reserved resource pool (`titus-kube-scheduler-reserved`). Once the kube-scheduler changes with the new profile that implements bin packing through SecurityGroup affinity are rolled out, we can set this configuration property to the new value (`titus-kube-scheduler-reserved-binpacking`) to place new critical tier pods accordingly. 