### PR TITLE
Implemented extraContainers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.2-rc.5'
+        titusApiDefinitionsVersion = '0.0.2-rc.7'
 
         springVersion = '5.2.11.RELEASE'
         springSecurityVersion = '5.3.6.RELEASE'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/BasicContainer.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/BasicContainer.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+
+import com.google.common.base.Preconditions;
+import com.netflix.titus.api.jobmanager.model.job.sanitizer.JobAssertions;
+import com.netflix.titus.common.model.sanitizer.CollectionInvariants;
+import com.netflix.titus.common.model.sanitizer.FieldInvariant;
+import com.netflix.titus.common.util.CollectionsExt;
+
+import static com.netflix.titus.common.util.CollectionsExt.nonNull;
+
+public class BasicContainer {
+
+    @Valid
+    private final String name;
+
+    @Valid
+    private final Image image;
+
+    @CollectionInvariants
+    @FieldInvariant(
+            value = "@asserts.isEntryPointNotTooLarge(value)",
+            message = "Entry point size exceeds the limit " + JobAssertions.MAX_ENTRY_POINT_SIZE_SIZE_KB + "KB"
+    )
+    private final List<String> entryPoint;
+
+    @CollectionInvariants
+    private final List<String> command;
+
+    @CollectionInvariants(allowEmptyKeys = false)
+    @FieldInvariant(
+            value = "@asserts.areEnvironmentVariablesNotTooLarge(value)",
+            message = "Container environment variables size exceeds the limit"
+    )
+    private final Map<String, String> env;
+
+    public BasicContainer(
+            String name,
+            Image image,
+            List<String> entryPoint,
+            List<String> command,
+            Map<String, String> env
+    ) {
+        this.name = name;
+        this.image = image;
+        this.entryPoint = CollectionsExt.nullableImmutableCopyOf(entryPoint);
+        this.command = CollectionsExt.nullableImmutableCopyOf(command);
+        this.env = CollectionsExt.nullableImmutableCopyOf(env);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Image getImage() {
+        return image;
+    }
+
+    public List<String> getEntryPoint() {
+        if (entryPoint == null) { return Collections.emptyList();}
+        return entryPoint;
+    }
+
+    public List<String> getCommand() {
+        if (command == null) { return Collections.emptyList();}
+        return command;
+    }
+
+    public Map<String, String> getEnv() {
+        if (env == null) { return Collections.emptyMap();}
+        return env;
+    }
+
+    public Builder toBuilder() {
+        return newBuilder(this);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilder(BasicContainer basicContainer) {
+        return new Builder()
+                .withName(basicContainer.getName())
+                .withImage(basicContainer.getImage())
+                .withEntryPoint(basicContainer.getEntryPoint())
+                .withCommand(basicContainer.getCommand())
+                .withEnv(basicContainer.getEnv());
+    }
+
+    public static final class Builder {
+        private String name;
+        private Image image;
+        private List<String> entryPoint;
+        private List<String> command;
+        private Map<String, String> env;
+
+        private Builder() {
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withImage(Image image) {
+            this.image = image;
+            return this;
+        }
+
+        public Builder withEntryPoint(List<String> entryPoint) {
+            if (entryPoint == null) { entryPoint = Collections.emptyList();}
+            this.entryPoint = entryPoint;
+            return this;
+        }
+
+        public Builder withCommand(List<String> command) {
+            if (command == null) { command = Collections.emptyList();}
+            this.command = command;
+            return this;
+        }
+
+        public Builder withEnv(Map<String, String> env) {
+            this.env = env;
+            return this;
+        }
+
+        public BasicContainer build() {
+            Preconditions.checkNotNull(image, "Image not defined");
+            return new BasicContainer(
+                    name,
+                    image,
+                    entryPoint,
+                    command,
+                    nonNull(env)
+            );
+        }
+    }
+
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
@@ -17,6 +17,7 @@
 package com.netflix.titus.api.jobmanager.model.job;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -82,6 +83,9 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
     @Valid
     private final NetworkConfiguration networkConfiguration;
 
+    @CollectionInvariants
+    private final List<BasicContainer> extraContainers;
+
     @Valid
     private final E extensions;
 
@@ -93,6 +97,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                          Container container,
                          DisruptionBudget disruptionBudget,
                          NetworkConfiguration networkConfiguration,
+                         List<BasicContainer> extraContainers,
                          E extensions) {
         this.owner = owner;
         this.applicationName = applicationName;
@@ -114,6 +119,9 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
         } else {
             this.networkConfiguration = networkConfiguration;
         }
+
+        if (extraContainers == null) { extraContainers = Collections.emptyList(); }
+        this.extraContainers = extraContainers;
     }
 
     /**
@@ -173,6 +181,11 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
     public NetworkConfiguration getNetworkConfiguration() { return networkConfiguration; }
 
     /**
+     * Network configuration for a job
+     */
+    public List<BasicContainer> getExtraContainers() { return extraContainers; }
+
+    /**
      * Returns job type specific data.
      */
     public E getExtensions() {
@@ -196,12 +209,13 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 Objects.equals(container, that.container) &&
                 Objects.equals(disruptionBudget, that.disruptionBudget) &&
                 Objects.equals(networkConfiguration, that.networkConfiguration) &&
+                Objects.equals(extraContainers, that.extraContainers) &&
                 Objects.equals(extensions, that.extensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extensions);
+        return Objects.hash(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extraContainers, extensions);
     }
 
     @Override
@@ -215,6 +229,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 ", container=" + container +
                 ", disruptionBudget=" + disruptionBudget +
                 ", networkConfiguration=" + networkConfiguration +
+                ", extraContainers=" + extraContainers +
                 ", extensions=" + extensions +
                 '}';
     }
@@ -299,6 +314,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 .withContainer(jobDescriptor.getContainer())
                 .withDisruptionBudget(jobDescriptor.getDisruptionBudget())
                 .withNetworkConfiguration(jobDescriptor.getNetworkConfiguration())
+                .withExtraContainers(jobDescriptor.getExtraContainers())
                 .withExtensions(jobDescriptor.getExtensions());
     }
 
