### PR TITLE
Small fixes for extraContainers functionality

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/BasicContainer.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/BasicContainer.java
@@ -115,9 +115,6 @@ public class BasicContainer {
         private List<String> command;
         private Map<String, String> env;
 
-        private Builder() {
-        }
-
         public Builder withName(String name) {
             this.name = name;
             return this;
@@ -156,5 +153,4 @@ public class BasicContainer {
             );
         }
     }
-
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
@@ -181,7 +181,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
     public NetworkConfiguration getNetworkConfiguration() { return networkConfiguration; }
 
     /**
-     * Network configuration for a job
+     * Extra containers to be run alongside the main container for a job
      */
     public List<BasicContainer> getExtraContainers() { return extraContainers; }
 
@@ -393,6 +393,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                     .withContainer(container)
                     .withDisruptionBudget(disruptionBudget)
                     .withNetworkConfiguration(networkConfiguration)
+                    .withExtraContainers(extraContainers)
                     .withExtensions(extensions);
         }
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
@@ -62,9 +62,6 @@ public class NetworkConfiguration {
     public static final class Builder {
         private int networkMode;
 
-        private Builder() {
-        }
-
         public Builder withNetworkMode(int networkMode) {
             this.networkMode = networkMode;
             return this;

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -214,11 +214,11 @@ public class V0SpecPodFactory implements PodFactory {
     }
 
     private List<V1Container> buildV1ExtraContainers(List<BasicContainer> extraContainers) {
-        if (extraContainers == null) { return Collections.emptyList();};
-        return extraContainers.stream().map(this::buildV1ExtraContainers).collect(Collectors.toList());
+        if (extraContainers == null) { return Collections.emptyList();}
+        return extraContainers.stream().map(this::buildV1ExtraContainer).collect(Collectors.toList());
     }
 
-    private V1Container buildV1ExtraContainers(BasicContainer extraContainer) {
+    private V1Container buildV1ExtraContainer(BasicContainer extraContainer) {
         return new V1Container()
                 .name(extraContainer.getName())
                 .command(extraContainer.getEntryPoint())

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobDescriptorGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobDescriptorGenerator.java
@@ -202,6 +202,7 @@ public final class JobDescriptorGenerator {
                         .withRetryPolicy(JobModel.newImmediateRetryPolicy().withRetries(0).build())
                         .build()
                 )
+                .withExtraContainers(jobDescriptor.getExtraContainers())
                 .build();
     }
 


### PR DESCRIPTION
I don't think any of these small fixes actually will
fix my core issue of extraContainers being empty, even
after confirming it is in the JobDescriptor grpc object.
