### PR TITLE
Add resourcePool to ApplicationSLA

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/endpoint/v2/rest/representation/ApplicationSlaRepresentation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/endpoint/v2/rest/representation/ApplicationSlaRepresentation.java
@@ -92,6 +92,11 @@ public class ApplicationSlaRepresentation {
      */
     private final String schedulerName;
 
+    /**
+     * Defines the resourcePool to use for managing capacity for applications using this SLA definition.
+     */
+    private final String resourcePool;
+
     @JsonCreator
     public ApplicationSlaRepresentation(@JsonProperty("appName") String appName,
                                         @JsonProperty("cellId") String cellId,
@@ -102,7 +107,8 @@ public class ApplicationSlaRepresentation {
                                         @JsonProperty("instanceNetworkMbs") Long instanceNetworkMbs,
                                         @JsonProperty("instanceCount") Integer instanceCount,
                                         @JsonProperty("reservationUsage") ReservationUsage reservationUsage,
-                                        @JsonProperty(value = "schedulerName", defaultValue = "fenzo") String schedulerName) {
+                                        @JsonProperty(value = "schedulerName", defaultValue = "fenzo") String schedulerName,
+                                        @JsonProperty("resourcePool") String resourcePool) {
         this.appName = appName;
         this.cellId = cellId;
         this.tier = tier;
@@ -113,6 +119,7 @@ public class ApplicationSlaRepresentation {
         this.instanceCount = instanceCount;
         this.reservationUsage = reservationUsage;
         this.schedulerName = schedulerName;
+        this.resourcePool = resourcePool;
     }
 
     public String getAppName() {
@@ -149,6 +156,10 @@ public class ApplicationSlaRepresentation {
 
     public ReservationUsage getReservationUsage() {
         return reservationUsage;
+    }
+
+    public String getResourcePool() {
+        return resourcePool;
     }
 
     public String getSchedulerName() {

--- a/titus-api/src/main/java/com/netflix/titus/api/model/ApplicationSLA.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/model/ApplicationSLA.java
@@ -21,12 +21,13 @@ import java.util.Objects;
 import com.google.common.base.Strings;
 import com.netflix.titus.common.util.StringExt;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_KUBE_SCHEDULER;
+
 /**
  * Application SLA definition.
  */
 public class ApplicationSLA {
-
-    public static final String DEFAULT_SCHEDULER_NAME = "fenzo";
 
     public static final String DEFAULT_CRITICAL_TIER_RESOURCE_POOL = "reserved";
 
@@ -62,7 +63,7 @@ public class ApplicationSLA {
         this.resourceDimension = resourceDimension;
         this.instanceCount = instanceCount;
         if (Strings.isNullOrEmpty(schedulerName)) {
-            this.schedulerName = DEFAULT_SCHEDULER_NAME;
+            this.schedulerName = SCHEDULER_NAME_FENZO;
         } else {
             this.schedulerName = schedulerName;
         }
@@ -74,7 +75,7 @@ public class ApplicationSLA {
         if (StringExt.isNotEmpty(resourcePool)) {
             this.resourcePool = resourcePool;
         } else {
-            if (Objects.equals(this.schedulerName, "kubeScheduler") && this.resourceDimension.getGpu() == 0L) {
+            if (Objects.equals(this.schedulerName, SCHEDULER_NAME_KUBE_SCHEDULER) && this.resourceDimension.getGpu() == 0L) {
                 if (tier == Tier.Critical) {
                     this.resourcePool = DEFAULT_CRITICAL_TIER_RESOURCE_POOL;
                 } else {

--- a/titus-api/src/main/java/com/netflix/titus/api/model/SchedulerConstants.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/model/SchedulerConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.model;
+
+/**
+ * Miscellaneous constants for supported Schedulers.
+ */
+public final class SchedulerConstants {
+    private SchedulerConstants() {
+    }
+
+    /**
+     * This constant is used to classify any {@link ApplicationSLA} instances associated with Fenzo scheduler.
+     */
+    public static final String SCHEDULER_NAME_FENZO = "fenzo";
+
+    /**
+     * This constant is used to identify any {@link ApplicationSLA} instances associated with Kube Scheduler.
+     */
+    public static final String SCHEDULER_NAME_KUBE_SCHEDULER = "kubeScheduler";
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/store/v2/ApplicationSlaMixIn.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/store/v2/ApplicationSlaMixIn.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.Tier;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
+
 /**
  * To better decouple service layer model from the persistence layer, we provide serialization
  * specific annotations via Jackson mix-ins.
@@ -33,7 +35,7 @@ public abstract class ApplicationSlaMixIn {
             @JsonProperty("tier") Tier tier,
             @JsonProperty("resourceDimension") ResourceDimension resourceDimension,
             @JsonProperty("instanceCount") int instanceCount,
-            @JsonProperty(value = "schedulerName", defaultValue = "fenzo") String schedulerName,
+            @JsonProperty(value = "schedulerName", defaultValue = SCHEDULER_NAME_FENZO) String schedulerName,
             @JsonProperty("resourcePool") String resourcePool) {
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/store/v2/ApplicationSlaMixIn.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/store/v2/ApplicationSlaMixIn.java
@@ -33,6 +33,7 @@ public abstract class ApplicationSlaMixIn {
             @JsonProperty("tier") Tier tier,
             @JsonProperty("resourceDimension") ResourceDimension resourceDimension,
             @JsonProperty("instanceCount") int instanceCount,
-            @JsonProperty(value = "schedulerName", defaultValue = "fenzo") String schedulerName) {
+            @JsonProperty(value = "schedulerName", defaultValue = "fenzo") String schedulerName,
+            @JsonProperty("resourcePool") String resourcePool) {
     }
 }

--- a/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraApplicationSlaStoreTest.java
+++ b/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraApplicationSlaStoreTest.java
@@ -76,8 +76,9 @@ public class CassandraApplicationSlaStoreTest {
         ApplicationSLA capacityGroup1 = ApplicationSlaSample.DefaultFlex.build();
         ApplicationSLA capacityGroup2 = ApplicationSlaSample.CriticalLarge.build();
         ApplicationSLA capacityGroup3 = ApplicationSlaSample.CriticalSmallKubeScheduler.build();
+        ApplicationSLA capacityGroup4 = ApplicationSlaSample.FlexSmallKubeScheduler.build();
 
-        List<ApplicationSLA> capacityGroups = Arrays.asList(capacityGroup1, capacityGroup2, capacityGroup3);
+        List<ApplicationSLA> capacityGroups = Arrays.asList(capacityGroup1, capacityGroup2, capacityGroup3, capacityGroup4);
 
         // Create initial
         ApplicationSlaStore bootstrappingTitusStore = createStore();
@@ -88,37 +89,46 @@ public class CassandraApplicationSlaStoreTest {
         // Read all
         ApplicationSlaStore store = createStore();
         List<ApplicationSLA> result = store.findAll().toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
-        assertThat(result).hasSize(3);
+        assertThat(result).hasSize(4);
         assertThat(result).containsAll(capacityGroups);
 
         // Find by name
         ApplicationSLA fetched = store.findByName(capacityGroup1.getAppName()).timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(fetched).isEqualTo(capacityGroup1);
+        assertThat(fetched.getSchedulerName()).isEqualTo(ApplicationSLA.DEFAULT_SCHEDULER_NAME);
+        assertThat(fetched.getResourcePool()).isEmpty();
 
         // Find by scheduler name
         List<ApplicationSLA> fetchedByFenzoScheduler = store.findBySchedulerName("fenzo").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(fetchedByFenzoScheduler).hasSize(2);
         assertThat(fetchedByFenzoScheduler).containsAll(ImmutableList.of(capacityGroup1, capacityGroup2));
 
-        List<ApplicationSLA> fetchByKubeScheduler = store.findBySchedulerName("kubescheduler").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
-        assertThat(fetchByKubeScheduler).hasSize(1);
-        assertThat(fetchByKubeScheduler).containsAll(ImmutableList.of(capacityGroup3));
+        List<ApplicationSLA> fetchByKubeScheduler = store.findBySchedulerName("kubeScheduler").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
+        assertThat(fetchByKubeScheduler).hasSize(2);
+        assertThat(fetchByKubeScheduler).containsAll(ImmutableList.of(capacityGroup3, capacityGroup4));
+        ApplicationSLA fetchedByKubeSchedulerCriticalTierApplicationSLA = fetchByKubeScheduler.stream().filter(applicationSLA -> applicationSLA.getAppName().equals(capacityGroup3.getAppName())).findFirst().orElseThrow(() -> new AssertionError("Expected value not found in the result"));
+        assertThat(fetchedByKubeSchedulerCriticalTierApplicationSLA.getSchedulerName()).isEqualTo("kubeScheduler");
+        assertThat(fetchedByKubeSchedulerCriticalTierApplicationSLA.getResourcePool()).isEqualTo(ApplicationSLA.DEFAULT_CRITICAL_TIER_RESOURCE_POOL);
+
+        ApplicationSLA fetchedByKubeSchedulerFlexTierApplicatonSLA = fetchByKubeScheduler.stream().filter(applicationSLA -> applicationSLA.getAppName().equals(capacityGroup4.getAppName())).findFirst().orElseThrow(() -> new AssertionError("Expected value not found in the result"));
+        assertThat(fetchedByKubeSchedulerFlexTierApplicatonSLA.getSchedulerName()).isEqualTo("kubeScheduler");
+        assertThat(fetchedByKubeSchedulerFlexTierApplicatonSLA.getResourcePool()).isEqualTo(ApplicationSLA.DEFAULT_FLEX_TIER_RESOURCE_POOL);
 
         // update an ApplicationSLA associated with fenzo to kubescheduler and verify the new set
-        ApplicationSLA updatedCapacityGroup = ApplicationSLA.newBuilder(capacityGroup1).withSchedulerName("kubescheduler").build();
+        ApplicationSLA updatedCapacityGroup = ApplicationSLA.newBuilder(capacityGroup1).withSchedulerName("kubeScheduler").build();
         assertThat(store.create(updatedCapacityGroup).toCompletable().await(TIMEOUT, TimeUnit.MILLISECONDS)).isTrue();
 
-        List<ApplicationSLA> fetchByKubeSchedulerAfterUpdate = store.findBySchedulerName("kubescheduler").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
-        assertThat(fetchByKubeSchedulerAfterUpdate).hasSize(2);
-        assertThat(fetchByKubeSchedulerAfterUpdate).containsAll(ImmutableList.of(updatedCapacityGroup, capacityGroup3));
+        List<ApplicationSLA> fetchByKubeSchedulerAfterUpdate = store.findBySchedulerName("kubeScheduler").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
+        assertThat(fetchByKubeSchedulerAfterUpdate).hasSize(3);
+        assertThat(fetchByKubeSchedulerAfterUpdate).containsAll(ImmutableList.of(updatedCapacityGroup, capacityGroup3, capacityGroup4));
 
         List<ApplicationSLA> fetchByFenzoAfterUpdate = store.findBySchedulerName("fenzo").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(fetchByFenzoAfterUpdate).hasSize(1);
         assertThat(fetchByFenzoAfterUpdate).containsAll(ImmutableList.of(capacityGroup2));
 
         List<ApplicationSLA> findAllResult = store.findAll().toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
-        assertThat(findAllResult).hasSize(3);
-        assertThat(findAllResult).containsAll(ImmutableList.of(updatedCapacityGroup, capacityGroup2, capacityGroup3));
+        assertThat(findAllResult).hasSize(4);
+        assertThat(findAllResult).containsAll(ImmutableList.of(updatedCapacityGroup, capacityGroup2, capacityGroup3, capacityGroup4));
 
         // Now delete
         assertThat(store.remove(capacityGroup1.getAppName()).toCompletable().await(TIMEOUT, TimeUnit.MILLISECONDS)).isTrue();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/v2/rest/Representation2ModelConvertions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/v2/rest/Representation2ModelConvertions.java
@@ -52,6 +52,7 @@ public final class Representation2ModelConvertions {
                 .withResourceDimension(resourceDimension)
                 .withInstanceCount(representation.getInstanceCount())
                 .withSchedulerName(representation.getSchedulerName())
+                .withResourcePool(representation.getResourcePool())
                 .build();
     }
 
@@ -73,7 +74,8 @@ public final class Representation2ModelConvertions {
                 resourceDimension.getNetworkMbs(),
                 coreEntity.getInstanceCount(),
                 reservationUsage,
-                coreEntity.getSchedulerName()
+                coreEntity.getSchedulerName(),
+                coreEntity.getResourcePool()
         );
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultTierSlaUpdater.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/scheduler/DefaultTierSlaUpdater.java
@@ -38,7 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Scheduler;
-import rx.schedulers.Schedulers;
+
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
 
 @Singleton
 public class DefaultTierSlaUpdater implements TierSlaUpdater {
@@ -84,7 +85,7 @@ public class DefaultTierSlaUpdater implements TierSlaUpdater {
     }
 
     private TieredQueueSlas recomputeSLAs() {
-        Collection<ApplicationSLA> applicationSLAs = applicationSlaManagementService.getApplicationSLAsForScheduler(ApplicationSLA.DEFAULT_SCHEDULER_NAME);
+        Collection<ApplicationSLA> applicationSLAs = applicationSlaManagementService.getApplicationSLAsForScheduler(SCHEDULER_NAME_FENZO);
 
         Map<Integer, ResAllocs> tierCapacities = new HashMap<>();
         Map<Integer, Map<String, ResAllocs>> slas = new HashMap<>();

--- a/titus-server-master/src/main/java/com/netflix/titus/master/service/management/ManagementSubsystemInitializer.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/service/management/ManagementSubsystemInitializer.java
@@ -22,10 +22,10 @@ import javax.inject.Singleton;
 import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.Tier;
-import com.netflix.titus.common.util.guice.annotation.Activator;
-import com.netflix.titus.master.service.management.CapacityManagementConfiguration.ResourceDimensionConfiguration;
 import com.netflix.titus.api.store.v2.ApplicationSlaStore;
 import com.netflix.titus.api.store.v2.exception.NotFoundException;
+import com.netflix.titus.common.util.guice.annotation.Activator;
+import com.netflix.titus.master.service.management.CapacityManagementConfiguration.ResourceDimensionConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -69,6 +69,7 @@ public class ManagementSubsystemInitializer {
                 .withAppName(ApplicationSlaManagementService.DEFAULT_APPLICATION)
                 .withTier(Tier.Flex)
                 .withSchedulerName(configuration.getDefaultSchedulerName())
+                .withResourcePool("")
                 .withInstanceCount(configuration.getDefaultApplicationInstanceCount())
                 .withResourceDimension(ResourceDimension.newBuilder()
                         .withCpus(rdConf.getCPU())

--- a/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ApplicationSlaManagementResourceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ApplicationSlaManagementResourceTest.java
@@ -28,9 +28,9 @@ import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.common.util.archaius2.Archaius2Ext;
 import com.netflix.titus.master.config.MasterConfiguration;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
-import com.netflix.titus.runtime.endpoint.rest.ErrorResponse;
 import com.netflix.titus.runtime.endpoint.common.rest.JsonMessageReaderWriter;
 import com.netflix.titus.runtime.endpoint.common.rest.TitusExceptionMapper;
+import com.netflix.titus.runtime.endpoint.rest.ErrorResponse;
 import com.netflix.titus.testkit.data.core.ApplicationSlaSample;
 import com.netflix.titus.testkit.junit.category.IntegrationTest;
 import com.netflix.titus.testkit.junit.jaxrs.JaxRsServerResource;
@@ -46,6 +46,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import rx.Observable;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_KUBE_SCHEDULER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -147,13 +148,13 @@ public class ApplicationSlaManagementResourceTest {
 
     @Test
     public void getApplicationSlaBySchedulerName() {
-        when(capacityManagementService.getApplicationSLAsForScheduler("kubeScheduler")).thenReturn(Arrays.asList(SAMPLE_SLA_MANAGED_BY_KUBESCHEDULER));
+        when(capacityManagementService.getApplicationSLAsForScheduler(SCHEDULER_NAME_KUBE_SCHEDULER)).thenReturn(Arrays.asList(SAMPLE_SLA_MANAGED_BY_KUBESCHEDULER));
         testClient.get()
-                .uri(uriBuilder -> uriBuilder.queryParam("schedulerName", "kubeScheduler").build())
+                .uri(uriBuilder -> uriBuilder.queryParam("schedulerName", SCHEDULER_NAME_KUBE_SCHEDULER).build())
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(APPLICATION_SLA_KUBE_SCHEDULER_REP_LIST_TR).value(result -> assertThat(result).hasSize(1));
-        verify(capacityManagementService, times(1)).getApplicationSLAsForScheduler("kubeScheduler");
+        verify(capacityManagementService, times(1)).getApplicationSLAsForScheduler(SCHEDULER_NAME_KUBE_SCHEDULER);
     }
 
     @Test

--- a/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ApplicationSlaManagementResourceTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/endpoint/v2/rest/ApplicationSlaManagementResourceTest.java
@@ -147,13 +147,13 @@ public class ApplicationSlaManagementResourceTest {
 
     @Test
     public void getApplicationSlaBySchedulerName() {
-        when(capacityManagementService.getApplicationSLAsForScheduler("kubescheduler")).thenReturn(Arrays.asList(SAMPLE_SLA_MANAGED_BY_KUBESCHEDULER));
+        when(capacityManagementService.getApplicationSLAsForScheduler("kubeScheduler")).thenReturn(Arrays.asList(SAMPLE_SLA_MANAGED_BY_KUBESCHEDULER));
         testClient.get()
-                .uri(uriBuilder -> uriBuilder.queryParam("schedulerName", "kubescheduler").build())
+                .uri(uriBuilder -> uriBuilder.queryParam("schedulerName", "kubeScheduler").build())
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(APPLICATION_SLA_KUBE_SCHEDULER_REP_LIST_TR).value(result -> assertThat(result).hasSize(1));
-        verify(capacityManagementService, times(1)).getApplicationSLAsForScheduler("kubescheduler");
+        verify(capacityManagementService, times(1)).getApplicationSLAsForScheduler("kubeScheduler");
     }
 
     @Test

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedApplicationSlaManagementService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedApplicationSlaManagementService.java
@@ -26,6 +26,8 @@ import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import rx.Observable;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
+
 class StubbedApplicationSlaManagementService implements ApplicationSlaManagementService {
 
     private static final ApplicationSLA DEFAULT = new ApplicationSLA(
@@ -33,7 +35,7 @@ class StubbedApplicationSlaManagementService implements ApplicationSlaManagement
             Tier.Flex,
             ResourceDimension.newBuilder().withCpus(16).withMemoryMB(32 * 1024).withNetworkMbs(4096).withDiskMB(100 * 1024).build(),
             10,
-            "fenzo",
+            SCHEDULER_NAME_FENZO,
             ""
     );
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedApplicationSlaManagementService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedApplicationSlaManagementService.java
@@ -33,7 +33,8 @@ class StubbedApplicationSlaManagementService implements ApplicationSlaManagement
             Tier.Flex,
             ResourceDimension.newBuilder().withCpus(16).withMemoryMB(32 * 1024).withNetworkMbs(4096).withDiskMB(100 * 1024).build(),
             10,
-            "fenzo"
+            "fenzo",
+            ""
     );
 
     @Override

--- a/titus-server-master/src/test/java/com/netflix/titus/master/scheduler/DefaultTierSlaUpdaterTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/scheduler/DefaultTierSlaUpdaterTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
 import static com.netflix.titus.master.model.ResourceDimensions.fromResAllocs;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +72,7 @@ public class DefaultTierSlaUpdaterTest {
         when(availableCapacityService.totalCapacityOf(Tier.Critical)).thenReturn(Optional.of(CRITICAL_CAPACITY));
         when(availableCapacityService.totalCapacityOf(Tier.Flex)).thenReturn(Optional.of(FLEX_CAPACITY));
 
-        when(applicationSlaManagementService.getApplicationSLAsForScheduler(ApplicationSLA.DEFAULT_SCHEDULER_NAME)).thenReturn(
+        when(applicationSlaManagementService.getApplicationSLAsForScheduler(SCHEDULER_NAME_FENZO)).thenReturn(
                 asList(FLEX_CAPACITY_GROUP, CRITICAL_CAPACITY_GROUP)
         );
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/store/cache/ApplicationSlaStoreCacheTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/store/cache/ApplicationSlaStoreCacheTest.java
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_KUBE_SCHEDULER;
 import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.CriticalSmall;
 import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.CriticalSmallKubeScheduler;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,10 +76,10 @@ public class ApplicationSlaStoreCacheTest {
 
     @Test
     public void testFindBySchedulerName() throws Exception {
-        List<ApplicationSLA> allFenzoApplicationSLAs = store.findBySchedulerName("fenzo").toList().toBlocking().first();
+        List<ApplicationSLA> allFenzoApplicationSLAs = store.findBySchedulerName(SCHEDULER_NAME_FENZO).toList().toBlocking().first();
         assertThat(allFenzoApplicationSLAs).hasSize(INIT_SIZE - 1);
 
-        List<ApplicationSLA> allKubeSchedulerApplicationSLAs = store.findBySchedulerName("kubeScheduler").toList().toBlocking().first();
+        List<ApplicationSLA> allKubeSchedulerApplicationSLAs = store.findBySchedulerName(SCHEDULER_NAME_KUBE_SCHEDULER).toList().toBlocking().first();
         assertThat(allKubeSchedulerApplicationSLAs).hasSize(1);
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/store/cache/ApplicationSlaStoreCacheTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/store/cache/ApplicationSlaStoreCacheTest.java
@@ -24,11 +24,12 @@ import com.netflix.titus.api.store.v2.ApplicationSlaStore;
 import com.netflix.titus.api.store.v2.ApplicationSlaStoreCache;
 import com.netflix.titus.api.store.v2.exception.NotFoundException;
 import com.netflix.titus.testkit.data.core.ApplicationSlaGenerator;
-
 import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
 
+import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.CriticalSmall;
+import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.CriticalSmallKubeScheduler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.anyString;
@@ -36,8 +37,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.*;
 
 public class ApplicationSlaStoreCacheTest {
 
@@ -78,7 +77,7 @@ public class ApplicationSlaStoreCacheTest {
         List<ApplicationSLA> allFenzoApplicationSLAs = store.findBySchedulerName("fenzo").toList().toBlocking().first();
         assertThat(allFenzoApplicationSLAs).hasSize(INIT_SIZE - 1);
 
-        List<ApplicationSLA> allKubeSchedulerApplicationSLAs = store.findBySchedulerName("kubescheduler").toList().toBlocking().first();
+        List<ApplicationSLA> allKubeSchedulerApplicationSLAs = store.findBySchedulerName("kubeScheduler").toList().toBlocking().first();
         assertThat(allKubeSchedulerApplicationSLAs).hasSize(1);
     }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/store/memory/InMemoryApplicationSlaStoreTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/store/memory/InMemoryApplicationSlaStoreTest.java
@@ -23,11 +23,11 @@ import java.util.concurrent.TimeUnit;
 import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.api.store.v2.ApplicationSlaStore;
 import com.netflix.titus.api.store.v2.ApplicationSlaStoreCache;
-
 import org.junit.Test;
 
-import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.CriticalSmall;
+import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.DefaultFlex;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InMemoryApplicationSlaStoreTest {
 
@@ -38,7 +38,7 @@ public class InMemoryApplicationSlaStoreTest {
         ApplicationSlaStore store = createStore();
         ApplicationSLA capacityGroup1 = DefaultFlex.build();
         ApplicationSLA capacityGroup2 = CriticalSmall.builder()
-                .withSchedulerName("kubescheduler").build();
+                .withSchedulerName("kubeScheduler").build();
 
         List<ApplicationSLA> capacityGroups = Arrays.asList(capacityGroup1, capacityGroup2);
 
@@ -62,7 +62,7 @@ public class InMemoryApplicationSlaStoreTest {
         result = store.findBySchedulerName("fenzo").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(result).containsExactlyInAnyOrder(capacityGroup1);
 
-        result = store.findBySchedulerName("kubescheduler").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
+        result = store.findBySchedulerName("kubeScheduler").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(result).containsExactlyInAnyOrder(capacityGroup2);
 
         // find by non-existent scheduler name
@@ -70,7 +70,7 @@ public class InMemoryApplicationSlaStoreTest {
         assertThat(result).isEmpty();
 
         // update scheduler name and verify
-        ApplicationSLA updatedCapacityGroup = ApplicationSLA.newBuilder(capacityGroup1).withSchedulerName("kubescheduler").build();
+        ApplicationSLA updatedCapacityGroup = ApplicationSLA.newBuilder(capacityGroup1).withSchedulerName("kubeScheduler").build();
         assertThat(store.create(updatedCapacityGroup).toCompletable().await(TIMEOUT, TimeUnit.MILLISECONDS)).isTrue();
         result = store.findAll().toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(result).containsExactlyInAnyOrder(updatedCapacityGroup, capacityGroup2);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/store/memory/InMemoryApplicationSlaStoreTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/store/memory/InMemoryApplicationSlaStoreTest.java
@@ -25,6 +25,8 @@ import com.netflix.titus.api.store.v2.ApplicationSlaStore;
 import com.netflix.titus.api.store.v2.ApplicationSlaStoreCache;
 import org.junit.Test;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_KUBE_SCHEDULER;
 import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.CriticalSmall;
 import static com.netflix.titus.testkit.data.core.ApplicationSlaSample.DefaultFlex;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +40,7 @@ public class InMemoryApplicationSlaStoreTest {
         ApplicationSlaStore store = createStore();
         ApplicationSLA capacityGroup1 = DefaultFlex.build();
         ApplicationSLA capacityGroup2 = CriticalSmall.builder()
-                .withSchedulerName("kubeScheduler").build();
+                .withSchedulerName(SCHEDULER_NAME_KUBE_SCHEDULER).build();
 
         List<ApplicationSLA> capacityGroups = Arrays.asList(capacityGroup1, capacityGroup2);
 
@@ -59,10 +61,10 @@ public class InMemoryApplicationSlaStoreTest {
         assertThat(result).containsExactlyInAnyOrder(capacityGroup1);
 
         // find by scheduler name
-        result = store.findBySchedulerName("fenzo").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
+        result = store.findBySchedulerName(SCHEDULER_NAME_FENZO).toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(result).containsExactlyInAnyOrder(capacityGroup1);
 
-        result = store.findBySchedulerName("kubeScheduler").toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
+        result = store.findBySchedulerName(SCHEDULER_NAME_KUBE_SCHEDULER).toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(result).containsExactlyInAnyOrder(capacityGroup2);
 
         // find by non-existent scheduler name
@@ -70,7 +72,7 @@ public class InMemoryApplicationSlaStoreTest {
         assertThat(result).isEmpty();
 
         // update scheduler name and verify
-        ApplicationSLA updatedCapacityGroup = ApplicationSLA.newBuilder(capacityGroup1).withSchedulerName("kubeScheduler").build();
+        ApplicationSLA updatedCapacityGroup = ApplicationSLA.newBuilder(capacityGroup1).withSchedulerName(SCHEDULER_NAME_KUBE_SCHEDULER).build();
         assertThat(store.create(updatedCapacityGroup).toCompletable().await(TIMEOUT, TimeUnit.MILLISECONDS)).isTrue();
         result = store.findAll().toList().timeout(TIMEOUT, TimeUnit.MILLISECONDS).toBlocking().first();
         assertThat(result).containsExactlyInAnyOrder(updatedCapacityGroup, capacityGroup2);

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriterTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriterTest.java
@@ -63,7 +63,7 @@ public class JsonMessageReaderWriterTest {
     @Test
     public void testFieldsSelection() throws Exception {
         ApplicationSlaRepresentation myAppSla = new ApplicationSlaRepresentation(
-                "myApp", null, TierRepresentation.Critical, 1D, 2L, 3L, 4L, 5, null, null
+                "myApp", null, TierRepresentation.Critical, 1D, 2L, 3L, 4L, 5, null, null, ""
         );
 
         when(httpServletRequest.getParameter(JsonMessageReaderWriter.FIELDS_PARAM)).thenReturn("appName,instanceCPU");

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/data/core/ApplicationSlaSample.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/data/core/ApplicationSlaSample.java
@@ -82,12 +82,23 @@ public enum ApplicationSlaSample {
                     .withInstanceCount(2);
         }
     },
+    FlexSmallKubeScheduler() {
+        @Override
+        public ApplicationSLA.Builder builder() {
+            return ApplicationSLA.newBuilder(CriticalSmall.build())
+                    .withAppName("flexSmallKubeSchedulerApp")
+                    .withTier(Tier.Flex)
+                    .withSchedulerName("kubeScheduler")
+                    .withInstanceCount(2);
+        }
+    },
     CriticalSmallKubeScheduler() {
         @Override
         public ApplicationSLA.Builder builder() {
             return CriticalSmall.builder()
                     .withAppName("criticalSmallKubeSchedulerApp")
-                    .withSchedulerName("kubescheduler");
+                    .withSchedulerName("kubeScheduler")
+                    .withResourcePool("reserved");
         }
     };
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/data/core/ApplicationSlaSample.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/data/core/ApplicationSlaSample.java
@@ -27,6 +27,7 @@ import com.netflix.titus.common.aws.AwsInstanceDescriptor;
 import com.netflix.titus.common.aws.AwsInstanceType;
 import com.netflix.titus.master.model.ResourceDimensions;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_KUBE_SCHEDULER;
 import static com.netflix.titus.master.endpoint.v2.rest.ApplicationSlaManagementEndpoint.DEFAULT_APPLICATION;
 
 /**
@@ -88,7 +89,7 @@ public enum ApplicationSlaSample {
             return ApplicationSLA.newBuilder(CriticalSmall.build())
                     .withAppName("flexSmallKubeSchedulerApp")
                     .withTier(Tier.Flex)
-                    .withSchedulerName("kubeScheduler")
+                    .withSchedulerName(SCHEDULER_NAME_KUBE_SCHEDULER)
                     .withInstanceCount(2);
         }
     },
@@ -97,7 +98,7 @@ public enum ApplicationSlaSample {
         public ApplicationSLA.Builder builder() {
             return CriticalSmall.builder()
                     .withAppName("criticalSmallKubeSchedulerApp")
-                    .withSchedulerName("kubeScheduler")
+                    .withSchedulerName(SCHEDULER_NAME_KUBE_SCHEDULER)
                     .withResourcePool("reserved");
         }
     };


### PR DESCRIPTION
Add resourcePool to ApplicationSLA

- Set default value for resourcePool to reserved/elastic for non-GPU critical/flex tier capacity groups when scheduler is set to kubeScheduler
- In additional to creating a mechanism to separate capacity management at ApplicationSLA (Capacity Group)m, this change enables GPU capacity management where there may be multiple pools of GPU instances
