### PR TITLE
Add capacity group based pod resource pool resolver

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodModule.java
@@ -33,6 +33,7 @@ import com.netflix.titus.master.kubernetes.pod.resourcepool.ExplicitJobPodResour
 import com.netflix.titus.master.kubernetes.pod.resourcepool.FarzonePodResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.FenzoPodResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.GpuPodResourcePoolResolver;
+import com.netflix.titus.master.kubernetes.pod.resourcepool.KubeSchedulerPodResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.PodResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.PodResourcePoolResolverChain;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.PodResourcePoolResolverFeatureGuard;
@@ -64,6 +65,7 @@ public class KubePodModule extends AbstractModule {
         return new PodResourcePoolResolverFeatureGuard(
                 configuration,
                 new PodResourcePoolResolverChain(Arrays.asList(
+                        new KubeSchedulerPodResourcePoolResolver(capacityGroupService),
                         new FenzoPodResourcePoolResolver(capacityGroupService),
                         new ExplicitJobPodResourcePoolResolver(),
                         new FarzonePodResourcePoolResolver(configuration),
@@ -75,7 +77,7 @@ public class KubePodModule extends AbstractModule {
                                 titusRuntime
                         ),
                         new TierPodResourcePoolResolver(capacityGroupService)
-                ))
+                ), titusRuntime)
         );
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/KubeSchedulerPodResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/KubeSchedulerPodResourcePoolResolver.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.pod.resourcepool;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+
+public class KubeSchedulerPodResourcePoolResolver implements PodResourcePoolResolver {
+
+    private final ApplicationSlaManagementService capacityGroupService;
+
+    public KubeSchedulerPodResourcePoolResolver(ApplicationSlaManagementService capacityGroupService) {
+        this.capacityGroupService = capacityGroupService;
+    }
+
+    @Override
+    public List<ResourcePoolAssignment> resolve(Job<?> job, Task task) {
+        if (!JobFunctions.isOwnedByKubeScheduler(task)) {
+            return Collections.emptyList();
+        }
+
+        ApplicationSLA capacityGroup = JobManagerUtil.getCapacityGroupDescriptor(job.getJobDescriptor(), capacityGroupService);
+        if (capacityGroup != null && StringExt.isNotEmpty(capacityGroup.getResourcePool())) {
+            String resourcePoolName = capacityGroup.getResourcePool();
+            return Collections.singletonList(ResourcePoolAssignment.newBuilder()
+                    .withResourcePoolName(resourcePoolName)
+                    .withRule("Kube-Scheduler task assigned to application Capacity Group " + resourcePoolName)
+                    .build());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/PodResourcePoolResolverChainTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/PodResourcePoolResolverChainTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.testkit.model.job.JobGenerator;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class PodResourcePoolResolverChainTest {
     private final PodResourcePoolResolver delegate1 = mock(PodResourcePoolResolver.class);
     private final PodResourcePoolResolver delegate2 = mock(PodResourcePoolResolver.class);
 
-    private final PodResourcePoolResolverChain resolver = new PodResourcePoolResolverChain(Arrays.asList(delegate1, delegate2));
+    private final PodResourcePoolResolverChain resolver = new PodResourcePoolResolverChain(Arrays.asList(delegate1, delegate2), TitusRuntimes.internal());
 
     @Test
     public void testChainedExecution() {


### PR DESCRIPTION
### Description of the Change

* Added a new resource pool resolver for pods when their associated capacity groups are enabled for kube scheduler and have a well-defined resource pool
* Provides a mechanism for controlling resource pool assignments from respective capacity groups (for example, GPU resource pools) which may have different underlying behaviors for capacity management
* Introduced a counter to track which pod resource pool resolver is active