### PR TITLE
Converting Java streams call to for-loop

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -642,7 +642,10 @@ public class DefaultV3JobOperations implements V3JobOperations {
     }
 
     private Pair<Job<?>, List<Task>> toJobTasksPair(EntityHolder jobHolder) {
-        List<Task> tasks = jobHolder.getChildren().stream().map(childHolder -> (Task) childHolder.getEntity()).collect(Collectors.toList());
+        List<Task> tasks = new ArrayList<>();
+        for (EntityHolder childHolder : jobHolder.getChildren()) {
+            tasks.add(childHolder.getEntity());
+        }
         return Pair.of(jobHolder.getEntity(), tasks);
     }
 


### PR DESCRIPTION
### Description of the Change

When JVM hiccup alert was triggering, we noticed a thread consuming quite a lot of CPU in this function. Converting this away from Java streams use to relieve some pressure as per our previous optimizations in this space. 