### PR TITLE
Self Managed relocation plan creation fixed

### DIFF
--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -40,6 +41,8 @@ import com.netflix.titus.supplementary.relocation.connector.Node;
 import com.netflix.titus.supplementary.relocation.connector.NodeDataResolver;
 import com.netflix.titus.supplementary.relocation.model.DeschedulingFailure;
 import com.netflix.titus.supplementary.relocation.model.DeschedulingResult;
+import com.netflix.titus.supplementary.relocation.util.RelocationPredicates;
+import com.netflix.titus.supplementary.relocation.util.RelocationUtil;
 
 /**
  * WARN This is a simple implementation focused on a single task migration use case.
@@ -100,16 +103,32 @@ public class DefaultDeschedulerService implements DeschedulerService {
             List<Task> tasks = bestMatch.get().getRight();
             tasks.forEach(task -> {
                 if (!allRequestedEvictions.containsKey(task.getId())) {
-                    TaskRelocationPlan relocationPlan = plannedAheadTaskRelocationPlans.get(task.getId());
-                    if (relocationPlan == null) {
-                        relocationPlan = newNotDelayedRelocationPlan(task, true);
+                    TaskRelocationPlan plannedAheadTaskRelocationPlan = plannedAheadTaskRelocationPlans.get(task.getId());
+
+                    AtomicReference<TaskRelocationPlan> selfManagedRelocationPlan = new AtomicReference<>();
+                    if (plannedAheadTaskRelocationPlan == null) {
+                        // re-check if self-managed
+                        jobOperations.getJob(task.getJobId()).ifPresent(job -> {
+                            RelocationPredicates.checkIfNeedsRelocationPlan(job, task, agent).ifPresent(reason -> {
+                                if (RelocationPredicates.isSelfManaged(job)) {
+                                    selfManagedRelocationPlan.set(RelocationUtil.buildSelfManagedRelocationPlan(job, task, reason, clock.wallTime()));
+                                }
+                            });
+                        });
+
+                        if (selfManagedRelocationPlan.get() == null) {
+                            plannedAheadTaskRelocationPlan = newNotDelayedRelocationPlan(task, true);
+                        } else {
+                            plannedAheadTaskRelocationPlan = selfManagedRelocationPlan.get();
+                        }
                     }
+
                     regularEvictions.put(
                             task.getId(),
                             DeschedulingResult.newBuilder()
                                     .withTask(task)
                                     .withAgentInstance(agent)
-                                    .withTaskRelocationPlan(relocationPlan)
+                                    .withTaskRelocationPlan(plannedAheadTaskRelocationPlan)
                                     .build()
                     );
                 }

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.titus.api.eviction.service.ReadOnlyEvictionOperations;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
@@ -43,6 +44,8 @@ import com.netflix.titus.supplementary.relocation.model.DeschedulingFailure;
 import com.netflix.titus.supplementary.relocation.model.DeschedulingResult;
 import com.netflix.titus.supplementary.relocation.util.RelocationPredicates;
 import com.netflix.titus.supplementary.relocation.util.RelocationUtil;
+
+import static com.netflix.titus.api.jobmanager.model.job.JobFunctions.hasDisruptionBudget;
 
 /**
  * WARN This is a simple implementation focused on a single task migration use case.
@@ -103,34 +106,15 @@ public class DefaultDeschedulerService implements DeschedulerService {
             List<Task> tasks = bestMatch.get().getRight();
             tasks.forEach(task -> {
                 if (!allRequestedEvictions.containsKey(task.getId())) {
-                    TaskRelocationPlan plannedAheadTaskRelocationPlan = plannedAheadTaskRelocationPlans.get(task.getId());
-
-                    AtomicReference<TaskRelocationPlan> selfManagedRelocationPlan = new AtomicReference<>();
-                    if (plannedAheadTaskRelocationPlan == null) {
-                        // re-check if self-managed
-                        jobOperations.getJob(task.getJobId()).ifPresent(job -> {
-                            RelocationPredicates.checkIfNeedsRelocationPlan(job, task, agent).ifPresent(reason -> {
-                                if (RelocationPredicates.isSelfManaged(job)) {
-                                    selfManagedRelocationPlan.set(RelocationUtil.buildSelfManagedRelocationPlan(job, task, reason, clock.wallTime()));
-                                }
-                            });
-                        });
-
-                        if (selfManagedRelocationPlan.get() == null) {
-                            plannedAheadTaskRelocationPlan = newNotDelayedRelocationPlan(task, true);
-                        } else {
-                            plannedAheadTaskRelocationPlan = selfManagedRelocationPlan.get();
-                        }
-                    }
-
-                    regularEvictions.put(
+                    Optional<TaskRelocationPlan> relocationPlanForTask = getRelocationPlanForTask(agent, task, plannedAheadTaskRelocationPlans);
+                    relocationPlanForTask.ifPresent(rp -> regularEvictions.put(
                             task.getId(),
                             DeschedulingResult.newBuilder()
                                     .withTask(task)
                                     .withAgentInstance(agent)
-                                    .withTaskRelocationPlan(plannedAheadTaskRelocationPlan)
+                                    .withTaskRelocationPlan(rp)
                                     .build()
-                    );
+                    ));
                 }
             });
         }
@@ -177,5 +161,28 @@ public class DefaultDeschedulerService implements DeschedulerService {
                 .withDecisionTime(now)
                 .withRelocationTime(now)
                 .build();
+    }
+
+    @VisibleForTesting
+    Optional<TaskRelocationPlan> getRelocationPlanForTask(Node agent, Task task,
+                                                          Map<String, TaskRelocationPlan> plannedAheadTaskRelocationPlans) {
+        AtomicReference<Optional<TaskRelocationPlan>> result = new AtomicReference<>(Optional.empty());
+        TaskRelocationPlan plannedAheadTaskRelocationPlan = plannedAheadTaskRelocationPlans.get(task.getId());
+        if (plannedAheadTaskRelocationPlan == null) {
+            // recheck if a self managed plan is needed
+            jobOperations.getJob(task.getJobId()).ifPresent(job ->
+                    RelocationPredicates.checkIfNeedsRelocationPlan(job, task, agent).ifPresent(reason -> {
+                        if (RelocationPredicates.isSelfManaged(job) && hasDisruptionBudget(job)) {
+                            result.set(Optional.of(RelocationUtil.buildSelfManagedRelocationPlan(job, task, reason, clock.wallTime())));
+                        }
+                    }));
+
+            if (!result.get().isPresent()) {
+                result.set(Optional.of(newNotDelayedRelocationPlan(task, true)));
+            }
+        } else {
+            result.set(Optional.of(plannedAheadTaskRelocationPlan));
+        }
+        return result.get();
     }
 }

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/util/RelocationPredicates.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/util/RelocationPredicates.java
@@ -174,7 +174,7 @@ public class RelocationPredicates {
         return JobFunctions.findTaskStatus(task, TaskState.Accepted).orElse(task.getStatus()).getTimestamp();
     }
 
-    private static boolean isSelfManaged(Job<?> job) {
+    public static boolean isSelfManaged(Job<?> job) {
         DisruptionBudgetPolicy disruptionBudgetPolicy = job.getJobDescriptor().getDisruptionBudget().getDisruptionBudgetPolicy();
         return disruptionBudgetPolicy instanceof SelfManagedDisruptionBudgetPolicy;
     }

--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
@@ -127,7 +127,7 @@ public class DefaultDeschedulerServiceTest {
             if (isImmediateJobMigration) {
                 assertThat(plan.getReasonMessage()).containsSequence("Job marked for immediate eviction");
             } else {
-                assertThat(plan.getReasonMessage()).containsSequence("Enough quota to migrate the task");
+                assertThat(plan.getReasonMessage()).isEqualTo("Enough quota to migrate the task (no migration delay configured)");
             }
         }
     }

--- a/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
+++ b/titus-supplementary-component/task-relocation/src/test/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerServiceTest.java
@@ -16,12 +16,16 @@
 
 package com.netflix.titus.supplementary.relocation.descheduler;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import com.netflix.titus.api.agent.model.AgentInstanceGroup;
 import com.netflix.titus.api.agent.model.InstanceGroupLifecycleState;
+import com.netflix.titus.api.eviction.service.ReadOnlyEvictionOperations;
 import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ServiceJobTask;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
@@ -34,11 +38,11 @@ import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.time.TestClock;
 import com.netflix.titus.runtime.RelocationAttributes;
 import com.netflix.titus.runtime.connector.agent.AgentDataReplicator;
-import com.netflix.titus.runtime.connector.eviction.EvictionConfiguration;
 import com.netflix.titus.supplementary.relocation.RelocationConfiguration;
 import com.netflix.titus.supplementary.relocation.RelocationConnectorStubs;
 import com.netflix.titus.supplementary.relocation.TestDataFactory;
 import com.netflix.titus.supplementary.relocation.connector.AgentManagementNodeDataResolver;
+import com.netflix.titus.supplementary.relocation.connector.Node;
 import com.netflix.titus.supplementary.relocation.model.DeschedulingResult;
 import com.netflix.titus.testkit.model.job.JobGenerator;
 import org.junit.Test;
@@ -55,6 +59,7 @@ import static com.netflix.titus.testkit.model.eviction.DisruptionBudgetGenerator
 import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskServiceJobDescriptor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DefaultDeschedulerServiceTest {
 
@@ -67,7 +72,7 @@ public class DefaultDeschedulerServiceTest {
     private final MutableDataGenerator<Job<ServiceJobExt>> jobGenerator = new MutableDataGenerator<>(
             JobGenerator.serviceJobs(oneTaskServiceJobDescriptor().but(
                     ofServiceSize(4),
-                    withDisruptionBudget(budget(selfManagedPolicy(30_000), unlimitedRate(), Collections.emptyList()))
+                    withDisruptionBudget(budget(selfManagedPolicy(0), unlimitedRate(), Collections.emptyList()))
             ))
     );
 
@@ -125,5 +130,55 @@ public class DefaultDeschedulerServiceTest {
                 assertThat(plan.getReasonMessage()).containsSequence("Enough quota to migrate the task");
             }
         }
+    }
+
+    @Test
+    public void verifySelfManagedRelocationPlanWithDelay() {
+        verifyRelocationPlan(10_000, "Agent instance tagged for eviction");
+    }
+
+    @Test
+    public void verifyRelocationPlanWithNoDelay() {
+        verifyRelocationPlan(0, "Enough quota to migrate the task (no migration delay configured)");
+    }
+
+    private void verifyRelocationPlan(long relocationDelay, String reasonMessage) {
+        ReadOnlyJobOperations jobOperations = mock(ReadOnlyJobOperations.class);
+        DefaultDeschedulerService dds = new DefaultDeschedulerService(
+                jobOperations,
+                mock(ReadOnlyEvictionOperations.class),
+                new AgentManagementNodeDataResolver(dataGenerator.getAgentOperations(), agentDataReplicator, instance -> true,
+                        mock(RelocationConfiguration.class),
+                        TestDataFactory.mockKubeApiFacade()),
+                () -> "foo|bar",
+                titusRuntime
+        );
+
+        Job<ServiceJobExt> job = JobGenerator.serviceJobs(
+                oneTaskServiceJobDescriptor()
+                        .but(ofServiceSize(2),
+                                withDisruptionBudget(budget(selfManagedPolicy(relocationDelay), unlimitedRate(), Collections.emptyList()))))
+                .getValue();
+
+        ServiceJobTask task = JobGenerator.serviceTasks(job).getValue();
+        when(jobOperations.getJob(job.getId())).thenReturn(Optional.of(job));
+
+        Node node = Node.newBuilder()
+                .withId("node1")
+                .withServerGroupId("asg1")
+                .withRelocationRequired(true).withBadCondition(false).build();
+
+        // Advance test clock
+        long clockAdvancedMs = 5_000;
+        TestClock testClock = (TestClock) titusRuntime.getClock();
+        testClock.advanceTime(Duration.ofMillis(clockAdvancedMs));
+
+        Optional<TaskRelocationPlan> relocationPlanForTask = dds.getRelocationPlanForTask(node, task, Collections.emptyMap());
+        assertThat(relocationPlanForTask).isPresent();
+        assertThat(relocationPlanForTask.get().getTaskId()).isEqualTo(task.getId());
+        // relocation time is expected to be decision clock time + retentionTimeMs
+        assertThat(relocationPlanForTask.get().getRelocationTime()).isEqualTo(relocationDelay + clockAdvancedMs);
+        assertThat(relocationPlanForTask.get().getDecisionTime()).isEqualTo(clockAdvancedMs);
+        assertThat(relocationPlanForTask.get().getReasonMessage()).isEqualTo(reasonMessage);
     }
 }


### PR DESCRIPTION
Titus relocation service  builds a list of planned relocation schedules for jobs with self managed relocation policies.  Due to a race condition it runs into a behavior where self managed plan contracts are not getting applied. It builds the list of planned relocations as the first step in de-scheduling. But then it also checks the node status for relocation at a later point in time in order to determine tasks that could be terminated from the eligible nodes.

This fix applies another check for self managed jobs to correctly apply the relocation delay as defined in the job specification.