### PR TITLE
Hide Kube Java lib invocations behind internal API

### DIFF
--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/DefaultKubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/DefaultKubeApiFacade.java
@@ -120,21 +120,29 @@ public class DefaultKubeApiFacade implements KubeApiFacade {
     }
 
     @Override
-    public void deleteNode(String nodeName) throws ApiException {
-        coreV1Api.deleteNode(
-                nodeName,
-                null,
-                null,
-                0,
-                null,
-                BACKGROUND,
-                null
-        );
+    public void deleteNode(String nodeName) throws KubeApiException {
+        try {
+            coreV1Api.deleteNode(
+                    nodeName,
+                    null,
+                    null,
+                    0,
+                    null,
+                    BACKGROUND,
+                    null
+            );
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
-    public void createNamespacedPod(String namespace, V1Pod pod) throws ApiException {
-        coreV1Api.createNamespacedPod(namespace, pod, null, null, null);
+    public void createNamespacedPod(String namespace, V1Pod pod) throws KubeApiException {
+        try {
+            coreV1Api.createNamespacedPod(namespace, pod, null, null, null);
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
@@ -145,69 +153,89 @@ public class DefaultKubeApiFacade implements KubeApiFacade {
     }
 
     @Override
-    public void deleteNamespacedPod(String namespace, String podName) throws ApiException {
-        coreV1Api.deleteNamespacedPod(
-                podName,
-                namespace,
-                null,
-                null,
-                0,
-                null,
-                BACKGROUND,
-                null
-        );
+    public void deleteNamespacedPod(String namespace, String podName) throws KubeApiException {
+        try {
+            coreV1Api.deleteNamespacedPod(
+                    podName,
+                    namespace,
+                    null,
+                    null,
+                    0,
+                    null,
+                    BACKGROUND,
+                    null
+            );
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
-    public void deleteNamespacedPod(String namespace, String podName, int deleteGracePeriod) throws ApiException {
-        coreV1Api.deleteNamespacedPod(
-                podName,
-                namespace,
-                null,
-                null,
-                deleteGracePeriod,
-                null,
-                null,
-                null
-        );
+    public void deleteNamespacedPod(String namespace, String podName, int deleteGracePeriod) throws KubeApiException {
+        try {
+            coreV1Api.deleteNamespacedPod(
+                    podName,
+                    namespace,
+                    null,
+                    null,
+                    deleteGracePeriod,
+                    null,
+                    null,
+                    null
+            );
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
-    public void deleteNamespacedPersistentVolumeClaim(String namespace, String volumeClaimName) throws ApiException {
-        coreV1Api.deleteNamespacedPersistentVolumeClaim(
-                volumeClaimName,
-                namespace,
-                null,
-                null,
-                0,
-                null,
-                null,
-                null
-        );
+    public void deleteNamespacedPersistentVolumeClaim(String namespace, String volumeClaimName) throws KubeApiException {
+        try {
+            coreV1Api.deleteNamespacedPersistentVolumeClaim(
+                    volumeClaimName,
+                    namespace,
+                    null,
+                    null,
+                    0,
+                    null,
+                    null,
+                    null
+            );
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
-    public void replacePersistentVolume(V1PersistentVolume persistentVolume) throws ApiException {
-        coreV1Api.replacePersistentVolume(
-                KubeUtil.getMetadataName(persistentVolume.getMetadata()),
-                persistentVolume,
-                null,
-                null,
-                null
-        );
+    public void replacePersistentVolume(V1PersistentVolume persistentVolume) throws KubeApiException {
+        try {
+            coreV1Api.replacePersistentVolume(
+                    KubeUtil.getMetadataName(persistentVolume.getMetadata()),
+                    persistentVolume,
+                    null,
+                    null,
+                    null
+            );
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
-    public void deletePersistentVolume(String volumeName) throws ApiException {
-        coreV1Api.deletePersistentVolume(
-                volumeName,
-                null,
-                null,
-                0,
-                null,
-                null,
-                null
-        );
+    public void deletePersistentVolume(String volumeName) throws KubeApiException {
+        try {
+            coreV1Api.deletePersistentVolume(
+                    volumeName,
+                    null,
+                    null,
+                    0,
+                    null,
+                    null,
+                    null
+            );
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
@@ -235,13 +263,21 @@ public class DefaultKubeApiFacade implements KubeApiFacade {
     }
 
     @Override
-    public void createPersistentVolume(V1PersistentVolume v1PersistentVolume) throws ApiException {
-        coreV1Api.createPersistentVolume(v1PersistentVolume, null, null, null);
+    public void createPersistentVolume(V1PersistentVolume v1PersistentVolume) throws KubeApiException {
+        try {
+            coreV1Api.createPersistentVolume(v1PersistentVolume, null, null, null);
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override
-    public void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) throws ApiException {
-        coreV1Api.createNamespacedPersistentVolumeClaim(namespace, v1PersistentVolumeClaim, null, null, null);
+    public void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) throws KubeApiException {
+        try {
+            coreV1Api.createNamespacedPersistentVolumeClaim(namespace, v1PersistentVolumeClaim, null, null, null);
+        } catch (ApiException e) {
+            throw new KubeApiException(e);
+        }
     }
 
     @Override

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/DefaultKubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/DefaultKubeApiFacade.java
@@ -29,6 +29,7 @@ import com.netflix.titus.runtime.connector.kubernetes.v1.V1OpportunisticResource
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.informer.SharedIndexInformer;
 import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
@@ -50,6 +51,11 @@ import static com.netflix.titus.runtime.connector.kubernetes.KubeApiClients.crea
 
 @Singleton
 public class DefaultKubeApiFacade implements KubeApiFacade {
+
+    public static final String FAILED = "Failed";
+    public static final String BACKGROUND = "Background";
+
+    public static final String DEFAULT_NAMESPACE = "default";
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultKubeApiFacade.class);
 
@@ -116,21 +122,92 @@ public class DefaultKubeApiFacade implements KubeApiFacade {
     }
 
     @Override
-    public ApiClient getApiClient() {
-        activate();
-        return apiClient;
+    public void deleteNode(String nodeName) throws ApiException {
+        coreV1Api.deleteNode(
+                nodeName,
+                null,
+                null,
+                0,
+                null,
+                BACKGROUND,
+                null
+        );
     }
 
     @Override
-    public CoreV1Api getCoreV1Api() {
-        activate();
-        return coreV1Api;
+    public void createNamespacedPod(String namespace, V1Pod pod) throws ApiException {
+        coreV1Api.createNamespacedPod(DEFAULT_NAMESPACE, pod, null, null, null);
     }
 
     @Override
-    public CustomObjectsApi getCustomObjectsApi() {
-        activate();
-        return customObjectsApi;
+    public Call createNamespacedPodAsync(String namespace, V1Pod pod, ApiCallback<V1Pod> callback) throws ApiException {
+        return coreV1Api.createNamespacedPodAsync(namespace, pod, null, null, null, callback);
+    }
+
+    @Override
+    public void deleteNamespacedPod(String namespace, String podName) throws ApiException {
+        coreV1Api.deleteNamespacedPod(
+                podName,
+                namespace,
+                null,
+                null,
+                0,
+                null,
+                BACKGROUND,
+                null
+        );
+    }
+
+    @Override
+    public void deleteNamespacedPod(String namespace, String podName, int deleteGracePeriod) throws ApiException {
+        coreV1Api.deleteNamespacedPod(
+                podName,
+                namespace,
+                null,
+                null,
+                deleteGracePeriod,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Override
+    public void deleteNamespacedPersistentVolumeClaim(String namespace, String volumeClaimName) throws ApiException {
+        coreV1Api.deleteNamespacedPersistentVolumeClaim(
+                volumeClaimName,
+                namespace,
+                null,
+                null,
+                0,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Override
+    public void replacePersistentVolume(V1PersistentVolume persistentVolume) throws ApiException {
+        coreV1Api.replacePersistentVolume(
+                KubeUtil.getMetadataName(persistentVolume.getMetadata()),
+                persistentVolume,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Override
+    public void deletePersistentVolume(String volumeName) throws ApiException {
+        coreV1Api.deletePersistentVolume(
+                volumeName,
+                null,
+                null,
+                0,
+                null,
+                null,
+                null
+        );
     }
 
     @Override
@@ -155,6 +232,16 @@ public class DefaultKubeApiFacade implements KubeApiFacade {
     public SharedIndexInformer<V1PersistentVolumeClaim> getPersistentVolumeClaimInformer() {
         activate();
         return persistentVolumeClaimInformer;
+    }
+
+    @Override
+    public void createPersistentVolume(V1PersistentVolume v1PersistentVolume) throws ApiException {
+        coreV1Api.createPersistentVolume(v1PersistentVolume, null, null, null);
+    }
+
+    @Override
+    public void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) throws ApiException {
+        coreV1Api.createNamespacedPersistentVolumeClaim(namespace, v1PersistentVolumeClaim, null, null, null);
     }
 
     @Override

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiException.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.kubernetes;
+
+import io.kubernetes.client.openapi.ApiException;
+
+public class KubeApiException extends RuntimeException {
+
+    private static final String NOT_FOUND = "Not Found";
+
+    public enum ErrorCode {
+        CONFLICT_ALREADY_EXISTS,
+        INTERNAL,
+        NOT_FOUND,
+    }
+
+    private final ErrorCode errorCode;
+
+    public KubeApiException(String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = cause instanceof ApiException ? toErrorCode((ApiException) cause) : ErrorCode.INTERNAL;
+    }
+
+    public KubeApiException(ApiException cause) {
+        this(cause.getMessage(), cause);
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    private ErrorCode toErrorCode(ApiException e) {
+        if (e.getMessage() == null) {
+            return ErrorCode.INTERNAL;
+        }
+        if (e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+            return ErrorCode.NOT_FOUND;
+        }
+        if (e.getCode() == 409 && e.getMessage().equals("Conflict") && e.getResponseBody().contains("AlreadyExists")) {
+            return ErrorCode.CONFLICT_ALREADY_EXISTS;
+        }
+        return ErrorCode.INTERNAL;
+    }
+}

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
@@ -18,7 +18,6 @@ package com.netflix.titus.runtime.connector.kubernetes;
 
 import com.netflix.titus.runtime.connector.kubernetes.v1.V1OpportunisticResource;
 import io.kubernetes.client.informer.SharedIndexInformer;
-import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
@@ -33,33 +32,33 @@ public interface KubeApiFacade {
 
     // Nodes
 
-    void deleteNode(String nodeName) throws ApiException;
+    void deleteNode(String nodeName) throws KubeApiException;
 
     SharedIndexInformer<V1Node> getNodeInformer();
 
     // Pods
 
-    void createNamespacedPod(String namespace, V1Pod pod) throws ApiException;
+    void createNamespacedPod(String namespace, V1Pod pod) throws KubeApiException;
 
     Mono<V1Pod> createNamespacedPodAsync(String namespace, V1Pod pod);
 
-    void deleteNamespacedPod(String namespace, String nodeName) throws ApiException;
+    void deleteNamespacedPod(String namespace, String nodeName) throws KubeApiException;
 
-    void deleteNamespacedPod(String namespace, String podName, int deleteGracePeriod) throws ApiException;
+    void deleteNamespacedPod(String namespace, String podName, int deleteGracePeriod) throws KubeApiException;
 
     SharedIndexInformer<V1Pod> getPodInformer();
 
     // Persistent volumes
 
-    void createPersistentVolume(V1PersistentVolume v1PersistentVolume) throws ApiException;
+    void createPersistentVolume(V1PersistentVolume v1PersistentVolume) throws KubeApiException;
 
-    void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) throws ApiException;
+    void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) throws KubeApiException;
 
-    void deleteNamespacedPersistentVolumeClaim(String namespace, String volumeClaimName) throws ApiException;
+    void deleteNamespacedPersistentVolumeClaim(String namespace, String volumeClaimName) throws KubeApiException;
 
-    void replacePersistentVolume(V1PersistentVolume persistentVolume) throws ApiException;
+    void replacePersistentVolume(V1PersistentVolume persistentVolume) throws KubeApiException;
 
-    void deletePersistentVolume(String volumeName) throws ApiException;
+    void deletePersistentVolume(String volumeName) throws KubeApiException;
 
     SharedIndexInformer<V1PersistentVolume> getPersistentVolumeInformer();
 

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
@@ -18,25 +18,49 @@ package com.netflix.titus.runtime.connector.kubernetes;
 
 import com.netflix.titus.runtime.connector.kubernetes.v1.V1OpportunisticResource;
 import io.kubernetes.client.informer.SharedIndexInformer;
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.ApiCallback;
+import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1Pod;
+import okhttp3.Call;
 
+/**
+ * {@link KubeApiFacade} encapsulates Kube Java, except the entity model and the informer API. The latter is
+ * provided as a set of interfaces (unlike ApiClient or CoreV1Api), so it is easy to mock in the test code.
+ */
 public interface KubeApiFacade {
 
-    ApiClient getApiClient();
+    // Nodes
 
-    CoreV1Api getCoreV1Api();
-
-    CustomObjectsApi getCustomObjectsApi();
+    void deleteNode(String nodeName) throws ApiException;
 
     SharedIndexInformer<V1Node> getNodeInformer();
 
+    // Pods
+
+    void createNamespacedPod(String namespace, V1Pod pod) throws ApiException;
+
+    Call createNamespacedPodAsync(String namespace, V1Pod pod, ApiCallback<V1Pod> callback) throws ApiException;
+
+    void deleteNamespacedPod(String namespace, String nodeName) throws ApiException;
+
+    void deleteNamespacedPod(String namespace, String podName, int deleteGracePeriod) throws ApiException;
+
     SharedIndexInformer<V1Pod> getPodInformer();
+
+    // Persistent volumes
+
+    void createPersistentVolume(V1PersistentVolume v1PersistentVolume)throws ApiException;
+
+    void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) throws ApiException;
+
+    void deleteNamespacedPersistentVolumeClaim(String namespace, String volumeClaimName) throws ApiException;
+
+    void replacePersistentVolume(V1PersistentVolume persistentVolume) throws ApiException;
+
+    void deletePersistentVolume(String volumeName) throws ApiException;
 
     SharedIndexInformer<V1PersistentVolume> getPersistentVolumeInformer();
 

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeApiFacade.java
@@ -18,13 +18,12 @@ package com.netflix.titus.runtime.connector.kubernetes;
 
 import com.netflix.titus.runtime.connector.kubernetes.v1.V1OpportunisticResource;
 import io.kubernetes.client.informer.SharedIndexInformer;
-import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1Pod;
-import okhttp3.Call;
+import reactor.core.publisher.Mono;
 
 /**
  * {@link KubeApiFacade} encapsulates Kube Java, except the entity model and the informer API. The latter is
@@ -42,7 +41,7 @@ public interface KubeApiFacade {
 
     void createNamespacedPod(String namespace, V1Pod pod) throws ApiException;
 
-    Call createNamespacedPodAsync(String namespace, V1Pod pod, ApiCallback<V1Pod> callback) throws ApiException;
+    Mono<V1Pod> createNamespacedPodAsync(String namespace, V1Pod pod);
 
     void deleteNamespacedPod(String namespace, String nodeName) throws ApiException;
 
@@ -52,7 +51,7 @@ public interface KubeApiFacade {
 
     // Persistent volumes
 
-    void createPersistentVolume(V1PersistentVolume v1PersistentVolume)throws ApiException;
+    void createPersistentVolume(V1PersistentVolume v1PersistentVolume) throws ApiException;
 
     void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) throws ApiException;
 

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeUtil.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/KubeUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.kubernetes;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+
+public final class KubeUtil {
+
+    /**
+     * Get Kube object name
+     */
+    public static String getMetadataName(V1ObjectMeta metadata) {
+        if (metadata == null) {
+            return "";
+        }
+
+        return metadata.getName();
+    }
+}

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/NoOpKubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/NoOpKubeApiFacade.java
@@ -18,28 +18,62 @@ package com.netflix.titus.runtime.connector.kubernetes;
 
 import com.netflix.titus.runtime.connector.kubernetes.v1.V1OpportunisticResource;
 import io.kubernetes.client.informer.SharedIndexInformer;
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1Pod;
+import okhttp3.Call;
 
 public class NoOpKubeApiFacade implements KubeApiFacade {
 
     @Override
-    public ApiClient getApiClient() {
+    public void deleteNode(String nodeName) {
         throw new IllegalStateException("Kubernetes not supported");
     }
 
     @Override
-    public CoreV1Api getCoreV1Api() {
+    public void createNamespacedPod(String namespace, V1Pod pod) {
         throw new IllegalStateException("Kubernetes not supported");
     }
 
     @Override
-    public CustomObjectsApi getCustomObjectsApi() {
+    public Call createNamespacedPodAsync(String namespace, V1Pod pod, ApiCallback<V1Pod> callback) {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public void deleteNamespacedPod(String namespace, String podName) {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public void deleteNamespacedPod(String namespace, String podName, int deleteGracePeriod) {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public void deleteNamespacedPersistentVolumeClaim(String namespace, String volumeClaimName) {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public void createPersistentVolume(V1PersistentVolume v1PersistentVolume) {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public void createNamespacedPersistentVolumeClaim(String namespace, V1PersistentVolumeClaim v1PersistentVolumeClaim) {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public void replacePersistentVolume(V1PersistentVolume persistentVolume) {
+        throw new IllegalStateException("Kubernetes not supported");
+    }
+
+    @Override
+    public void deletePersistentVolume(String volumeName) {
         throw new IllegalStateException("Kubernetes not supported");
     }
 

--- a/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/NoOpKubeApiFacade.java
+++ b/titus-common-runtime/src/main/java/com/netflix/titus/runtime/connector/kubernetes/NoOpKubeApiFacade.java
@@ -18,12 +18,11 @@ package com.netflix.titus.runtime.connector.kubernetes;
 
 import com.netflix.titus.runtime.connector.kubernetes.v1.V1OpportunisticResource;
 import io.kubernetes.client.informer.SharedIndexInformer;
-import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1Pod;
-import okhttp3.Call;
+import reactor.core.publisher.Mono;
 
 public class NoOpKubeApiFacade implements KubeApiFacade {
 
@@ -38,7 +37,7 @@ public class NoOpKubeApiFacade implements KubeApiFacade {
     }
 
     @Override
-    public Call createNamespacedPodAsync(String namespace, V1Pod pod, ApiCallback<V1Pod> callback) {
+    public Mono<V1Pod> createNamespacedPodAsync(String namespace, V1Pod pod) {
         throw new IllegalStateException("Kubernetes not supported");
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/GcControllerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/GcControllerUtil.java
@@ -24,7 +24,6 @@ import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1Pod;
 import org.slf4j.Logger;
 
-import static com.netflix.titus.runtime.kubernetes.KubeConstants.BACKGROUND;
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.DEFAULT_NAMESPACE;
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.NOT_FOUND;
 
@@ -33,15 +32,7 @@ public final class GcControllerUtil {
     public static boolean deleteNode(KubeApiFacade kubeApiFacade, Logger logger, V1Node node) {
         String nodeName = KubeUtil.getMetadataName(node.getMetadata());
         try {
-            kubeApiFacade.getCoreV1Api().deleteNode(
-                    nodeName,
-                    null,
-                    null,
-                    0,
-                    null,
-                    BACKGROUND,
-                    null
-            );
+            kubeApiFacade.deleteNode(nodeName);
             return true;
         } catch (JsonSyntaxException e) {
             // this will be counted as successful as the response type mapping in the client is incorrect
@@ -59,16 +50,7 @@ public final class GcControllerUtil {
     public static boolean deletePod(KubeApiFacade kubeApiFacade, Logger logger, V1Pod pod) {
         String podName = KubeUtil.getMetadataName(pod.getMetadata());
         try {
-            kubeApiFacade.getCoreV1Api().deleteNamespacedPod(
-                    podName,
-                    DEFAULT_NAMESPACE,
-                    null,
-                    null,
-                    0,
-                    null,
-                    BACKGROUND,
-                    null
-            );
+            kubeApiFacade.deleteNamespacedPod(DEFAULT_NAMESPACE, podName);
             return true;
         } catch (JsonSyntaxException e) {
             // this will be counted as successful as the response type mapping in the client is incorrect

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/GcControllerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/GcControllerUtil.java
@@ -18,14 +18,13 @@ package com.netflix.titus.master.kubernetes.controller;
 
 import com.google.gson.JsonSyntaxException;
 import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiException;
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
-import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1Pod;
 import org.slf4j.Logger;
 
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.DEFAULT_NAMESPACE;
-import static com.netflix.titus.runtime.kubernetes.KubeConstants.NOT_FOUND;
 
 public final class GcControllerUtil {
 
@@ -37,8 +36,8 @@ public final class GcControllerUtil {
         } catch (JsonSyntaxException e) {
             // this will be counted as successful as the response type mapping in the client is incorrect
             return true;
-        } catch (ApiException e) {
-            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+        } catch (KubeApiException e) {
+            if (e.getErrorCode() != KubeApiException.ErrorCode.NOT_FOUND) {
                 logger.error("Failed to delete node: {} with error: ", nodeName, e);
             }
         } catch (Exception e) {
@@ -55,8 +54,8 @@ public final class GcControllerUtil {
         } catch (JsonSyntaxException e) {
             // this will be counted as successful as the response type mapping in the client is incorrect
             return true;
-        } catch (ApiException e) {
-            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+        } catch (KubeApiException e) {
+            if (e.getErrorCode() != KubeApiException.ErrorCode.NOT_FOUND) {
                 logger.error("Failed to delete pod: {} with error: ", podName, e);
             }
         } catch (Exception e) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
@@ -110,7 +110,7 @@ public class PersistentVolumeClaimGcController extends BaseGcController<V1Persis
             logger.info("Successfully deleted persistent volume claim {}", formatPvcEssentials(pvc));
             return true;
         } catch (KubeApiException e) {
-            if (e.getErrorCode() != KubeApiException.ErrorCode.NOT_FOUND) {
+            if (e.getErrorCode() == KubeApiException.ErrorCode.NOT_FOUND) {
                 // If we did not find the PVC return true as it is removed
                 logger.info("Delete for persistent volume claim {} not found", formatPvcEssentials(pvc));
                 return true;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
@@ -107,16 +107,7 @@ public class PersistentVolumeClaimGcController extends BaseGcController<V1Persis
             // If the PVC is deleted while still in use by a pod (though that is not expected), the PVC
             // will not be removed until no pod is using it.
             // https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection
-            kubeApiFacade.getCoreV1Api().deleteNamespacedPersistentVolumeClaim(
-                    volumeClaimName,
-                    DEFAULT_NAMESPACE,
-                    null,
-                    null,
-                    0,
-                    null,
-                    null,
-                    null
-            );
+            kubeApiFacade.deleteNamespacedPersistentVolumeClaim(DEFAULT_NAMESPACE, volumeClaimName);
             logger.info("Successfully deleted persistent volume claim {}", formatPvcEssentials(pvc));
             return true;
         } catch (ApiException e) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcController.java
@@ -31,8 +31,8 @@ import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucke
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.KubeModelConverters;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiException;
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
-import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import static com.netflix.titus.api.jobmanager.model.job.TaskState.isTerminalState;
 import static com.netflix.titus.master.mesos.kubeapiserver.KubeObjectFormatter.formatPvcEssentials;
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.DEFAULT_NAMESPACE;
-import static com.netflix.titus.runtime.kubernetes.KubeConstants.NOT_FOUND;
 
 /**
  * Garbage collects persistent volume claims that are not associated with active/non-terminal tasks.
@@ -110,8 +109,8 @@ public class PersistentVolumeClaimGcController extends BaseGcController<V1Persis
             kubeApiFacade.deleteNamespacedPersistentVolumeClaim(DEFAULT_NAMESPACE, volumeClaimName);
             logger.info("Successfully deleted persistent volume claim {}", formatPvcEssentials(pvc));
             return true;
-        } catch (ApiException e) {
-            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+        } catch (KubeApiException e) {
+            if (e.getErrorCode() != KubeApiException.ErrorCode.NOT_FOUND) {
                 // If we did not find the PVC return true as it is removed
                 logger.info("Delete for persistent volume claim {} not found", formatPvcEssentials(pvc));
                 return true;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeReclaimController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeReclaimController.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.netflix.titus.common.framework.scheduler.LocalScheduler;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
-import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeBuilder;
@@ -92,13 +91,7 @@ public class PersistentVolumeReclaimController extends BaseGcController<V1Persis
                 .withSpec(new V1PersistentVolumeSpecBuilder(spec).build().claimRef(null))
                 .build();
         try {
-            kubeApiFacade.getCoreV1Api().replacePersistentVolume(
-                    KubeUtil.getMetadataName(updatedPv.getMetadata()),
-                    updatedPv,
-                    null,
-                    null,
-                    null
-            );
+            kubeApiFacade.replacePersistentVolume(updatedPv);
             logger.info("Successfully reclaimed pv {}", formatPvEssentials(updatedPv));
         } catch (Exception e) {
             logger.error("Failed to reclaim pv {} with error: ", formatPvEssentials(v1PersistentVolume), e);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
@@ -33,8 +33,8 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
 import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiException;
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
-import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeStatus;
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.netflix.titus.master.mesos.kubeapiserver.KubeObjectFormatter.formatPvEssentials;
-import static com.netflix.titus.runtime.kubernetes.KubeConstants.NOT_FOUND;
 
 /**
  * Garbage collects persistent volumes that are not associated with active/non-terminal jobs.
@@ -116,8 +115,8 @@ public class PersistentVolumeUnassociatedGcController extends BaseGcController<V
             kubeApiFacade.deletePersistentVolume(volumeName);
             logger.info("Successfully deleted persistent volume {}", formatPvEssentials(pv));
             return true;
-        } catch (ApiException e) {
-            if (!e.getMessage().equalsIgnoreCase(NOT_FOUND)) {
+        } catch (KubeApiException e) {
+            if (e.getErrorCode() != KubeApiException.ErrorCode.NOT_FOUND) {
                 // If we did not find the PV return true as it is removed
                 logger.info("Delete for persistent volume {} not found", formatPvEssentials(pv));
                 return true;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
@@ -116,7 +116,7 @@ public class PersistentVolumeUnassociatedGcController extends BaseGcController<V
             logger.info("Successfully deleted persistent volume {}", formatPvEssentials(pv));
             return true;
         } catch (KubeApiException e) {
-            if (e.getErrorCode() != KubeApiException.ErrorCode.NOT_FOUND) {
+            if (e.getErrorCode() == KubeApiException.ErrorCode.NOT_FOUND) {
                 // If we did not find the PV return true as it is removed
                 logger.info("Delete for persistent volume {} not found", formatPvEssentials(pv));
                 return true;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcController.java
@@ -113,15 +113,7 @@ public class PersistentVolumeUnassociatedGcController extends BaseGcController<V
             // If the PV is deleted while still associated with a PVC (though that is not expected), the PV
             // will not be removed until it is no longer bound to a PVC.
             // https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection
-            kubeApiFacade.getCoreV1Api().deletePersistentVolume(
-                    volumeName,
-                    null,
-                    null,
-                    0,
-                    null,
-                    null,
-                    null
-            );
+            kubeApiFacade.deletePersistentVolume(volumeName);
             logger.info("Successfully deleted persistent volume {}", formatPvEssentials(pv));
             return true;
         } catch (ApiException e) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeApiServerIntegrator.java
@@ -240,8 +240,7 @@ public class KubeApiServerIntegrator implements VirtualMachineMasterService {
         List<Mono<Void>> podAddActions = new ArrayList<>(assignments.getCount());
         for (TaskInfoRequest request : assignments) {
             V1Pod v1Pod = taskInfoToPod(request);
-            Mono<Void> podAddAction = KubeUtil
-                    .<V1Pod>toReact(handler -> kubeApiFacade.createNamespacedPodAsync(DEFAULT_NAMESPACE, v1Pod, handler))
+            Mono<Void> podAddAction = kubeApiFacade.createNamespacedPodAsync(DEFAULT_NAMESPACE, v1Pod)
                     .doOnSubscribe(subscription -> {
                         launchTaskCounter.increment();
                         logger.info("creating pod: {}", formatPodEssentials(v1Pod));

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
@@ -337,14 +337,11 @@ public class KubeUtil {
     }
 
     /**
-     * Get pod name
+     * Get Kube object name
      */
+    @Deprecated
     public static String getMetadataName(V1ObjectMeta metadata) {
-        if (metadata == null) {
-            return "";
-        }
-
-        return metadata.getName();
+        return com.netflix.titus.runtime.connector.kubernetes.KubeUtil.getMetadataName(metadata);
     }
 
     public static Optional<V1NodeCondition> findNodeCondition(V1Node node, String type) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
@@ -64,13 +64,6 @@ public class KubeUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(KubeUtil.class);
 
-    /**
-     * Like {@link Function}, but with {@link ApiException} throws clause.
-     */
-    public interface KubeFunction<I, O> {
-        O apply(I argument) throws ApiException;
-    }
-
     private static final String SUCCEEDED = "Succeeded";
 
     private static final String FAILED = "Failed";
@@ -298,42 +291,6 @@ public class KubeUtil {
                 apiException.getCode(),
                 Evaluators.getOrDefault(apiException.getResponseBody(), "<not set>")
         );
-    }
-
-    public static <T> Mono<T> toReact(KubeFunction<ApiCallback<T>, Call> handler) {
-        return Mono.create(sink -> {
-            Call call;
-            try {
-                call = handler.apply(new ApiCallback<T>() {
-                    @Override
-                    public void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
-                        sink.error(e);
-                    }
-
-                    @Override
-                    public void onSuccess(T result, int statusCode, Map<String, List<String>> responseHeaders) {
-                        if (result == null) {
-                            sink.success();
-                        } else {
-                            sink.success(result);
-                        }
-                    }
-
-                    @Override
-                    public void onUploadProgress(long bytesWritten, long contentLength, boolean done) {
-                    }
-
-                    @Override
-                    public void onDownloadProgress(long bytesRead, long contentLength, boolean done) {
-                    }
-                });
-            } catch (ApiException e) {
-                sink.error(e);
-                return;
-            }
-
-            sink.onCancel(call::cancel);
-        });
     }
 
     /**

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -40,7 +39,6 @@ import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.master.kubernetes.pod.KubePodConfiguration;
 import com.netflix.titus.master.mesos.TitusExecutorDetails;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
-import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ContainerState;
 import io.kubernetes.client.openapi.models.V1ContainerStateRunning;
@@ -55,10 +53,8 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1Taint;
 import io.kubernetes.client.openapi.models.V1Toleration;
-import okhttp3.Call;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
 
 public class KubeUtil {
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultDirectKubeApiServerIntegrator.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/direct/DefaultDirectKubeApiServerIntegrator.java
@@ -52,7 +52,6 @@ import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodUpdatedEvent
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
 import io.kubernetes.client.informer.ResourceEventHandler;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
@@ -154,18 +153,18 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
     public Mono<V1Pod> launchTask(Job job, Task task) {
         boolean isEbsVolumePvEnabled = configuration.isEbsVolumePvEnabled();
         return Mono.fromCallable(() -> {
-            try {
-                V1Pod v1Pod = podFactory.buildV1Pod(job, task, true, isEbsVolumePvEnabled);
-                logger.info("creating pod: {}", formatPodEssentials(v1Pod));
-                logger.debug("complete pod data: {}", v1Pod);
-                return v1Pod;
-            } catch (Exception e) {
-                logger.error("Unable to convert job {} and task {} to pod: {}", job, task, KubeUtil.toErrorDetails(e), e);
-                throw new IllegalStateException("Unable to convert task to pod " + task.getId(), e);
-            }
-        })
+                    try {
+                        V1Pod v1Pod = podFactory.buildV1Pod(job, task, true, isEbsVolumePvEnabled);
+                        logger.info("creating pod: {}", formatPodEssentials(v1Pod));
+                        logger.debug("complete pod data: {}", v1Pod);
+                        return v1Pod;
+                    } catch (Exception e) {
+                        logger.error("Unable to convert job {} and task {} to pod: {}", job, task, KubeUtil.toErrorDetails(e), e);
+                        throw new IllegalStateException("Unable to convert task to pod " + task.getId(), e);
+                    }
+                })
                 .flatMap(v1Pod -> isEbsVolumePvEnabled
-                        ? launchEbsVolume(job, task, v1Pod, kubeApiFacade.getCoreV1Api()).then(Mono.just(v1Pod))
+                        ? launchEbsVolume(job, task, v1Pod).then(Mono.just(v1Pod))
                         : Mono.just(v1Pod))
                 .flatMap(v1Pod -> launchPod(task, v1Pod))
                 .subscribeOn(apiClientScheduler)
@@ -181,17 +180,7 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
             Stopwatch timer = Stopwatch.createStarted();
             try {
                 logger.info("Deleting pod: {}", taskId);
-                kubeApiFacade.getCoreV1Api().deleteNamespacedPod(
-                        taskId,
-                        KUBERNETES_NAMESPACE,
-                        null,
-                        null,
-                        DELETE_GRACE_PERIOD_SECONDS,
-                        null,
-                        null,
-                        null
-                );
-
+                kubeApiFacade.deleteNamespacedPod(KUBERNETES_NAMESPACE, taskId, DELETE_GRACE_PERIOD_SECONDS);
                 metrics.terminateSuccess(task, timer.elapsed(TimeUnit.MILLISECONDS));
             } catch (JsonSyntaxException e) {
                 // this is probably successful. the generated client has the wrong response type
@@ -231,7 +220,7 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
     /**
      * Launches/creates any EBS persistent volumes or claims associated with the task/pod.
      */
-    private Mono<Void> launchEbsVolume(Job<?> job, Task task, V1Pod v1Pod, CoreV1Api coreV1Api) {
+    private Mono<Void> launchEbsVolume(Job<?> job, Task task, V1Pod v1Pod) {
         // We currently only handle a single volume per-pod
         Optional<V1Volume> optionalV1Volume = CollectionsExt.nonNull(v1Pod.getSpec().getVolumes())
                 .stream()
@@ -255,12 +244,12 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
 
         // Create a persistent volume followed by a claim for that volume
         // If the attempt to create the PVC fails, the PV will be subsequently garbage collected
-        return launchEbsPersistentVolume(ebsVolume, coreV1Api)
-                .flatMap(v1PersistentVolume -> launchPersistentVolumeClaim(v1PersistentVolume, v1Pod, coreV1Api))
+        return launchEbsPersistentVolume(ebsVolume)
+                .flatMap(v1PersistentVolume -> launchPersistentVolumeClaim(v1PersistentVolume, v1Pod))
                 .then();
     }
 
-    private Mono<V1PersistentVolume> launchEbsPersistentVolume(EbsVolume ebsVolume, CoreV1Api coreV1Api) {
+    private Mono<V1PersistentVolume> launchEbsPersistentVolume(EbsVolume ebsVolume) {
         return Mono.defer(() -> {
             Stopwatch timer = Stopwatch.createStarted();
 
@@ -268,7 +257,7 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
             logger.info("Creating persistent volume {}", v1PersistentVolume);
 
             try {
-                coreV1Api.createPersistentVolume(v1PersistentVolume, null, null, null);
+                kubeApiFacade.createPersistentVolume(v1PersistentVolume);
                 logger.info("Created persistent volume {} in {}ms", v1PersistentVolume, timer.elapsed(TimeUnit.MILLISECONDS));
                 metrics.persistentVolumeCreateSuccess(timer.elapsed(TimeUnit.MILLISECONDS));
             } catch (ApiException apiException) {
@@ -285,7 +274,7 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
         });
     }
 
-    private Mono<V1PersistentVolumeClaim> launchPersistentVolumeClaim(V1PersistentVolume v1PersistentVolume, V1Pod v1Pod, CoreV1Api coreV1Api) {
+    private Mono<V1PersistentVolumeClaim> launchPersistentVolumeClaim(V1PersistentVolume v1PersistentVolume, V1Pod v1Pod) {
         return Mono.defer(() -> {
             Stopwatch timer = Stopwatch.createStarted();
 
@@ -293,7 +282,7 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
             logger.info("Creating persistent volume claim {}", v1PersistentVolumeClaim);
 
             try {
-                coreV1Api.createNamespacedPersistentVolumeClaim(KUBERNETES_NAMESPACE, v1PersistentVolumeClaim, null, null, null);
+                kubeApiFacade.createNamespacedPersistentVolumeClaim(KUBERNETES_NAMESPACE, v1PersistentVolumeClaim);
                 long latencyMs = timer.elapsed(TimeUnit.MILLISECONDS);
                 logger.info("Created persistent volume claim {} in {}ms", v1PersistentVolumeClaim, latencyMs);
                 metrics.persistentVolumeClaimCreateSuccess(latencyMs);
@@ -317,7 +306,7 @@ public class DefaultDirectKubeApiServerIntegrator implements DirectKubeApiServer
             try {
                 fitKubeInjection.ifPresent(i -> i.beforeImmediate(KubeFitAction.ErrorKind.POD_CREATE_ERROR.name()));
 
-                kubeApiFacade.getCoreV1Api().createNamespacedPod(KUBERNETES_NAMESPACE, v1Pod, null, null, null);
+                kubeApiFacade.createNamespacedPod(KUBERNETES_NAMESPACE, v1Pod);
                 pods.putIfAbsent(task.getId(), v1Pod);
 
                 metrics.launchSuccess(task, v1Pod, timer.elapsed(TimeUnit.MILLISECONDS));

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeClaimGcControllerTest.java
@@ -29,11 +29,9 @@ import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucke
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
 import com.netflix.titus.testkit.model.job.JobGenerator;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimStatus;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,7 +50,6 @@ public class PersistentVolumeClaimGcControllerTest {
     private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
     private final LocalScheduler scheduler = mock(LocalScheduler.class);
     private final V3JobOperations v3JobOperations = mock(V3JobOperations.class);
-    private final CoreV1Api coreV1Api = mock(CoreV1Api.class);
 
     private final PersistentVolumeClaimGcController pvcGcController = new PersistentVolumeClaimGcController(
             titusRuntime,
@@ -62,11 +59,6 @@ public class PersistentVolumeClaimGcControllerTest {
             kubeApiFacade,
             v3JobOperations
     );
-
-    @Before
-    public void setUp() {
-        when(kubeApiFacade.getCoreV1Api()).thenReturn(coreV1Api);
-    }
 
     /**
      * Tests that a PVC that is Bound is not GC'd.

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeReclaimControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeReclaimControllerTest.java
@@ -21,16 +21,13 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.limiter.tokenbucket.FixedIntervalTokenBucketConfiguration;
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PersistentVolume;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeStatus;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class PersistentVolumeReclaimControllerTest {
 
@@ -41,7 +38,6 @@ public class PersistentVolumeReclaimControllerTest {
     private final ControllerConfiguration controllerConfiguration = mock(ControllerConfiguration.class);
     private final KubeApiFacade kubeApiFacade = mock(KubeApiFacade.class);
     private final LocalScheduler scheduler = mock(LocalScheduler.class);
-    private final CoreV1Api coreV1Api = mock(CoreV1Api.class);
 
     private final PersistentVolumeReclaimController pvcReclaimController = new PersistentVolumeReclaimController(
             titusRuntime,
@@ -50,11 +46,6 @@ public class PersistentVolumeReclaimControllerTest {
             controllerConfiguration,
             kubeApiFacade
     );
-
-    @Before
-    public void setUp() {
-        when(kubeApiFacade.getCoreV1Api()).thenReturn(coreV1Api);
-    }
 
     /**
      * Tests that a bound VPC is not selected for reclamation.

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcControllerTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/controller/PersistentVolumeUnassociatedGcControllerTest.java
@@ -67,7 +67,6 @@ public class PersistentVolumeUnassociatedGcControllerTest {
     @Before
     public void setUp() {
         when(kubeControllerConfiguration.getPersistentVolumeUnassociatedGracePeriodMs()).thenReturn(PERSISTENT_VOLUME_GRACE_PERIOD_MS);
-        when(kubeApiFacade.getCoreV1Api()).thenReturn(coreV1Api);
     }
 
     /**


### PR DESCRIPTION
Hide Kube Java lib invocations behind internal API. We need a proper interface between Kube and Titus so we can easily inject stubbed version of Kube Cluster in the integration tests.