### PR TITLE
Support for creating CapacityGroups with GPU resource dimension

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/endpoint/v2/rest/representation/ApplicationSlaRepresentation.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/endpoint/v2/rest/representation/ApplicationSlaRepresentation.java
@@ -80,6 +80,9 @@ public class ApplicationSlaRepresentation {
     @Min(value = 1, message = "'instanceCount' must be at least 1")
     private final Integer instanceCount;
 
+    @Min(value = 0, message = "'instanceGPU' must be at least 0")
+    private final Long instanceGPU;
+
     // ----------------------------------------------------------------
     // Fields of the extended model.
 
@@ -105,6 +108,7 @@ public class ApplicationSlaRepresentation {
                                         @JsonProperty("instanceMemoryMB") Long instanceMemoryMB,
                                         @JsonProperty("instanceDiskMB") Long instanceDiskMB,
                                         @JsonProperty("instanceNetworkMbs") Long instanceNetworkMbs,
+                                        @JsonProperty(value = "instanceGPU", defaultValue = "0") Long instanceGPU,
                                         @JsonProperty("instanceCount") Integer instanceCount,
                                         @JsonProperty("reservationUsage") ReservationUsage reservationUsage,
                                         @JsonProperty(value = "schedulerName", defaultValue = "fenzo") String schedulerName,
@@ -116,6 +120,11 @@ public class ApplicationSlaRepresentation {
         this.instanceMemoryMB = instanceMemoryMB;
         this.instanceDiskMB = instanceDiskMB;
         this.instanceNetworkMbs = instanceNetworkMbs;
+        if (instanceGPU == null) {
+            this.instanceGPU = 0L;
+        } else {
+            this.instanceGPU = instanceGPU;
+        }
         this.instanceCount = instanceCount;
         this.reservationUsage = reservationUsage;
         this.schedulerName = schedulerName;
@@ -148,6 +157,10 @@ public class ApplicationSlaRepresentation {
 
     public Long getInstanceNetworkMbs() {
         return instanceNetworkMbs;
+    }
+
+    public Long getInstanceGPU() {
+        return instanceGPU;
     }
 
     public Integer getInstanceCount() {

--- a/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraApplicationSlaStoreTest.java
+++ b/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraApplicationSlaStoreTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import com.datastax.driver.core.Session;
 import com.google.common.collect.ImmutableList;
 import com.netflix.titus.api.model.ApplicationSLA;
-import static com.netflix.titus.api.model.SchedulerConstants.*;
 import com.netflix.titus.api.store.v2.ApplicationSlaStore;
 import com.netflix.titus.testkit.data.core.ApplicationSlaSample;
 import com.netflix.titus.testkit.junit.category.IntegrationNotParallelizableTest;
@@ -36,6 +35,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_FENZO;
+import static com.netflix.titus.api.model.SchedulerConstants.SCHEDULER_NAME_KUBE_SCHEDULER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/v2/rest/Representation2ModelConvertions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/endpoint/v2/rest/Representation2ModelConvertions.java
@@ -37,6 +37,7 @@ public final class Representation2ModelConvertions {
                 .withMemoryMB(representation.getInstanceMemoryMB())
                 .withDiskMB(representation.getInstanceDiskMB())
                 .withNetworkMbs(representation.getInstanceNetworkMbs())
+                .withGpu(representation.getInstanceGPU())
                 .build();
 
         Tier tier;
@@ -72,6 +73,7 @@ public final class Representation2ModelConvertions {
                 resourceDimension.getMemoryMB(),
                 resourceDimension.getDiskMB(),
                 resourceDimension.getNetworkMbs(),
+                resourceDimension.getGpu(),
                 coreEntity.getInstanceCount(),
                 reservationUsage,
                 coreEntity.getSchedulerName(),

--- a/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriterTest.java
+++ b/titus-server-runtime/src/test/java/com/netflix/titus/runtime/endpoint/common/rest/JsonMessageReaderWriterTest.java
@@ -63,7 +63,7 @@ public class JsonMessageReaderWriterTest {
     @Test
     public void testFieldsSelection() throws Exception {
         ApplicationSlaRepresentation myAppSla = new ApplicationSlaRepresentation(
-                "myApp", null, TierRepresentation.Critical, 1D, 2L, 3L, 4L, 5, null, null, ""
+                "myApp", null, TierRepresentation.Critical, 1D, 2L, 3L, 4L, 5L, null, null, "", ""
         );
 
         when(httpServletRequest.getParameter(JsonMessageReaderWriter.FIELDS_PARAM)).thenReturn("appName,instanceCPU");


### PR DESCRIPTION
### Description of the Change

* Allow management of Capacity Groups with GPU resource dimension through application management v2 api
* Default value for the `instanceGPU` is 0 and it is optionally set to maintain backward compatibility of the API
* This API will be used by Titus UI and Capacity Controller to keep Capacity Groups' GPU asks in sync
