### PR TITLE
Only set the ipv4 container attribute if we have one

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -58,6 +58,7 @@ public final class TaskAttributes {
     public static final String TASK_ATTRIBUTES_CONTAINER_IP = "task.containerIp";
     public static final String TASK_ATTRIBUTES_CONTAINER_IPV4 = "task.containerIPv4";
     public static final String TASK_ATTRIBUTES_CONTAINER_IPV6 = "task.containerIPv6";
+    public static final String TASK_ATTRIBUTES_TRANSITION_IPV4 = "task.transitionIPv4";
     public static final String TASK_ATTRIBUTES_NETWORK_INTERFACE_ID = "task.networkInterfaceId";
     public static final String TASK_ATTRIBUTES_NETWORK_INTERFACE_INDEX = "task.networkInterfaceIndex";
     public static final String TASK_ATTRIBUTES_EXECUTOR_URI_OVERRIDE = "task.executorUriOverride";

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -58,6 +58,12 @@ public final class TaskAttributes {
     public static final String TASK_ATTRIBUTES_CONTAINER_IP = "task.containerIp";
     public static final String TASK_ATTRIBUTES_CONTAINER_IPV4 = "task.containerIPv4";
     public static final String TASK_ATTRIBUTES_CONTAINER_IPV6 = "task.containerIPv6";
+    /*
+     * TASK_ATTRIBUTES_TRANSITION_IPV4 is a special IP that represents the IP that
+     * Tasks in the special Ipv6AndIpv4Fallback network Mode use.
+     * It represents a kind of "NAT" ip. It should not be considered the normal
+     * IPv4 for a task (you cannot ssh to it), therefore it gets a distinct attribute.
+     */
     public static final String TASK_ATTRIBUTES_TRANSITION_IPV4 = "task.transitionIPv4";
     public static final String TASK_ATTRIBUTES_NETWORK_INTERFACE_ID = "task.networkInterfaceId";
     public static final String TASK_ATTRIBUTES_NETWORK_INTERFACE_INDEX = "task.networkInterfaceIndex";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -133,21 +133,31 @@ public final class JobManagerUtil {
             }
 
             Task newTask = JobFunctions.changeTaskStatus(oldTask, newTaskStatus);
-            Task newTaskWithPlacementData = attachTitusExecutorData(newTask, detailsOpt);
+            Task newTaskWithPlacementData = attachTitusExecutorNetworkData(newTask, detailsOpt);
             return Optional.of(newTaskWithPlacementData);
         };
     }
 
-    public static Task attachTitusExecutorData(Task task, Optional<TitusExecutorDetails> detailsOpt) {
+    public static Task attachTitusExecutorNetworkData(Task task, Optional<TitusExecutorDetails> detailsOpt) {
         return detailsOpt.map(details -> {
             TitusExecutorDetails.NetworkConfiguration networkConfiguration = details.getNetworkConfiguration();
             if (networkConfiguration != null) {
+                String ipv4 = networkConfiguration.getIpAddress();
+                String ipv6 = networkConfiguration.getIpV6Address();
+                String primaryIP = networkConfiguration.getPrimaryIpAddress();
                 Map<String, String> newContext = new HashMap<>(task.getTaskContext());
                 BiConsumer<String, String> contextSetter = (key, value) -> StringExt.applyIfNonEmpty(value, v -> newContext.put(key, v));
 
-                contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, networkConfiguration.getIpAddress());
-                contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV4, networkConfiguration.getIpAddress());
-                Evaluators.acceptNotNull(networkConfiguration.getIpV6Address(), ipv6 -> newContext.put(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV6, ipv6));
+                if (networkConfiguration.getNetworkMode() == "Ipv6AndIpv4Fallback") {
+                    // In the IPV6_ONLY_WITH_TRANSITION mode, the ipv4 on the pod doesn't represent
+                    // a unique IP for that pod, but a shared one. This should not be consumed
+                    // as a normal ip by normal tools, and deserves a special attribute
+                    contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_TRANSITION_IPV4, ipv4);
+                } else {
+                    contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV4, ipv4);
+                }
+                contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, primaryIP);
+                contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV6, ipv6);
                 contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_NETWORK_INTERFACE_ID, networkConfiguration.getEniID());
                 parseEniResourceId(networkConfiguration.getResourceID()).ifPresent(index -> newContext.put(TaskAttributes.TASK_ATTRIBUTES_NETWORK_INTERFACE_INDEX, index));
 
