### PR TITLE
live logs url included in task attributes

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -78,6 +78,8 @@ public final class TaskAttributes {
 
     public static final String TASK_ATTRIBUTE_LOG_UI_LOCATION = TASK_ATTRIBUTE_LOG_PREFIX + "uiLogLocation";
 
+    public static final String TASK_ATTRIBUTE_LOG_LIVE_STREAM = TASK_ATTRIBUTE_LOG_PREFIX + "liveStream";
+
     public static final String TASK_ATTRIBUTE_LOG_S3_PREFIX = TASK_ATTRIBUTE_LOG_PREFIX + "s3.";
 
     public static final String TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME = TASK_ATTRIBUTE_LOG_S3_PREFIX + "accountName";

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -104,6 +104,7 @@ import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_SY
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_INDEX;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_ORIGINAL_ID;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_RESUBMIT_OF;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_LIVE_STREAM;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME;
@@ -554,18 +555,19 @@ public final class GrpcJobManagementModelConverters {
         Map<String, String> attributes = new HashMap<>(grpcTask.getAttributesMap());
         if (grpcTask.hasLogLocation()) {
             LogLocation logLocation = grpcTask.getLogLocation();
-            if (logLocation != null) {
-                if (logLocation.getUi() != null) {
-                    attributes.put(TASK_ATTRIBUTE_LOG_UI_LOCATION, logLocation.getUi().getUrl());
-                }
-                if (logLocation.getS3() != null) {
-                    LogLocation.S3 s3 = logLocation.getS3();
-                    attributes.put(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME, s3.getAccountName());
-                    attributes.put(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID, s3.getAccountId());
-                    attributes.put(TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME, s3.getBucket());
-                    attributes.put(TASK_ATTRIBUTE_LOG_S3_KEY, s3.getKey());
-                    attributes.put(TASK_ATTRIBUTE_LOG_S3_REGION, s3.getRegion());
-                }
+            if (logLocation.hasUi()) {
+                attributes.put(TASK_ATTRIBUTE_LOG_UI_LOCATION, logLocation.getUi().getUrl());
+            }
+            if (logLocation.hasLiveStream()) {
+                attributes.put(TASK_ATTRIBUTE_LOG_LIVE_STREAM, logLocation.getLiveStream().getUrl());
+            }
+            if (logLocation.hasS3()) {
+                LogLocation.S3 s3 = logLocation.getS3();
+                attributes.put(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME, s3.getAccountName());
+                attributes.put(TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID, s3.getAccountId());
+                attributes.put(TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME, s3.getBucket());
+                attributes.put(TASK_ATTRIBUTE_LOG_S3_KEY, s3.getKey());
+                attributes.put(TASK_ATTRIBUTE_LOG_S3_REGION, s3.getRegion());
             }
         }
         return attributes;

--- a/titus-client/src/test/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConvertersTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConvertersTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_RESUBMIT_NUMBER;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_TASK_ORIGINAL_ID;
+import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_LIVE_STREAM;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_ID;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_ACCOUNT_NAME;
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTE_LOG_S3_BUCKET_NAME;
@@ -23,6 +24,7 @@ public class GrpcJobManagementModelConvertersTest {
     public void coreTaskLogAttributes() {
         String taskId = "tid-1";
         String uiLocation = "http://titus-ui/tasks/" + taskId;
+        String liveStream = "http://agentIp:8080/logs/" + taskId;
         String s3Bucket = "bucket-1";
         String s3Key = "key-1";
         String s3AccountId = "acc-1";
@@ -37,6 +39,7 @@ public class GrpcJobManagementModelConvertersTest {
                 .putAllTaskContext(taskContext)
                 .setLogLocation(LogLocation.newBuilder()
                         .setUi(LogLocation.UI.newBuilder().setUrl(uiLocation))
+                        .setLiveStream(LogLocation.LiveStream.newBuilder().setUrl(liveStream).build())
                         .setS3(LogLocation.S3.newBuilder()
                                 .setRegion(s3Region)
                                 .setBucket(s3Bucket)
@@ -66,5 +69,8 @@ public class GrpcJobManagementModelConvertersTest {
 
         assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_UI_LOCATION)).isTrue();
         assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_UI_LOCATION)).isEqualTo(uiLocation);
+
+        assertThat(coreTask.getAttributes().containsKey(TASK_ATTRIBUTE_LOG_LIVE_STREAM)).isTrue();
+        assertThat(coreTask.getAttributes().get(TASK_ATTRIBUTE_LOG_LIVE_STREAM)).isEqualTo(liveStream);
     }
 }


### PR DESCRIPTION
### Titus task core model update

This change provides a way to include the live logs (stdout) location for a Titus task / container inside the Titus Task Core model attributes. This helps with remote data replicator building Task core model from gRpc response.