### PR TITLE
EBS and IP AZ Validation

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
@@ -29,7 +29,6 @@ import com.netflix.titus.common.model.sanitizer.ClassInvariant;
 import com.netflix.titus.common.model.sanitizer.CollectionInvariants;
 import com.netflix.titus.common.model.sanitizer.FieldInvariant;
 import com.netflix.titus.common.model.sanitizer.FieldSanitizer;
-import com.netflix.titus.common.model.sanitizer.VerifierMode;
 import com.netflix.titus.common.util.CollectionsExt;
 
 import static com.netflix.titus.common.util.CollectionsExt.nonNull;
@@ -37,7 +36,7 @@ import static com.netflix.titus.common.util.CollectionsExt.nonNull;
 /**
  */
 @ClassInvariant.List({
-        @ClassInvariant(expr = "@asserts.matchingDeleteMe(ipSignedAddressAllocations)", mode = VerifierMode.Strict),
+        // TODO: This should be enabled as a ClassInvariant rather than a {@link ExtendedJobSanitizer} with TITUS-5370.
         // @ClassInvariant(expr = "@asserts.matchingEbsAndIpZones(ebsVolumes, ipSignedAddressAllocations)", mode = VerifierMode.Strict),
         @ClassInvariant(condition = "shmMB <= memoryMB", message = "'shmMB' (#{shmMB}) must be <= 'memoryMB' (#{memoryMB})")
 })

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/ContainerResources.java
@@ -29,13 +29,18 @@ import com.netflix.titus.common.model.sanitizer.ClassInvariant;
 import com.netflix.titus.common.model.sanitizer.CollectionInvariants;
 import com.netflix.titus.common.model.sanitizer.FieldInvariant;
 import com.netflix.titus.common.model.sanitizer.FieldSanitizer;
+import com.netflix.titus.common.model.sanitizer.VerifierMode;
 import com.netflix.titus.common.util.CollectionsExt;
 
 import static com.netflix.titus.common.util.CollectionsExt.nonNull;
 
 /**
  */
