### PR TITLE
Fix TJC snapshot; better inconsistency handling in PCollectionJobSnapshot

### DIFF
--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/JobSnapshotPerf.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/JobSnapshotPerf.java
@@ -74,7 +74,9 @@ public class JobSnapshotPerf {
         }
         this.snapshot = legacyMode
                 ? LegacyJobSnapshot.newInstance("test", jobs, taskByJobId)
-                : PCollectionJobSnapshot.newInstance("test", jobs, taskByJobId);
+                : PCollectionJobSnapshot.newInstance(
+                "test", jobs, taskByJobId, false, message -> {
+                });
     }
 
     private Pair<Job<?>, List<Task>> newJobWithTasks() {

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/JobSnapshotTestUtil.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/JobSnapshotTestUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.jobmanager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+
+class JobSnapshotTestUtil {
+
+    static JobSnapshot newSnapshot(JobSnapshotFactory factory, Pair<Job<?>, List<Task>>... pairs) {
+        Map<String, Job<?>> jobsById = new HashMap<>();
+        Map<String, List<Task>> tasksByJobId = new HashMap<>();
+        for (Pair<Job<?>, List<Task>> pair : pairs) {
+            Job<?> job = pair.getLeft();
+            jobsById.put(job.getId(), job);
+            tasksByJobId.put(job.getId(), pair.getRight());
+        }
+        return factory.newSnapshot(jobsById, tasksByJobId);
+    }
+
+    static Pair<Job<?>, List<Task>> newJobWithTasks(int jobIdx, int taskCount) {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob().toBuilder().withId("job#" + jobIdx).build();
+        List<Task> tasks = new ArrayList<>();
+        for (int t = 0; t < taskCount; t++) {
+            tasks.add(newTask(job, t));
+        }
+        return Pair.of(job, tasks);
+    }
+
+    static BatchJobTask newTask(Job<?> job, int taskIdx) {
+        return JobGenerator.oneBatchTask().toBuilder()
+                .withId("task#" + taskIdx + "@" + job.getId())
+                .withJobId(job.getId())
+                .build();
+    }
+}

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/PCollectionJobSnapshotTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/PCollectionJobSnapshotTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.jobmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.common.util.tuple.Pair;
+import org.junit.Test;
+
+import static com.netflix.titus.runtime.connector.jobmanager.JobSnapshotTestUtil.newJobWithTasks;
+import static com.netflix.titus.runtime.connector.jobmanager.JobSnapshotTestUtil.newSnapshot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Negative test scenarios only. Positive tests are in {@link JobSnapshotTest}.
+ */
+public class PCollectionJobSnapshotTest {
+
+    private final List<String> inconsistenciesReports = new ArrayList<>();
+
+    @Test
+    public void testAutoFixMode() {
+        Pair<Job<?>, List<Task>> pair1 = newJobWithTasks(1, 2);
+        List<Task> tasks1 = pair1.getRight();
+
+        JobSnapshot initial = newSnapshot(newFactory(true), pair1);
+        JobSnapshot updated = initial.updateTask(tasks1.get(0), true).orElse(null);
+        assertThat(updated).isNotNull();
+        assertThat(inconsistenciesReports).hasSize(1);
+    }
+
+    @Test
+    public void testNoAutoFixMode() {
+        Pair<Job<?>, List<Task>> pair1 = newJobWithTasks(1, 2);
+        List<Task> tasks1 = pair1.getRight();
+
+        JobSnapshot initial = newSnapshot(newFactory(false), pair1);
+        try {
+            initial.updateTask(tasks1.get(0), true);
+            fail("error expected");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(IllegalStateException.class);
+        }
+        assertThat(inconsistenciesReports).hasSize(1);
+    }
+
+    private JobSnapshotFactory newFactory(boolean autoFix) {
+        return JobSnapshotFactories.newDefault(autoFix, inconsistenciesReports::add);
+    }
+}


### PR DESCRIPTION
TJC GRPC snapshot could include task events without their corresponding,
leading job events. It was possible because jobs and tasks were requested
in two subsequent calls from Job API.
