### PR TITLE
Ignore the string version of network_configuration

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
@@ -16,9 +16,13 @@
 
 package com.netflix.titus.api.jobmanager.model.job;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  */
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class NetworkConfiguration {
 
     final private int networkMode;
@@ -29,6 +33,7 @@ public class NetworkConfiguration {
 
     public int getNetworkMode() { return networkMode; }
 
+    @JsonIgnore
     public String getNetworkModeName() {
         return networkModeToName(networkMode);
     }


### PR DESCRIPTION
getNetworkModeName() is somehow leaking into the json serialization
of the NetworkConfiguration object, leading to:

```
"networkConfiguration":{"networkMode":0,"networkModeName":"UnknownNetworkMode"}
```

I don't want this, I only want the enum int in there.

Additionally, if we do make mistakes in the future with new properties,
I don't want the API to panic, so I added

    @JsonIgnoreProperties(ignoreUnknown = true)

Which seems to be common practice in this codebase.

I'm not sure how to test this end-to-end.