-@ClassInvariant(condition = "shmMB <= memoryMB", message = "'shmMB' (#{shmMB}) must be <= 'memoryMB' (#{memoryMB})")
+@ClassInvariant.List({
+        @ClassInvariant(expr = "@asserts.matchingDeleteMe(ipSignedAddressAllocations)", mode = VerifierMode.Strict),
+        // @ClassInvariant(expr = "@asserts.matchingEbsAndIpZones(ebsVolumes, ipSignedAddressAllocations)", mode = VerifierMode.Strict),
+        @ClassInvariant(condition = "shmMB <= memoryMB", message = "'shmMB' (#{shmMB}) must be <= 'memoryMB' (#{memoryMB})")
+})
 public class ContainerResources {
 
     @FieldSanitizer(adjuster = "T(java.lang.Math).max(@constraints.getCpuMin(), value)")
@@ -69,6 +74,7 @@ public class ContainerResources {
     private final int shmMB;
 
     @Valid
+    @CollectionInvariants(allowDuplicateValues = false)
     private final List<SignedIpAddressAllocation> ipSignedAddressAllocations;
 
     @Valid

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobAssertions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobAssertions.java
@@ -240,10 +240,6 @@ public class JobAssertions {
         return Collections.emptyMap();
     }
 
-    public Map<String, String> matchingDeleteMe(List<SignedIpAddressAllocation> ipSignedAddressAllocations) {
-        return Collections.emptyMap();
-    }
-
     public Map<String, String> matchingEbsAndIpZones(List<EbsVolume> ebsVolumes, List<SignedIpAddressAllocation> ipSignedAddressAllocations) {
         return validateMatchingEbsAndIpZones(ebsVolumes, ipSignedAddressAllocations).stream()
                 .collect(Collectors.toMap(ValidationError::getField, ValidationError::getDescription));

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobAssertions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/JobAssertions.java
@@ -22,9 +22,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
 import com.netflix.titus.api.jobmanager.model.job.Container;
@@ -37,6 +39,7 @@ import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressAllocation;
 import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
 import com.netflix.titus.api.model.ResourceDimension;
+import com.netflix.titus.common.model.sanitizer.ValidationError;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.StringExt;
 
@@ -242,12 +245,17 @@ public class JobAssertions {
     }
 
     public Map<String, String> matchingEbsAndIpZones(List<EbsVolume> ebsVolumes, List<SignedIpAddressAllocation> ipSignedAddressAllocations) {
+        return validateMatchingEbsAndIpZones(ebsVolumes, ipSignedAddressAllocations).stream()
+                .collect(Collectors.toMap(ValidationError::getField, ValidationError::getDescription));
+    }
+
+    public static Set<ValidationError> validateMatchingEbsAndIpZones(List<EbsVolume> ebsVolumes, List<SignedIpAddressAllocation> ipSignedAddressAllocations) {
         if (ebsVolumes == null || ipSignedAddressAllocations == null) {
-            return Collections.emptyMap();
+            return Collections.emptySet();
         }
 
         if (ebsVolumes.isEmpty() || ipSignedAddressAllocations.isEmpty()) {
-            return Collections.emptyMap();
+            return Collections.emptySet();
         }
 
         int numElements = Math.min(ebsVolumes.size(), ipSignedAddressAllocations.size());
@@ -255,17 +263,17 @@ public class JobAssertions {
             EbsVolume ebsVolume = ebsVolumes.get(i);
             IpAddressAllocation ipAddressAllocation = ipSignedAddressAllocations.get(i).getIpAddressAllocation();
             if (!ebsVolume.getVolumeAvailabilityZone().equals(ipAddressAllocation.getIpAddressLocation().getAvailabilityZone())) {
-                return Collections.singletonMap(
+                return Collections.singleton(new ValidationError(
                         "containerResources.ebsVolumes",
                         String.format(
-                                "EBS volume %s zone %s conflicts with Static IP %s zone %s",
-                                ebsVolume.getVolumeId(), ebsVolume.getVolumeAvailabilityZone(), ipAddressAllocation.getAllocationId(), ipAddressAllocation.getIpAddressLocation().getAvailabilityZone()
+                                "EBS volume %s zone %s conflicts with Static IP %s zone %s and index %d",
+                                ebsVolume.getVolumeId(), ebsVolume.getVolumeAvailabilityZone(), ipAddressAllocation.getAllocationId(), ipAddressAllocation.getIpAddressLocation().getAvailabilityZone(), i
                         )
-                );
+                ));
             }
         }
 
-        return Collections.emptyMap();
+        return Collections.emptySet();
     }
 
     private <N extends Number> Optional<String> check(Supplier<N> jobResource, Supplier<N> maxAllowed) {

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/IpAddressAllocation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/IpAddressAllocation.java
@@ -47,6 +47,10 @@ public class IpAddressAllocation {
         return new Builder();
     }
 
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
     public IpAddressLocation getIpAddressLocation() {
         return ipAddressLocation;
     }
@@ -77,7 +81,6 @@ public class IpAddressAllocation {
     public int hashCode() {
         return Objects.hash(ipAddressLocation, allocationId, ipAddress);
     }
-
     @Override
     public String toString() {
         return "IpAddressAllocation{" +
@@ -93,6 +96,12 @@ public class IpAddressAllocation {
         private String ipAddress;
 
         private Builder() {
+        }
+
+        private Builder(IpAddressAllocation ipAddressAllocation) {
+            this.ipAddressLocation = ipAddressAllocation.getIpAddressLocation();
+            this.allocationId = ipAddressAllocation.getAllocationId();
+            this.ipAddress = ipAddressAllocation.getIpAddress();
         }
 
         public Builder withIpAddressLocation(IpAddressLocation val) {

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/IpAddressLocation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/vpc/IpAddressLocation.java
@@ -58,6 +58,10 @@ public class IpAddressLocation {
         return new Builder();
     }
 
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -92,6 +96,12 @@ public class IpAddressLocation {
         private String subnetId;
 
         private Builder() {
+        }
+
+        private Builder(IpAddressLocation ipAddressLocation) {
+            this.region = ipAddressLocation.getRegion();
+            this.availabilityZone = ipAddressLocation.getAvailabilityZone();
+            this.subnetId = ipAddressLocation.getSubnetId();
         }
 
         public Builder withRegion(String val) {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizer.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizer.java
@@ -95,7 +95,14 @@ class ExtendedJobSanitizer implements EntitySanitizer {
 
     @Override
     public <T> Set<ValidationError> validate(T entity) {
-        return entitySanitizer.validate(entity);
+        Set<ValidationError> errors = entitySanitizer.validate(entity);
+
+        if (entity instanceof com.netflix.titus.api.jobmanager.model.job.JobDescriptor) {
+            JobDescriptor jd = ((JobDescriptor)entity);
+            errors.addAll(JobAssertions.validateMatchingEbsAndIpZones(jd.getContainer().getContainerResources().getEbsVolumes(), jd.getContainer().getContainerResources().getSignedIpAddressAllocations()));
+        }
+
+        return errors;
     }
 
     @Override

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobEbsVolumeGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobEbsVolumeGenerator.java
@@ -36,7 +36,7 @@ public class JobEbsVolumeGenerator {
         return PrimitiveValueGenerators.hexValues(8).map(hex -> "vol-" + hex);
     }
 
-    private static DataGenerator<String> availabilityZones() {
+    public static DataGenerator<String> availabilityZones() {
         return DataGenerator.items("us-east-1a", "us-east-1b", "us-east-1c")
                 .loop();
     }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobIpAllocationGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobIpAllocationGenerator.java
@@ -35,11 +35,11 @@ public final class JobIpAllocationGenerator {
     private JobIpAllocationGenerator() {
     }
 
-    private static DataGenerator<String> zones() { return items("zoneA", "zoneB"); }
+    private static DataGenerator<String> zones() { return items("zoneA", "zoneB").loop(); }
 
-    private static DataGenerator<String> subnets() { return items("subnet-1"); }
+    private static DataGenerator<String> subnets() { return items("subnet-1").loop(); }
 
-    private static DataGenerator<String> regions() { return items("us-east-1"); }
+    private static DataGenerator<String> regions() { return items("us-east-1").loop(); }
 
     private static DataGenerator<String> ipAddresses() {
         return PrimitiveValueGenerators.ipv4CIDRs("96.96.96.1/28");


### PR DESCRIPTION
Validates that jobs submitted with EBS Volumes and Static IPs have lists with matching resource AZs. Jobs with mismatched AZs are rejected as tasks from those indexes would not have been schedulable.