### PR TITLE
tolerate decommissioning nodes by default

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/taint/DefaultTaintTolerationFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/taint/DefaultTaintTolerationFactory.java
@@ -56,7 +56,7 @@ public class DefaultTaintTolerationFactory implements TaintTolerationFactory {
         tolerations.add(Tolerations.TOLERATION_VIRTUAL_KUBLET);
         V1Toleration schedulerToleration = useKubeScheduler ? Tolerations.TOLERATION_KUBE_SCHEDULER : Tolerations.TOLERATION_FENZO_SCHEDULER;
         tolerations.add(schedulerToleration);
-        resolveDecomissioningToleration(job).ifPresent(tolerations::add);
+        resolveDecommissioningToleration(job).ifPresent(tolerations::add);
         tolerations.add(resolveTierToleration(job));
         resolveAvailabilityZoneToleration(job).ifPresent(tolerations::add);
         resolveGpuInstanceTypeToleration(job).ifPresent(tolerations::add);
@@ -69,11 +69,11 @@ public class DefaultTaintTolerationFactory implements TaintTolerationFactory {
      * All tasks by default tolerate nodes being decommissioned, unless their job has the {@link JobConstraints#ACTIVE_HOST}
      * hard constraint
      */
-    private Optional<V1Toleration> resolveDecomissioningToleration(Job<?> job) {
+    private Optional<V1Toleration> resolveDecommissioningToleration(Job<?> job) {
         if (JobFunctions.findHardConstraint(job, JobConstraints.ACTIVE_HOST).isPresent()) {
             return Optional.empty();
         }
-        return Optional.of(Tolerations.TOLERATION_DECOMISSIONING);
+        return Optional.of(Tolerations.TOLERATION_DECOMMISSIONING);
     }
 
     private V1Toleration resolveTierToleration(Job<?> job) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/taint/Tolerations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/taint/Tolerations.java
@@ -63,4 +63,9 @@ public final class Tolerations {
             .key(KubeConstants.TAINT_GPU_INSTANCE)
             .operator("Exists")
             .effect("NoSchedule");
+
+    public static final V1Toleration TOLERATION_DECOMISSIONING = new V1Toleration()
+            .key(KubeConstants.TAINT_NODE_DECOMISSIONING)
+            .operator("Exists")
+            .effect("NoSchedule");
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/taint/Tolerations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/taint/Tolerations.java
@@ -64,8 +64,8 @@ public final class Tolerations {
             .operator("Exists")
             .effect("NoSchedule");
 
-    public static final V1Toleration TOLERATION_DECOMISSIONING = new V1Toleration()
-            .key(KubeConstants.TAINT_NODE_DECOMISSIONING)
+    public static final V1Toleration TOLERATION_DECOMMISSIONING = new V1Toleration()
+            .key(KubeConstants.TAINT_NODE_DECOMMISSIONING)
             .operator("Exists")
             .effect("NoSchedule");
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/taint/DefaultTaintTolerationFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/taint/DefaultTaintTolerationFactoryTest.java
@@ -46,6 +46,15 @@ public class DefaultTaintTolerationFactoryTest {
     );
 
     @Test
+    public void decommissioningNodesAreTolerated() {
+        List<V1Toleration> tolerations = factory.buildV1Toleration(JobGenerator.oneBatchJob(), JobGenerator.oneBatchTask(), true);
+        assertThat(tolerations).contains(Tolerations.TOLERATION_DECOMISSIONING);
+
+        List<V1Toleration> withConstraints = factory.buildV1Toleration(newJobWithConstraint(JobConstraints.ACTIVE_HOST, "true"), JobGenerator.oneBatchTask(), true);
+        assertThat(withConstraints).doesNotContain(Tolerations.TOLERATION_DECOMISSIONING);
+    }
+
+    @Test
     public void testGpuInstanceAssignment() {
         List<V1Toleration> tolerations = factory.buildV1Toleration(newGpuJob(), JobGenerator.oneBatchTask(), true);
         V1Toleration gpuToleration = tolerations.stream().filter(t -> t.getKey().equals(KubeConstants.TAINT_GPU_INSTANCE)).findFirst().orElse(null);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/taint/DefaultTaintTolerationFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/taint/DefaultTaintTolerationFactoryTest.java
@@ -48,10 +48,10 @@ public class DefaultTaintTolerationFactoryTest {
     @Test
     public void decommissioningNodesAreTolerated() {
         List<V1Toleration> tolerations = factory.buildV1Toleration(JobGenerator.oneBatchJob(), JobGenerator.oneBatchTask(), true);
-        assertThat(tolerations).contains(Tolerations.TOLERATION_DECOMISSIONING);
+        assertThat(tolerations).contains(Tolerations.TOLERATION_DECOMMISSIONING);
 
         List<V1Toleration> withConstraints = factory.buildV1Toleration(newJobWithConstraint(JobConstraints.ACTIVE_HOST, "true"), JobGenerator.oneBatchTask(), true);
-        assertThat(withConstraints).doesNotContain(Tolerations.TOLERATION_DECOMISSIONING);
+        assertThat(withConstraints).doesNotContain(Tolerations.TOLERATION_DECOMMISSIONING);
     }
 
     @Test

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -134,6 +134,15 @@ public final class KubeConstants {
      */
     public static final String TAINT_KUBE_BACKEND = TITUS_NODE_DOMAIN + "backend";
 
+    /**
+     * Nodes with this taint have are in the process of being decommissioned. Effects have different meaning:
+     *
+     * - <code>PreferNoSchedule</code>: nodes being drained, while preserving capacity if needed
+     * - <code>NoSchedule</code>: used to avoid placing tasks with the {@link com.netflix.titus.api.jobmanager.JobConstraints#ACTIVE_HOST} onto nodes being decommissioned
+     * - <code>NoExecute</code>: nodes being actively evacuated by task relocation
+     */
+    public static final String TAINT_NODE_DECOMISSIONING = TITUS_NODE_DOMAIN + "decommissioning";
+
     /*
      * Opportunistic scheduling annotations
      */

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -135,13 +135,13 @@ public final class KubeConstants {
     public static final String TAINT_KUBE_BACKEND = TITUS_NODE_DOMAIN + "backend";
 
     /**
-     * Nodes with this taint have are in the process of being decommissioned. Effects have different meaning:
+     * Nodes with this taint are in the process of being decommissioned. Effects have different meaning:
      *
-     * - <code>PreferNoSchedule</code>: nodes being drained, while preserving capacity if needed
+     * - <code>PreferNoSchedule</code>: nodes being drained, and capacity is preserved if needed
      * - <code>NoSchedule</code>: used to avoid placing tasks with the {@link com.netflix.titus.api.jobmanager.JobConstraints#ACTIVE_HOST} onto nodes being decommissioned
      * - <code>NoExecute</code>: nodes being actively evacuated by task relocation
      */
-    public static final String TAINT_NODE_DECOMISSIONING = TITUS_NODE_DOMAIN + "decommissioning";
+    public static final String TAINT_NODE_DECOMMISSIONING = TITUS_NODE_DOMAIN + "decommissioning";
 
     /*
      * Opportunistic scheduling annotations


### PR DESCRIPTION
unless jobs have the `activehost` hard constraint