### PR TITLE
Fix inconsistent EBS and IP index usage

### DIFF
--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizer.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/ExtendedJobSanitizer.java
@@ -95,14 +95,7 @@ class ExtendedJobSanitizer implements EntitySanitizer {
 
     @Override
     public <T> Set<ValidationError> validate(T entity) {
-        Set<ValidationError> errors = entitySanitizer.validate(entity);
-
-        if (entity instanceof com.netflix.titus.api.jobmanager.model.job.JobDescriptor) {
-            JobDescriptor jd = ((JobDescriptor)entity);
-            errors.addAll(JobAssertions.validateMatchingEbsAndIpZones(jd.getContainer().getContainerResources().getEbsVolumes(), jd.getContainer().getContainerResources().getSignedIpAddressAllocations()));
-        }
-
-        return errors;
+        return entitySanitizer.validate(entity);
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/DifferenceResolverUtils.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/DifferenceResolverUtils.java
@@ -252,7 +252,6 @@ public class DifferenceResolverUtils {
         // Get a sorted list of all IP allocations from the job
         List<String> unassignedIpAddressIds = refJobView.getJob().getJobDescriptor().getContainer().getContainerResources().getSignedIpAddressAllocations().stream()
                 .map(signedIpAddressAllocation -> signedIpAddressAllocation.getIpAddressAllocation().getAllocationId())
-                .sorted()
                 .collect(Collectors.toList());
 
         // Filter out those that are assigned
@@ -269,7 +268,6 @@ public class DifferenceResolverUtils {
         // Get a sorted list of all ebs values from the job
         List<String> unassignedEbsVolumeIds = refJobView.getJob().getJobDescriptor().getContainer().getContainerResources().getEbsVolumes().stream()
                 .map(EbsVolume::getVolumeId)
-                .sorted()
                 .collect(Collectors.toList());
 
         // Filter out those that are assigned


### PR DESCRIPTION
Fixes an issue where EBS and IP provided index orders were not being honored. The usage of `.sorted()` was legacy and not functionally adding anything.

Also, the validation of EBS and IP matching AZs is moved to the `JobEbsVolumeValidator` so that it only runs on TJC where the EbsVolume objects are sanitized.
