### PR TITLE
Added new NetworkConfiguration API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,7 @@ systemProp.nebula.features.coreLockingSupport=true
 # See: https://github.com/gradle/gradle/issues/11308
 # and: https://www.jfrog.com/jira/browse/RTFACT-21426
 systemProp.org.gradle.internal.publish.checksums.insecure=true
+
+# Uncomment this and run ./gradlew generateProto to use a local
+# copy of titus-api-definitions
+# idlLocal=true

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
@@ -80,6 +80,9 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
     private final DisruptionBudget disruptionBudget;
 
     @Valid
+    private final NetworkConfiguration networkConfiguration;
+
+    @Valid
     private final E extensions;
 
     public JobDescriptor(Owner owner,
@@ -89,6 +92,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                          Map<String, String> attributes,
                          Container container,
                          DisruptionBudget disruptionBudget,
+                         NetworkConfiguration networkConfiguration,
                          E extensions) {
         this.owner = owner;
         this.applicationName = applicationName;
@@ -103,6 +107,12 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
             this.disruptionBudget = DEFAULT_DISRUPTION_BUDGET;
         } else {
             this.disruptionBudget = disruptionBudget;
+        }
+
+        if (networkConfiguration == null) {
+            this.networkConfiguration = NetworkConfiguration.newBuilder().build();
+        } else {
+            this.networkConfiguration = networkConfiguration;
         }
     }
 
@@ -158,6 +168,11 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
     }
 
     /**
+     * Network configuration for a job
+     */
+    public NetworkConfiguration getNetworkConfiguration() { return networkConfiguration; }
+
+    /**
      * Returns job type specific data.
      */
     public E getExtensions() {
@@ -180,12 +195,13 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 Objects.equals(attributes, that.attributes) &&
                 Objects.equals(container, that.container) &&
                 Objects.equals(disruptionBudget, that.disruptionBudget) &&
+                Objects.equals(networkConfiguration, that.networkConfiguration) &&
                 Objects.equals(extensions, that.extensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, extensions);
+        return Objects.hash(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extensions);
     }
 
     @Override
@@ -198,6 +214,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 ", attributes=" + attributes +
                 ", container=" + container +
                 ", disruptionBudget=" + disruptionBudget +
+                ", networkConfiguration" + networkConfiguration +
                 ", extensions=" + extensions +
                 '}';
     }
@@ -218,6 +235,12 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
         }
         if (result instanceof JobDescriptor.Builder) {
             return ((JobDescriptor.Builder<E>) result).build();
+        }
+        if (result instanceof NetworkConfiguration) {
+            return toBuilder().withNetworkConfiguration((NetworkConfiguration) result).build();
+        }
+        if (result instanceof NetworkConfiguration.Builder) {
+            return toBuilder().withNetworkConfiguration(((NetworkConfiguration.Builder) result).build()).build();
         }
         if (result instanceof Owner) {
             return toBuilder().withOwner((Owner) result).build();
@@ -275,6 +298,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 .withAttributes(jobDescriptor.getAttributes())
                 .withContainer(jobDescriptor.getContainer())
                 .withDisruptionBudget(jobDescriptor.getDisruptionBudget())
+                .withNetworkConfiguration(jobDescriptor.getNetworkConfiguration())
                 .withExtensions(jobDescriptor.getExtensions());
     }
 
@@ -286,6 +310,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
         private Map<String, String> attributes;
         private Container container;
         private DisruptionBudget disruptionBudget;
+        private NetworkConfiguration networkConfiguration;
         private E extensions;
 
         private Builder() {
@@ -326,6 +351,11 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
             return this;
         }
 
+        public Builder<E> withNetworkConfiguration(NetworkConfiguration networkConfiguration) {
+            this.networkConfiguration = networkConfiguration;
+            return this;
+        }
+
         public Builder<E> withExtensions(E extensions) {
             this.extensions = extensions;
             return this;
@@ -340,11 +370,12 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                     .withAttributes(attributes)
                     .withContainer(container)
                     .withDisruptionBudget(disruptionBudget)
+                    .withNetworkConfiguration(networkConfiguration)
                     .withExtensions(extensions);
         }
 
         public JobDescriptor<E> build() {
-            JobDescriptor<E> jobDescriptor = new JobDescriptor<>(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, extensions);
+            JobDescriptor<E> jobDescriptor = new JobDescriptor<>(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extensions);
             return jobDescriptor;
         }
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
@@ -98,6 +98,8 @@ public final class JobModel {
         return SecurityProfile.newBuilder(securityProfile);
     }
 