@@ -311,6 +327,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
         private Container container;
         private DisruptionBudget disruptionBudget;
         private NetworkConfiguration networkConfiguration;
+        private List<BasicContainer> extraContainers;
         private E extensions;
 
         private Builder() {
@@ -356,6 +373,11 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
             return this;
         }
 
+        public Builder<E> withExtraContainers(List<BasicContainer> extraContainersList) {
+            this.extraContainers = extraContainersList;
+            return this;
+        }
+
         public Builder<E> withExtensions(E extensions) {
             this.extensions = extensions;
             return this;
@@ -375,7 +397,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
         }
 
         public JobDescriptor<E> build() {
-            JobDescriptor<E> jobDescriptor = new JobDescriptor<>(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extensions);
+            JobDescriptor<E> jobDescriptor = new JobDescriptor<>(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extraContainers, extensions);
             return jobDescriptor;
         }
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/BasicContainerMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/BasicContainerMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.store.mixin;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.titus.api.jobmanager.model.job.Image;
+
+public abstract class BasicContainerMixin {
+    @JsonCreator
+    public BasicContainerMixin(@JsonProperty("name") String name,
+                               @JsonProperty("image") Image image,
+                               @JsonProperty("entryPoint") List<String> entryPoint,
+                               @JsonProperty("command") List<String> command,
+                               @JsonProperty("env") Map<String, String> env) {
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/JobDescriptorMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/JobDescriptorMixin.java
@@ -16,10 +16,12 @@
 
 package com.netflix.titus.api.jobmanager.store.mixin;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.titus.api.jobmanager.model.job.BasicContainer;
 import com.netflix.titus.api.jobmanager.model.job.Container;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobGroupInfo;
@@ -37,6 +39,7 @@ public abstract class JobDescriptorMixin {
                               @JsonProperty("container") Container container,
                               @JsonProperty("disruptionBudget") DisruptionBudget disruptionBudget,
                               @JsonProperty("networkConfiguration") NetworkConfiguration networkConfiguration,
-                              @JsonProperty("extensions") JobDescriptor.JobDescriptorExt extensions) {
+                              @JsonProperty("extraContainers") List<BasicContainer> extraContainers,
+                              @JsonProperty("extensions") JobDescriptor.JobDescriptorExt extensions){
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
@@ -47,6 +47,7 @@ import com.netflix.titus.api.appscale.store.mixin.PredefinedMetricSpecificationM
 import com.netflix.titus.api.appscale.store.mixin.StepAdjustmentMixIn;
 import com.netflix.titus.api.appscale.store.mixin.StepScalingPolicyConfigurationMixIn;
 import com.netflix.titus.api.appscale.store.mixin.TargetTrackingPolicyMixin;
+import com.netflix.titus.api.jobmanager.model.job.BasicContainer;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
 import com.netflix.titus.api.jobmanager.model.job.Capacity;
 import com.netflix.titus.api.jobmanager.model.job.Container;
@@ -94,6 +95,7 @@ import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressAllocation;
 import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressLocation;
 import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
 import com.netflix.titus.api.jobmanager.store.mixin.AvailabilityPercentageLimitDisruptionBudgetPolicyMixIn;
+import com.netflix.titus.api.jobmanager.store.mixin.BasicContainerMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.BatchJobExtMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.BatchJobTaskMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.CapacityMixin;
@@ -271,6 +273,7 @@ public class ObjectMappers {
         objectMapper.addMixIn(ContainerResources.class, ContainerResourcesMixin.class);
         objectMapper.addMixIn(SecurityProfile.class, SecurityProfileMixin.class);
         objectMapper.addMixIn(Container.class, ContainerMixin.class);
+        objectMapper.addMixIn(BasicContainer.class, BasicContainerMixin.class);
         objectMapper.addMixIn(Image.class, ImageMixin.class);
         objectMapper.addMixIn(ServiceJobProcesses.class, ServiceJobProcessesMixin.class);
         objectMapper.addMixIn(NetworkConfiguration.class, NetworkConfigurationMixin.class);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.pod.v1;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+import com.netflix.titus.api.jobmanager.model.job.BasicContainer;
+import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
+import com.netflix.titus.api.jobmanager.model.job.Image;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.master.kubernetes.pod.KubePodConfiguration;
+import com.netflix.titus.master.kubernetes.pod.affinity.PodAffinityFactory;
+import com.netflix.titus.master.kubernetes.pod.env.PodEnvFactory;
+import com.netflix.titus.master.kubernetes.pod.legacy.PodContainerInfoFactory;
+import com.netflix.titus.master.kubernetes.pod.taint.TaintTolerationFactory;
+import com.netflix.titus.master.kubernetes.pod.topology.TopologyFactory;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+import com.netflix.titus.master.kubernetes.pod.env.DefaultPodEnvFactory;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import io.kubernetes.client.openapi.models.V1Affinity;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.titanframework.messages.TitanProtos.ContainerInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class V1SpecPodFactoryTest {
+
+    private final KubePodConfiguration configuration = mock(KubePodConfiguration.class);
+
+    private final ApplicationSlaManagementService capacityGroupManagement = mock(ApplicationSlaManagementService.class);
+
+    private final PodAffinityFactory podAffinityFactory = mock(PodAffinityFactory.class);
+
+    private final TaintTolerationFactory taintTolerationFactory = mock(TaintTolerationFactory.class);
+
+    private final  PodEnvFactory podEnvFactory = new DefaultPodEnvFactory();
+
+    private final TopologyFactory topologyFactory = mock(TopologyFactory.class);
+
+    private final PodContainerInfoFactory podContainerInfoFactory = mock(PodContainerInfoFactory.class);
+
+    private V1SpecPodFactory podFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        podFactory = new V1SpecPodFactory(
+                configuration,
+                capacityGroupManagement,
+                podAffinityFactory,
+                taintTolerationFactory,
+                topologyFactory,
+                podEnvFactory,
+                podContainerInfoFactory
+        );
+        when(podContainerInfoFactory.buildContainerInfo(any(), any(), anyBoolean())).thenReturn(ContainerInfo.newBuilder().build());
+    }
+
+    @Test
+    public void multipleContainers() {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob();
+        BatchJobTask task = JobGenerator.oneBatchTask();
+        Image testImage = Image.newBuilder().withName("testImage").withDigest("123").build();
+        List<BasicContainer> extraContainers = Arrays.asList(
+                new BasicContainer("extraContainer1", testImage, null, null, new HashMap<>()),
+                new BasicContainer("extraContainer2", testImage, null, null, new HashMap<>())
+        );
+        job = job.toBuilder().withJobDescriptor(job.getJobDescriptor().toBuilder().withExtraContainers(extraContainers).build()).build();
+        when(podAffinityFactory.buildV1Affinity(job, task)).thenReturn(Pair.of(new V1Affinity(), new HashMap<>()));
+        V1Pod pod = podFactory.buildV1Pod(job, task, true, false);
+
+        List<V1Container> containers = Objects.requireNonNull(pod.getSpec()).getContainers();
+        // 3 containers here, 1 from the main container, 2 from the extras
+        assertThat(containers.size()).isEqualTo(1 + extraContainers.size());
+    }
+
+}


### PR DESCRIPTION
This changed takes in the new proto for ExtraContainers and appends
those containers to the pod (v0 and v1 schemas).

This adds a new place for adding test to the V1 schema pod builder
as well.

These new extraContainers are constructed pretty much as-is from
proto to V1Container, minimal processing is done.

----

Because these are just "extra" containers, which will be empty for 99% of workloads (for now), the incremental increase in load on Cassandra will be minimal (just `extraContainers: []`) and the incremental load on k8s/etcd will be none.

This is just the really the most basic container you can get, there will need to be future room for things like volumes and healthchecks and all sorts of fancy stuff, but in the end those too will be just passed into the pod object.