### PR TITLE
Add routing cell metadata to jobs created via fedv1

### DIFF
--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/AggregatingJobServiceGateway.java
@@ -145,6 +145,7 @@ public class AggregatingJobServiceGateway implements JobServiceGateway {
 
         JobDescriptor.Builder jobDescriptorBuilder = addStackName(jobDescriptor.toBuilder());
         jobDescriptorBuilder = removeFederationAttributes(jobDescriptorBuilder);
+        jobDescriptorBuilder = addRoutingCell(jobDescriptorBuilder, cell);
         JobDescriptor jd = jobDescriptorBuilder.build();
 
         return createRequestObservable(emitter -> {
@@ -460,10 +461,14 @@ public class AggregatingJobServiceGateway implements JobServiceGateway {
         return result.toCompletable();
     }
 
+    private JobDescriptor.Builder addRoutingCell(JobDescriptor.Builder jobDescriptorBuilder, Cell cell) {
+        return jobDescriptorBuilder
+                .putAttributes(JOB_ATTRIBUTE_ROUTING_CELL, cell.getName());
+    }
+
     private JobDescriptor.Builder removeFederationAttributes(JobDescriptor.Builder jobDescriptorBuilder) {
         return jobDescriptorBuilder
-                .removeAttributes(JOB_ATTRIBUTES_FEDERATED_JOB_ID)
-                .removeAttributes(JOB_ATTRIBUTE_ROUTING_CELL);
+                .removeAttributes(JOB_ATTRIBUTES_FEDERATED_JOB_ID);
     }
 
     private JobQueryResult addStackName(JobQueryResult result) {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSubmitAndControlBasicTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/JobSubmitAndControlBasicTest.java
@@ -87,10 +87,13 @@ public class JobSubmitAndControlBasicTest extends BaseIntegrationTest {
      */
     @Test(timeout = 30_000)
     public void testSubmitSimpleBatchJobWhichEndsOk() throws Exception {
+        JobDescriptor<BatchJobExt> tmpJob =
+                appendJobDescriptorAttribute(ONE_TASK_BATCH_JOB, JobAttributes.JOB_ATTRIBUTES_CREATED_BY, "embeddedFederationClient");
+        tmpJob = appendJobDescriptorAttribute(tmpJob, JobAttributes.JOB_ATTRIBUTE_ROUTING_CELL, "embeddedCell");
+        final JobDescriptor<BatchJobExt> expectedJob = tmpJob;
+
         jobsScenarioBuilder.schedule(ONE_TASK_BATCH_JOB, jobScenarioBuilder -> jobScenarioBuilder
-                .inJob(job -> assertThat(job.getJobDescriptor()).isEqualTo(
-                        appendJobDescriptorAttribute(ONE_TASK_BATCH_JOB, JobAttributes.JOB_ATTRIBUTES_CREATED_BY, "embeddedFederationClient"))
-                )
+                .inJob(job -> assertThat(job.getJobDescriptor()).isEqualTo(expectedJob))
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .assertEachContainer(
                         containerWithResources(ONE_TASK_BATCH_JOB.getContainer().getContainerResources(), jobConfiguration.getMinDiskSizeMB()),


### PR DESCRIPTION
### Description of the Change
This information is necessary to evaluate scheduling parity between
fedv1 and fedv2 approaches before the transition to fedv2