### PR TITLE
Reorder resource pool resolvers to prioritize special cases first

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodModule.java
@@ -79,11 +79,11 @@ public class KubePodModule extends AbstractModule {
         return new PodResourcePoolResolverFeatureGuard(
                 configuration,
                 new PodResourcePoolResolverChain(Arrays.asList(
-                        new KubeSchedulerPodResourcePoolResolver(capacityGroupService),
-                        new FenzoPodResourcePoolResolver(capacityGroupService),
                         new ExplicitJobPodResourcePoolResolver(),
                         new FarzonePodResourcePoolResolver(configuration),
-                        new GpuPodResourcePoolResolver(configuration),
+                        new GpuPodResourcePoolResolver(configuration, capacityGroupService),
+                        new KubeSchedulerPodResourcePoolResolver(capacityGroupService),
+                        new FenzoPodResourcePoolResolver(capacityGroupService),
                         new CapacityGroupPodResourcePoolResolver(
                                 configuration,
                                 config.getPrefixedView(RESOURCE_POOL_PROPERTIES_PREFIX),

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/GpuPodResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/GpuPodResourcePoolResolver.java
@@ -16,17 +16,21 @@
 
 package com.netflix.titus.master.kubernetes.pod.resourcepool;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
 import com.netflix.titus.master.kubernetes.pod.KubePodConfiguration;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,19 +42,34 @@ public class GpuPodResourcePoolResolver implements PodResourcePoolResolver {
 
     private final Lock lock = new ReentrantLock();
     private volatile String lastParsedValue;
+    private volatile Set<String> gpuResourcePoolNames = Collections.emptySet();
     private volatile List<ResourcePoolAssignment> gpuResourcePoolAssignments = Collections.emptyList();
+    private final ApplicationSlaManagementService capacityGroupService;
 
-    public GpuPodResourcePoolResolver(KubePodConfiguration configuration) {
+    public GpuPodResourcePoolResolver(KubePodConfiguration configuration, ApplicationSlaManagementService capacityGroupService) {
         this.configuration = configuration;
+        this.capacityGroupService = capacityGroupService;
         // Call early to initialize before the first usage.
         getCurrent();
     }
 
     @Override
     public List<ResourcePoolAssignment> resolve(Job<?> job, Task task) {
-        return job.getJobDescriptor().getContainer().getContainerResources().getGpu() <= 0
-                ? Collections.emptyList()
-                : getCurrent();
+        if (job.getJobDescriptor().getContainer().getContainerResources().getGpu() <= 0) {
+            return Collections.emptyList();
+        }
+        // If capacity group is already configured with a GPU resource pool, use just that rather than a list of GPU resource pools
+        // as defined in the GpuResourcePoolNames fast property
+        ApplicationSLA capacityGroup = JobManagerUtil.getCapacityGroupDescriptor(job.getJobDescriptor(), capacityGroupService);
+        if (capacityGroup != null && StringExt.isNotEmpty(capacityGroup.getResourcePool()) &&
+                this.gpuResourcePoolNames.contains(capacityGroup.getResourcePool())) {
+            String resourcePoolName = capacityGroup.getResourcePool();
+            return Collections.singletonList(ResourcePoolAssignment.newBuilder()
+                    .withResourcePoolName(resourcePoolName)
+                    .withRule("GPU task assigned to application Capacity Group " + resourcePoolName)
+                    .build());
+        }
+        return getCurrent();
     }
 
     private List<ResourcePoolAssignment> getCurrent() {
@@ -62,13 +81,15 @@ public class GpuPodResourcePoolResolver implements PodResourcePoolResolver {
             String currentValue = configuration.getGpuResourcePoolNames();
             if (!Objects.equals(lastParsedValue, currentValue)) {
                 this.lastParsedValue = currentValue;
-                this.gpuResourcePoolAssignments = StringExt.splitByComma(currentValue).stream()
-                        .map(name -> ResourcePoolAssignment.newBuilder()
-                                .withResourcePoolName(name)
-                                .withRule("GPU resources pool assignment")
-                                .build()
-                        )
-                        .collect(Collectors.toList());
+                this.gpuResourcePoolNames = StringExt.splitByCommaIntoSet(currentValue);
+                List<ResourcePoolAssignment> assignments = new ArrayList<>();
+                for (String gpuResourcePoolName : this.gpuResourcePoolNames) {
+                    assignments.add(ResourcePoolAssignment.newBuilder()
+                            .withResourcePoolName(gpuResourcePoolName)
+                            .withRule("GPU resources pool assignment")
+                            .build());
+                }
+                this.gpuResourcePoolAssignments = assignments;
             }
         } catch (Exception e) {
             logger.error("Cannot parse GPU resource pool", e);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/GpuPodResourcePoolResolverTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/GpuPodResourcePoolResolverTest.java
@@ -23,12 +23,18 @@ import com.netflix.titus.api.jobmanager.model.job.ContainerResources;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.api.model.ApplicationSLA;
+import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.archaius2.Archaius2Ext;
 import com.netflix.titus.master.kubernetes.pod.KubePodConfiguration;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class GpuPodResourcePoolResolverTest {
 
@@ -36,28 +42,37 @@ public class GpuPodResourcePoolResolverTest {
 
     private final KubePodConfiguration configuration = Archaius2Ext.newConfiguration(KubePodConfiguration.class, config);
 
-    private final GpuPodResourcePoolResolver resolver = new GpuPodResourcePoolResolver(configuration);
+    private final ApplicationSlaManagementService capacityGroupService = mock(ApplicationSlaManagementService.class);
+
+    private GpuPodResourcePoolResolver resolver;
 
     private final Task task = JobGenerator.oneBatchTask();
 
+    @Before
+    public void setUp() {
+        config.setProperty("titusMaster.kubernetes.pod.gpuResourcePoolNames", "gpu1,gpu2");
+        resolver = new GpuPodResourcePoolResolver(configuration, capacityGroupService);
+    }
+
     @Test
     public void testNonGpuJob() {
-        assertThat(resolver.resolve(newJob(0), task)).isEmpty();
+        assertThat(resolver.resolve(newJob(0, null), task)).isEmpty();
     }
 
     @Test
     public void testGpuJob() {
         config.setProperty("titusMaster.kubernetes.pod.gpuResourcePoolNames", "gpu1,gpu2");
-        List<ResourcePoolAssignment> result = resolver.resolve(newJob(1), task);
+        List<ResourcePoolAssignment> result = resolver.resolve(newJob(1, null), task);
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getResourcePoolName()).isEqualTo("gpu1");
         assertThat(result.get(1).getResourcePoolName()).isEqualTo("gpu2");
     }
 
-    private Job<?> newJob(int gpuCount) {
+    private Job<?> newJob(int gpuCount, String capacityGroup) {
         Job<BatchJobExt> job = JobGenerator.oneBatchJob();
         return job.toBuilder().withJobDescriptor(
                 job.getJobDescriptor().toBuilder()
+                        .withCapacityGroup(capacityGroup)
                         .withContainer(job.getJobDescriptor().getContainer().toBuilder()
                                 .withContainerResources(
                                         ContainerResources.newBuilder().withGpu(gpuCount).build()
@@ -66,5 +81,40 @@ public class GpuPodResourcePoolResolverTest {
                         )
                         .build()
         ).build();
+    }
+
+    @Test
+    // Validate that when the job is using a Capacity Group with a GPU resource pool, we resolve to
+    // exactly that one resource pool
+    public void testGpuJobWithGpuCapacityGroup() {
+        when(capacityGroupService.getApplicationSLA("gpu1_capacity_group")).thenReturn(
+                ApplicationSLA.newBuilder()
+                        .withAppName("gpu1_capacity_group")
+                        .withTier(Tier.Flex)
+                        .withResourcePool("gpu1")
+                        .build()
+        );
+        Job<?> job = newJob(1, "gpu1_capacity_group");
+        List<ResourcePoolAssignment> result = resolver.resolve(job, task);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo("gpu1");
+    }
+
+    @Test
+    // Validate despite specifying a Capacity Group with a non-GPU resource pool, we get the resolution
+    // to a pre-configured GPU resource pools list
+    public void testGpuJobWithElasticCapacityGroup() {
+        when(capacityGroupService.getApplicationSLA("cg_with_elastic_resourcepool")).thenReturn(
+                ApplicationSLA.newBuilder()
+                        .withAppName("cg_with_elastic_resourcepool")
+                        .withTier(Tier.Flex)
+                        .withResourcePool("elastic")
+                        .build()
+        );
+        Job<?> job = newJob(1, "cg_with_elastic_resourcepool");
+        List<ResourcePoolAssignment> result = resolver.resolve(job, task);
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo("gpu1");
+        assertThat(result.get(1).getResourcePoolName()).isEqualTo("gpu2");
     }
 }


### PR DESCRIPTION
### Description of the Change

When Jobs have an associated ApplicationSLA with a well-defined resourcePool, the order in which current resourcePool resolution works would always use the one on ApplicationSLA as the primary resourcePool to annotate the pods and set node selectors. This evaluation order does not work for special cases such as GPU and farzone.
In this PR, we are changing the order such that GPU and farzone jobs resolve to their pre-configured resourcePools (using fast properties) before any other resolution steps.