### PR TITLE
Tier based flags to route StaticIP and EBS Volume jobs to Kube-Scheduler

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/KubeSchedulerFeatureConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/KubeSchedulerFeatureConfiguration.java
@@ -31,13 +31,13 @@ public interface KubeSchedulerFeatureConfiguration {
     /**
      * Allows tier level feature gate for routing Static IP jobs. Set to .* to route these jobs for both tiers.
      */
-    @DefaultValue("Flex")
+    @DefaultValue("")
     String getEnabledStaticIpOverrideTiers();
 
     /**
      * Allows tier level feature gate for routing EBS Volume jobs. Set to .* to route these jobs for both tiers.
      */
-    @DefaultValue("Flex")
+    @DefaultValue("")
     String getEnabledEbsVolumeOverrideTiers();
 
     /**

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/KubeSchedulerFeatureConfiguration.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/KubeSchedulerFeatureConfiguration.java
@@ -29,10 +29,16 @@ public interface KubeSchedulerFeatureConfiguration {
     boolean isGpuEnabled();
 
     /**
-     * Set to true to enable routing jobs with static IPs to KubeScheduler.
+     * Allows tier level feature gate for routing Static IP jobs. Set to .* to route these jobs for both tiers.
      */
-    @DefaultValue("false")
-    boolean isStaticIpEnabled();
+    @DefaultValue("Flex")
+    String getEnabledStaticIpOverrideTiers();
+
+    /**
+     * Allows tier level feature gate for routing EBS Volume jobs. Set to .* to route these jobs for both tiers.
+     */
+    @DefaultValue("Flex")
+    String getEnabledEbsVolumeOverrideTiers();
 
     /**
      * Jobs with machine type hard constraint which request machine types not allowed by this regexp pattern, will be
@@ -40,10 +46,4 @@ public interface KubeSchedulerFeatureConfiguration {
      */
     @DefaultValue(".*")
     String getEnabledMachineTypes();
-
-    /**
-     * Set to true to enable routing jobs with EBS volume configuration to KubeScheduler.
-     */
-    @DefaultValue("false")
-    boolean isEbsVolumeEnabled();
 }


### PR DESCRIPTION
### Description of the Change

Removed previous flags and added Tier based override flags that are checked first for routing all jobs with Static IP and EBS volume to kube-scheduler