+    public static NetworkConfiguration.Builder newNetworkConfiguration(int mode) { return NetworkConfiguration.newBuilder(); }
+
     public static Container.Builder newContainer() {
         return Container.newBuilder();
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job;
+
+/**
+ */
+
+public class NetworkConfiguration {
+
+    final private int networkMode;
+
+    public NetworkConfiguration(int networkMode) {
+        this.networkMode = networkMode;
+    }
+
+    public int getNetworkMode() { return networkMode; }
+
+    public String getNetworkModeName() {
+        return networkModeToName(networkMode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NetworkConfiguration netConfig = (NetworkConfiguration) o;
+        return networkMode == netConfig.networkMode;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilder(NetworkConfiguration networkConfiguration) {
+        return new Builder()
+                .withNetworkMode(networkConfiguration.getNetworkMode());
+    }
+
+    public static final class Builder {
+        private int networkMode;
+
+        private Builder() {
+        }
+
+        public Builder withNetworkMode(int networkMode) {
+            this.networkMode = networkMode;
+            return this;
+        }
+
+        public NetworkConfiguration build() {
+            return new NetworkConfiguration(networkMode);
+        }
+    }
+
+    public static String networkModeToName(int mode) {
+        // TODO: Use the generated protobuf version of this function if available?
+        switch (mode) {
+            case 0: return "UnknownNetworkMode";
+            case 1: return "Ipv4Only";
+            case 2: return "Ipv6AndIpv4";
+            case 3: return "Ipv6AndIpv4Fallback";
+            case 4: return "Ipv6Only";
+            default: return "";
+        }
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/JobDescriptorMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/JobDescriptorMixin.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.titus.api.jobmanager.model.job.Container;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobGroupInfo;
+import com.netflix.titus.api.jobmanager.model.job.NetworkConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.Owner;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.DisruptionBudget;
 
@@ -35,6 +36,7 @@ public abstract class JobDescriptorMixin {
                               @JsonProperty("labels") Map<String, String> labels,
                               @JsonProperty("container") Container container,
                               @JsonProperty("disruptionBudget") DisruptionBudget disruptionBudget,
+                              @JsonProperty("networkConfiguration") NetworkConfiguration networkConfiguration,
                               @JsonProperty("extensions") JobDescriptor.JobDescriptorExt extensions) {
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/NetworkConfigurationMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/NetworkConfigurationMixin.java
@@ -1,0 +1,11 @@
+package com.netflix.titus.api.jobmanager.store.mixin;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+public abstract class NetworkConfigurationMixin {
+
+    @JsonCreator
+    public NetworkConfigurationMixin(
+            @JsonProperty("networkMode") int networkMode) {
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
@@ -56,6 +56,7 @@ import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobGroupInfo;
 import com.netflix.titus.api.jobmanager.model.job.JobStatus;
+import com.netflix.titus.api.jobmanager.model.job.NetworkConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.Owner;
 import com.netflix.titus.api.jobmanager.model.job.SecurityProfile;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
@@ -116,6 +117,7 @@ import com.netflix.titus.api.jobmanager.store.mixin.JobMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.JobStatusMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.MigrationDetailsMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.MigrationPolicyMixin;
+import com.netflix.titus.api.jobmanager.store.mixin.NetworkConfigurationMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.OwnerMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.PercentagePerHourDisruptionBudgetRateMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.RatePerIntervalDisruptionBudgetRateMixIn;
@@ -269,6 +271,7 @@ public class ObjectMappers {
         objectMapper.addMixIn(Container.class, ContainerMixin.class);
         objectMapper.addMixIn(Image.class, ImageMixin.class);
         objectMapper.addMixIn(ServiceJobProcesses.class, ServiceJobProcessesMixin.class);
+        objectMapper.addMixIn(NetworkConfiguration.class, NetworkConfigurationMixin.class);
 
         objectMapper.addMixIn(IpAddressLocation.class, IpAddressLocationMixin.class);
         objectMapper.addMixIn(IpAddressAllocation.class, IpAddressAllocationMixin.class);

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
+import com.google.common.graph.Network;
 import com.google.protobuf.ByteString;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
 import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
@@ -37,6 +38,7 @@ import com.netflix.titus.api.jobmanager.model.job.JobModel;
 import com.netflix.titus.api.jobmanager.model.job.JobState;
 import com.netflix.titus.api.jobmanager.model.job.JobStatus;
 import com.netflix.titus.api.jobmanager.model.job.LogStorageInfo;
+import com.netflix.titus.api.jobmanager.model.job.NetworkConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.Owner;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobTask;
@@ -163,6 +165,7 @@ public final class GrpcJobManagementModelConverters {
                 .withJobGroupInfo(toCoreJobGroupInfo(grpcJobDescriptor.getJobGroupInfo()))
                 .withCapacityGroup(grpcJobDescriptor.getCapacityGroup())
                 .withContainer(toCoreContainer(grpcJobDescriptor.getContainer()))
+                .withNetworkConfiguration(toCoreNetworkConfiguration(grpcJobDescriptor.getNetworkConfiguration()))
                 .withAttributes(grpcJobDescriptor.getAttributesMap())
                 .withDisruptionBudget(toCoreDisruptionBudget(grpcJobDescriptor.getDisruptionBudget()))
                 .withExtensions(toCoreJobExtensions(grpcJobDescriptor))
@@ -197,6 +200,11 @@ public final class GrpcJobManagementModelConverters {
                 .withStack(grpcJobGroupInfo.getStack())
                 .withDetail(grpcJobGroupInfo.getDetail())
                 .withSequence(grpcJobGroupInfo.getSequence())
+                .build();
+    }
+
+    public static NetworkConfiguration toCoreNetworkConfiguration(com.netflix.titus.grpc.protogen.NetworkConfiguration grpcNetworkConfiguration) {
+        return JobModel.newNetworkConfiguration(grpcNetworkConfiguration.getNetworkMode().getNumber())
                 .build();
     }
 
@@ -655,6 +663,12 @@ public final class GrpcJobManagementModelConverters {
         return builder.build();
     }
 
+    private static com.netflix.titus.grpc.protogen.NetworkConfiguration toGrpcNetworkConfiguration(NetworkConfiguration networkConfiguration) {
+        com.netflix.titus.grpc.protogen.NetworkConfiguration.Builder builder = com.netflix.titus.grpc.protogen.NetworkConfiguration.newBuilder();
+        builder.setNetworkModeValue(networkConfiguration.getNetworkMode());
+        return builder.build();
+    }
+
     public static com.netflix.titus.grpc.protogen.ContainerResources.EfsMount toGrpcEfsMount(EfsMount coreEfsMount) {
         com.netflix.titus.grpc.protogen.ContainerResources.EfsMount.Builder builder = com.netflix.titus.grpc.protogen.ContainerResources.EfsMount.newBuilder()
                 .setEfsId(coreEfsMount.getEfsId())
@@ -914,6 +928,7 @@ public final class GrpcJobManagementModelConverters {
                 .setOwner(toGrpcOwner(jobDescriptor.getOwner()))
                 .setApplicationName(jobDescriptor.getApplicationName())
                 .setCapacityGroup(jobDescriptor.getCapacityGroup())
+                .setNetworkConfiguration(toGrpcNetworkConfiguration(jobDescriptor.getNetworkConfiguration()))
                 .setContainer(toGrpcContainer(jobDescriptor.getContainer()))
                 .setJobGroupInfo(toGrpcJobGroupInfo(jobDescriptor.getJobGroupInfo()))
                 .setDisruptionBudget(toGrpcDisruptionBudget(jobDescriptor.getDisruptionBudget()))

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -82,6 +82,10 @@ public class KubePodUtil {
                 task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_IP_ALLOCATION_ID),
                 id -> annotations.put(KubeConstants.STATIC_IP_ALLOCATION_ID, id)
         );
+        Evaluators.acceptNotNull(
+              job.getJobDescriptor().getNetworkConfiguration().getNetworkModeName(),
+                modeName -> annotations.put(KubeConstants.NETWORK_MODE, modeName)
+        );
 
         annotations.putAll(createEbsPodAnnotations(job, task));
 

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -208,4 +208,5 @@ public final class KubeConstants {
      */
     public static final String NETWORK_DOMAIN = "network." + NETFLIX_DOMAIN;
     public static final String STATIC_IP_ALLOCATION_ID = NETWORK_DOMAIN + "static-ip-allocation-uuid";
+    public static final String NETWORK_MODE = NETWORK_DOMAIN + "network-mode";
 }


### PR DESCRIPTION
Pairs with
https://github.com/Netflix/titus-api-definitions/pull/130

This represents a new place to put job-level networking
configuration (instead of container resources).
Starting with a new enum for networking mode.

My intent here is only to pass this through into the pod
for the backend to consume, no other logic in the control-plane
should be needed here.

----

I am over my head here. The test I wrote passes, but I can't explain why, and the other validator tests fail with

```
<[Validation failed: 'field: '', description: ''null' in fields: networkConfiguration', type: 'HARD'',
    Validation failed: 'field: 'container.securityProfile.securityGroups', description: 'Number of security groups must be between 1 and 6', type: 'HARD'']>
	at com.netflix.titus.api.jobmanager.model.job.sanitizer.JobModelSanitizationTest.testBatchWithNoSecurityGroup(JobModelSanitizationTest.java:178)
```

Which means that ... something in the way that I build the job model is leaving NetworkConfiguration null?