@@ -157,7 +167,7 @@ public final class JobManagerUtil {
         }).orElse(task);
     }
 
-    public static Task attachKubeletData(Task task, PodWrapper podWrapper) {
+    public static Task attachKubeletNetworkData(Task task, PodWrapper podWrapper) {
         if (podWrapper.getV1Pod().getStatus() == null) {
             return task;
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -48,7 +48,6 @@ import com.netflix.titus.common.framework.reconciler.EntityHolder;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.CollectionsExt;
-import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.jobmanager.service.event.JobManagerReconcilerEvent;
@@ -57,6 +56,7 @@ import com.netflix.titus.master.mesos.TitusExecutorDetails;
 import com.netflix.titus.master.mesos.kubeapiserver.KubeUtil;
 import com.netflix.titus.master.mesos.kubeapiserver.direct.model.PodWrapper;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+import com.netflix.titus.grpc.protogen.NetworkConfiguration.NetworkMode;
 import org.apache.mesos.Protos;
 
 import static com.netflix.titus.api.jobmanager.TaskAttributes.TASK_ATTRIBUTES_EXECUTOR_URI_OVERRIDE;
@@ -148,7 +148,7 @@ public final class JobManagerUtil {
                 Map<String, String> newContext = new HashMap<>(task.getTaskContext());
                 BiConsumer<String, String> contextSetter = (key, value) -> StringExt.applyIfNonEmpty(value, v -> newContext.put(key, v));
 
-                if (networkConfiguration.getNetworkMode() == "Ipv6AndIpv4Fallback") {
+                if (networkConfiguration.getNetworkMode().equals(NetworkMode.Ipv6AndIpv4Fallback.toString())) {
                     // In the IPV6_ONLY_WITH_TRANSITION mode, the ipv4 on the pod doesn't represent
                     // a unique IP for that pod, but a shared one. This should not be consumed
                     // as a normal ip by normal tools, and deserves a special attribute

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessor.java
@@ -323,9 +323,9 @@ public class KubeNotificationProcessor {
         Task fixedTask = fillInMissingStates(podWrapper, updatedTask);
         Task taskWithExecutorData;
         if (executorDetailsOpt.isPresent()) {
-            taskWithExecutorData = JobManagerUtil.attachTitusExecutorData(fixedTask, executorDetailsOpt);
+            taskWithExecutorData = JobManagerUtil.attachTitusExecutorNetworkData(fixedTask, executorDetailsOpt);
         } else {
-            taskWithExecutorData = JobManagerUtil.attachKubeletData(fixedTask, podWrapper);
+            taskWithExecutorData = JobManagerUtil.attachKubeletNetworkData(fixedTask, podWrapper);
         }
         Task taskWithNodeMetadata = node.map(n -> attachNodeMetadata(taskWithExecutorData, n)).orElse(taskWithExecutorData);
         Task taskWithAnnotations = addMissingAttributes(podWrapper, taskWithNodeMetadata);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/TitusExecutorDetails.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/TitusExecutorDetails.java
@@ -85,6 +85,8 @@ public class TitusExecutorDetails {
 
         private final String ipV6Address;
 
+        private final String networkMode;
+
         private final String eniIPAddress;
 
         private final String eniID;
@@ -96,11 +98,13 @@ public class TitusExecutorDetails {
                 @JsonProperty("IPAddress") String ipAddress,
                 @JsonProperty("IPV6Address") String ipV6Address,
                 @JsonProperty("EniIPAddress") String eniIPAddress,
+                @JsonProperty("NetworkMode") String networkMode,
                 @JsonProperty("EniID") String eniID,
                 @JsonProperty("ResourceID") String resourceID) {
             this.isRoutableIP = isRoutableIP;
             this.ipAddress = ipAddress;
             this.ipV6Address = ipV6Address;
+            this.networkMode = networkMode;
             this.eniIPAddress = eniIPAddress;
             this.eniID = eniID;
             this.resourceID = resourceID;
@@ -126,6 +130,11 @@ public class TitusExecutorDetails {
             return eniIPAddress;
         }
 
+        @JsonProperty("NetworkMode")
+        public String getNetworkMode() {
+            return networkMode;
+        }
+
         @JsonProperty("EniID")
         public String getEniID() {
             return eniID;
@@ -148,6 +157,7 @@ public class TitusExecutorDetails {
             return isRoutableIP == that.isRoutableIP &&
                     Objects.equals(ipAddress, that.ipAddress) &&
                     Objects.equals(ipV6Address, that.ipV6Address) &&
+                    Objects.equals(networkMode, that.networkMode) &&
                     Objects.equals(eniIPAddress, that.eniIPAddress) &&
                     Objects.equals(eniID, that.eniID) &&
                     Objects.equals(resourceID, that.resourceID);
@@ -155,7 +165,7 @@ public class TitusExecutorDetails {
 
         @Override
         public int hashCode() {
-            return Objects.hash(isRoutableIP, ipAddress, ipV6Address, eniIPAddress, eniID, resourceID);
+            return Objects.hash(isRoutableIP, ipAddress, ipV6Address, eniIPAddress, networkMode, eniID, resourceID);
         }
 
         @Override
@@ -165,9 +175,24 @@ public class TitusExecutorDetails {
                     ", ipAddress='" + ipAddress + '\'' +
                     ", ipV6Address='" + ipV6Address + '\'' +
                     ", eniIPAddress='" + eniIPAddress + '\'' +
+                    ", networkMode='" + networkMode + '\'' +
                     ", eniID='" + eniID + '\'' +
                     ", resourceID='" + resourceID + '\'' +
                     '}';
+        }
+
+        public String getPrimaryIpAddress() {
+            // For backward-compatibility reasons, the "primary ip" is considered the v4 address
+            // if we have one (if we are not in the transition mode), otherwise ipv6
+            if (ipAddress != null && !ipAddress.equals("")) {
+                if (!networkMode.equals("Ipv6AndIpv4Fallback")) {
+                    return ipAddress;
+                }
+            }
+            if (ipV6Address != null && !ipV6Address.equals("")) {
+                return ipV6Address;
+            }
+            return "";
         }
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/TitusExecutorDetails.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/TitusExecutorDetails.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.grpc.protogen.NetworkConfiguration.NetworkMode;
 
 /**
  * Titus executor data model for reporting back resource allocation data.
@@ -184,12 +186,12 @@ public class TitusExecutorDetails {
         public String getPrimaryIpAddress() {
             // For backward-compatibility reasons, the "primary ip" is considered the v4 address
             // if we have one (if we are not in the transition mode), otherwise ipv6
-            if (ipAddress != null && !ipAddress.equals("")) {
-                if (!networkMode.equals("Ipv6AndIpv4Fallback")) {
+            if (StringExt.isNotEmpty(ipAddress)) {
+                if (!networkMode.equals(NetworkMode.Ipv6AndIpv4Fallback.toString())) {
                     return ipAddress;
                 }
             }
-            if (ipV6Address != null && !ipV6Address.equals("")) {
+            if (StringExt.isNotEmpty(ipV6Address)) {
                 return ipV6Address;
             }
             return "";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/mesos/kubeapiserver/KubeUtil.java
@@ -116,6 +116,7 @@ public class KubeUtil {
                             annotations.getOrDefault("IpAddress", "UnknownIpAddress"),
                             annotations.get("EniIPv6Address"),
                             annotations.getOrDefault("EniIpAddress", "UnknownEniIpAddress"),
+                            annotations.getOrDefault("NetworkMode", "UnknownNetworkMode"),
                             annotations.getOrDefault("EniId", "UnknownEniId"),
                             annotations.getOrDefault("ResourceId", "UnknownResourceId")
                     )

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
@@ -38,6 +38,7 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.grpc.protogen.NetworkConfiguration;
 import com.netflix.titus.master.mesos.ContainerEvent;
 import com.netflix.titus.master.mesos.TitusExecutorDetails;
 import com.netflix.titus.master.mesos.kubeapiserver.ContainerResultCodeResolver;
@@ -173,7 +174,7 @@ public class KubeNotificationProcessorTest {
                         "1.2.3.4",
                         "",
                         "1.2.3.4",
-                        "Ipv4Only",
+                        NetworkConfiguration.NetworkMode.Ipv4Only.toString(),
                         "eniId123",
                         "resourceId123"
                 ))),
@@ -205,7 +206,7 @@ public class KubeNotificationProcessorTest {
                         "192.0.2.1",
                         "2001:db8:0:1234:0:567:8:1",
                         "192.0.2.1",
-                        "Ipv6AndIpv4Fallback",
+                        NetworkConfiguration.NetworkMode.Ipv6AndIpv4Fallback.toString(),
                         "eniId123",
                         "resourceId123"
                 ))),

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
@@ -28,6 +28,7 @@ import com.netflix.fenzo.functions.Action1;
 import com.netflix.titus.api.json.ObjectMappers;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.grpc.protogen.NetworkConfiguration;
 import com.netflix.titus.master.mesos.ContainerEvent;
 import com.netflix.titus.master.mesos.LeaseRescindedEvent;
 import com.netflix.titus.master.mesos.TaskAssignments;
@@ -62,7 +63,7 @@ class StubbedVirtualMachineMasterService implements VirtualMachineMasterService 
                         "1.2.3.4",
                         "2600:1f18:2772:d500:6410:ec14:39ca:30d7",
                         "1.1.1.1",
-                        "Ipv4AndIpv6",
+                        NetworkConfiguration.NetworkMode.Ipv6AndIpv4.toString(),
                         "eni-12345",
                         "eni-resource-1"
                 ));

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/StubbedVirtualMachineMasterService.java
@@ -58,7 +58,13 @@ class StubbedVirtualMachineMasterService implements VirtualMachineMasterService 
         return new TitusExecutorDetails(
                 CollectionsExt.asMap("nfvpc", "1.2.3.4"),
                 new TitusExecutorDetails.NetworkConfiguration(
-                        true, "1.2.3.4", "2600:1f18:2772:d500:6410:ec14:39ca:30d7", "1.1.1.1", "eni-12345", "eni-resource-1"
+                        true,
+                        "1.2.3.4",
+                        "2600:1f18:2772:d500:6410:ec14:39ca:30d7",
+                        "1.1.1.1",
+                        "Ipv4AndIpv6",
+                        "eni-12345",
+                        "eni-resource-1"
                 ));
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/TaskExecutorHolder.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/TaskExecutorHolder.java
@@ -29,6 +29,7 @@ import com.netflix.titus.api.json.ObjectMappers;
 import com.netflix.titus.api.model.EfsMount;
 import com.netflix.titus.common.aws.AwsInstanceType;
 import com.netflix.titus.common.util.CollectionsExt;
+import com.netflix.titus.grpc.protogen.NetworkConfiguration;
 import com.netflix.titus.master.mesos.TitusExecutorDetails;
 import com.netflix.titus.testkit.embedded.cloud.agent.player.ContainerPlayersManager;
 import org.apache.mesos.Protos;
@@ -219,7 +220,7 @@ public class TaskExecutorHolder {
                             containerIp,
                             null,
                             containerIp,
-                            "UnknownNetworkMode",
+                            NetworkConfiguration.NetworkMode.UnknownNetworkMode.toString(),
                             "simulatedENI-" + eniID,
                             "resource-eni-" + eniID
                     )

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/TaskExecutorHolder.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/agent/TaskExecutorHolder.java
@@ -219,6 +219,7 @@ public class TaskExecutorHolder {
                             containerIp,
                             null,
                             containerIp,
+                            "UnknownNetworkMode",
                             "simulatedENI-" + eniID,
                             "resource-eni-" + eniID
                     )

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/connector/remote/SimulatedRemoteMesosSchedulerDriver.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cloud/connector/remote/SimulatedRemoteMesosSchedulerDriver.java
@@ -411,6 +411,7 @@ class SimulatedRemoteMesosSchedulerDriver implements SchedulerDriver {
                             networkConfiguration.getIpAddress(),
                             null,
                             networkConfiguration.getEniIPAddress(),
+                            "UnknownNetworkMode",
                             networkConfiguration.getEniID(),
                             networkConfiguration.getResourceID()
                     )


### PR DESCRIPTION
We are moving to a new world where IPv6 is the main thing,
and IPv4 is extra.

This change makes the ipv4/ipv6 task attribute setter "NetworkMode"-aware,
and only sets the IPv4 when it makes sense.

Only a small number of experimental tasks are using this mode,
so we need to use those as canaries to see what else will break
when we stop publishing a v4 address in this way.

----

This change will also be paired with a titus-executor change that add networkMode
to the details that come back for the control-plane to use.