### PR TITLE
Removing federatedJobId from JobAttributes

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -58,7 +58,7 @@ public final class JobAttributes {
     /**
      * This attribute is used to persist original federated Job id that may have been used to populate job id.
      */
-    public static final String JOB_ATTRIBUTES_ORIGINAL_FEDERATED_JOB_ID = TITUS_ATTRIBUTE_PREFIX + "job.originalFederatedJobId";
+    public static final String JOB_ATTRIBUTES_ORIGINAL_FEDERATED_JOB_ID = TITUS_ATTRIBUTE_PREFIX + "originalFederatedJobId";
 
     /**
      * Set to true when sanitization for iam roles fails open

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/JobAttributes.java
@@ -56,6 +56,11 @@ public final class JobAttributes {
     public static final String JOB_ATTRIBUTES_FEDERATED_JOB_ID = TITUS_ATTRIBUTE_PREFIX + "federatedJobId";
 
     /**
+     * This attribute is used to persist original federated Job id that may have been used to populate job id.
+     */
+    public static final String JOB_ATTRIBUTES_ORIGINAL_FEDERATED_JOB_ID = TITUS_ATTRIBUTE_PREFIX + "job.originalFederatedJobId";
+
+    /**
      * Set to true when sanitization for iam roles fails open
      */
     public static final String JOB_ATTRIBUTES_SANITIZATION_SKIPPED_IAM = JOB_ATTRIBUTE_SANITIZATION_PREFIX + "skipped.iam";

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -515,9 +515,12 @@ public final class JobFunctions {
     }
 
     public static <E extends JobDescriptorExt> Job<E> deleteJobAttributes(Job<E> input, Set<String> keys) {
-        JobDescriptor<E> jobDescriptor = input.getJobDescriptor();
-        Map<String, String> updatedAttributes = CollectionsExt.copyAndRemove(jobDescriptor.getAttributes(), keys);
-        return input.toBuilder().withJobDescriptor(jobDescriptor.toBuilder().withAttributes(updatedAttributes).build()).build();
+        return input.toBuilder().withJobDescriptor(deleteJobAttributes(input.getJobDescriptor(), keys)).build();
+    }
+
+    public static <E extends JobDescriptorExt> JobDescriptor<E> deleteJobAttributes(JobDescriptor<E> input, Set<String> keys) {
+        Map<String, String> updatedAttributes = CollectionsExt.copyAndRemove(input.getAttributes(), keys);
+        return input.toBuilder().withAttributes(updatedAttributes).build();
     }
 
     public static <E extends JobDescriptorExt> JobDescriptor<E> appendJobSecurityAttributes(JobDescriptor<E> input, Map<String, String> attributes) {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/JobSchedulingCommonTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/JobSchedulingCommonTest.java
@@ -63,7 +63,11 @@ public class JobSchedulingCommonTest {
 
     private void testJobWithTaskInAcceptedStateNotScheduledYetWithFederatedJobId(JobDescriptor<?> oneTaskJobDescriptor, String federatedJobId) {
         jobsScenarioBuilder.scheduleJob(oneTaskJobDescriptor, jobScenario ->
-                jobScenario.expectJobEvent(job -> assertThat(job.getId()).isEqualTo(federatedJobId)));
+                jobScenario.expectJobEvent(job -> {
+                    assertThat(job.getId()).isEqualTo(federatedJobId);
+                    assertThat(job.getJobDescriptor().getAttributes().get(JobAttributes.JOB_ATTRIBUTES_ORIGINAL_FEDERATED_JOB_ID)).isEqualTo(federatedJobId);
+                    assertThat(job.getJobDescriptor().getAttributes().get(JobAttributes.JOB_ATTRIBUTES_FEDERATED_JOB_ID)).isNull();
+                }));
     }
 
     /**


### PR DESCRIPTION
### Description of the Change
* Removing the `federatedJobId` attribute when a job is being created so we can prevent cloned federatedJobIds
* Introducing `originalFederatedJobId` (copy of federatedJobId) for tracking

