### PR TITLE
Make the job descriptor builder always include network configuration

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
@@ -214,7 +214,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 ", attributes=" + attributes +
                 ", container=" + container +
                 ", disruptionBudget=" + disruptionBudget +
-                ", networkConfiguration" + networkConfiguration +
+                ", networkConfiguration=" + networkConfiguration +
                 ", extensions=" + extensions +
                 '}';
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobModel.java
@@ -98,7 +98,9 @@ public final class JobModel {
         return SecurityProfile.newBuilder(securityProfile);
     }
 
-    public static NetworkConfiguration.Builder newNetworkConfiguration(int mode) { return NetworkConfiguration.newBuilder(); }
+    public static NetworkConfiguration.Builder newNetworkConfiguration() { return NetworkConfiguration.newBuilder(); }
+
+    public static NetworkConfiguration.Builder newNetworkConfiguration(NetworkConfiguration networkConfiguration) { return NetworkConfiguration.newBuilder(networkConfiguration); }
 
     public static Container.Builder newContainer() {
         return Container.newBuilder();

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -204,7 +204,8 @@ public final class GrpcJobManagementModelConverters {
     }
 
     public static NetworkConfiguration toCoreNetworkConfiguration(com.netflix.titus.grpc.protogen.NetworkConfiguration grpcNetworkConfiguration) {
-        return JobModel.newNetworkConfiguration(grpcNetworkConfiguration.getNetworkMode().getNumber())
+        return JobModel.newNetworkConfiguration()
+                .withNetworkMode(grpcNetworkConfiguration.getNetworkModeValue())
                 .build();
     }
 


### PR DESCRIPTION
I missed this piece, which actually tells the model builder
to use the NetworkConfiguration when provided by the actual
descriptor.

My tests were not enough to exercise this because I was building
the job object manually and not fully through CreateJob.

----

I couldn't quite find a unit test where you don't end up building the job object yourself.
But I tested this manually on my dev stack and confirmed it connects the dots.