### PR TITLE
Binpack self-managed tasks to optimize their relocation

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/FeatureActivationConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/FeatureActivationConfiguration.java
@@ -54,4 +54,10 @@ public interface FeatureActivationConfiguration {
      */
     @DefaultValue("false")
     boolean isKubeSchedulerEnabled();
+
+    /**
+     * Enable binpacking of tasks based on how hard they are to relocate
+     */
+    @DefaultValue("true")
+    boolean isRelocationBinpackingEnabled();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
@@ -30,13 +30,13 @@ import com.netflix.titus.api.jobmanager.JobConstraints;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.Task;
-import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.SelfManagedDisruptionBudgetPolicy;
 import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolumeUtils;
 import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressAllocationUtils;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
 import com.netflix.titus.master.kubernetes.pod.KubePodConfiguration;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.PodResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.ResourcePoolAssignment;
@@ -294,7 +294,7 @@ public class DefaultPodAffinityFactory implements PodAffinityFactory {
         }
 
         private void processRelocationAffinity() {
-            if (!featureConfiguration.isRelocationBinpackingEnabled() || !shouldBinpackForRelocation()) {
+            if (!featureConfiguration.isRelocationBinpackingEnabled() || !JobManagerUtil.getRelocationBinpackMode(job).isPresent()) {
                 return;
             }
             getPodAffinity().addPreferredDuringSchedulingIgnoredDuringExecutionItem(
@@ -323,10 +323,6 @@ public class DefaultPodAffinityFactory implements PodAffinityFactory {
                                     .topologyKey(KubeConstants.NODE_LABEL_MACHINE_ID)
                             )
             );
-        }
-
-        private boolean shouldBinpackForRelocation() {
-            return job.getJobDescriptor().getDisruptionBudget().getDisruptionBudgetPolicy() instanceof SelfManagedDisruptionBudgetPolicy;
         }
 
         private V1NodeAffinity getNodeAffinity() {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -112,6 +112,7 @@ public class V0SpecPodFactory implements PodFactory {
         Map<String, String> labels = new HashMap<>();
         labels.put(KubeConstants.POD_LABEL_JOB_ID, job.getId());
         labels.put(KubeConstants.POD_LABEL_TASK_ID, taskId);
+        JobManagerUtil.getRelocationBinpackMode(job).ifPresent(mode -> labels.put(KubeConstants.POD_LABEL_RELOCATION_BINPACK, mode));
 
         String capacityGroup = JobManagerUtil.getCapacityGroupDescriptorName(job.getJobDescriptor(), capacityGroupManagement).toLowerCase();
         labels.put(KubeConstants.LABEL_CAPACITY_GROUP, capacityGroup);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -178,8 +178,9 @@ public class V1SpecPodFactory implements PodFactory {
         annotations.put(POD_USER_ENV_VARS_START_INDEX, String.valueOf(userEnvBeginIndex));
 
         Map<String, String> labels = new HashMap<>();
-        labels.put("v3.job.titus.netflix.com/job-id", job.getId());
-        labels.put("v3.job.titus.netflix.com/task-id", taskId);
+        labels.put(KubeConstants.POD_LABEL_JOB_ID, job.getId());
+        labels.put(KubeConstants.POD_LABEL_TASK_ID, taskId);
+        JobManagerUtil.getRelocationBinpackMode(job).ifPresent(mode -> labels.put(KubeConstants.POD_LABEL_RELOCATION_BINPACK, mode));
 
         JobDescriptor<?> jobDescriptor = job.getJobDescriptor();
         JobGroupInfo jobGroupInfo = jobDescriptor.getJobGroupInfo();

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -74,6 +74,8 @@ public final class KubeConstants {
 
     public static final String POD_LABEL_SUBNETS = TITUS_POD_DOMAIN + "subnets";
 
+    public static final String POD_LABEL_RELOCATION_BINPACK = TITUS_POD_DOMAIN + "relocation-binpack";
+
     public static final String POD_LABEL_JOB_ID = TITUS_V3_JOB_DOMAIN + "job-id";
 
     public static final String POD_LABEL_TASK_ID = TITUS_V3_JOB_DOMAIN + "task-id";
@@ -175,6 +177,16 @@ public final class KubeConstants {
     public static final String POD_ENV_TITUS_TASK_INSTANCE_ID = "TITUS_TASK_INSTANCE_ID";
     public static final String POD_ENV_TITUS_TASK_ORIGINAL_ID = "TITUS_TASK_ORIGINAL_ID";
     public static final String POD_ENV_TITUS_TASK_INDEX = "TITUS_TASK_INDEX";
+
+    /*
+     * Label selector operators. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+     */
+    public static final String SELECTOR_OPERATOR_IN = "In";
+    public static final String SELECTOR_OPERATOR_NOT_IN = "NotIn";
+    public static final String SELECTOR_OPERATOR_EXISTS = "Exists";
+    public static final String SELECTOR_OPERATOR_DOES_NOT_EXIST = "DoesNotExist";
+    public static final String SELECTOR_OPERATOR_GT = "Gt";
+    public static final String SELECTOR_OPERATOR_LT = "Lt";
 
     /*
      * API Constants

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobGenerator.java
@@ -176,6 +176,14 @@ public class JobGenerator {
         );
     }
 
+    public static Job<ServiceJobExt> oneServiceJob() {
+        return serviceJobs(JobDescriptorGenerator.oneTaskServiceJobDescriptor()).getValue();
+    }
+
+    public static ServiceJobTask oneServiceTask() {
+        return JobGenerator.serviceTasks(oneServiceJob()).getValue();
+    }
+
     public static Job<BatchJobExt> oneBatchJob() {
         return batchJobs(JobDescriptorGenerator.oneTaskBatchJobDescriptor()).getValue();
     }


### PR DESCRIPTION
The new behavior can be disabled by the `titus.feature.relocationBinpackingEnabled` flag.

Binpacking is accomplished by:

* a new label added to tasks that should opt-into binpacking (currently only tasks from jobs with SelfManaged disruption policies)
* Pod affinity and anti-affinity rules against the label above