### PR TITLE
Enrich v0 pod objects with image,cmd,args

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -127,8 +127,10 @@ public class V0SpecPodFactory implements PodFactory {
 
         V1Container container = new V1Container()
                 .name(taskId)
-                .image("imageIsInContainerInfo")
+                .image(job.getJobDescriptor().getContainer().getImage().toString())
                 .env(toV1EnvVar(containerEnvFactory.buildContainerEnv(job, task)))
+                .command(job.getJobDescriptor().getContainer().getCommand())
+                .args(job.getJobDescriptor().getContainer().getEntryPoint())
                 .resources(buildV1ResourceRequirements(job.getJobDescriptor().getContainer().getContainerResources()));
 
         String schedulerName = FENZO_SCHEDULER;


### PR DESCRIPTION
I'm trying to help remove the JobDescriptor object from our pods.

To do that, on those tools that need the jobdescriptor, we can fake
it by sourcing other pieces of data from the pod object itself.

For https://github.com/Netflix-Skunkworks/titus-isolate/pull/341
specifically, in this PR, I've added in Image, Cmd, Args into the
pod object directly instead of the cinfo placeholders.

Sure, this data isn't actually consumed by VK (on v0 pods), but it
is useful for other surrounding tools, annd heck just running kubectl
to see what the heck is going on?
