### PR TITLE
Take incoming platform Sidecars and make annotations for them

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobDescriptor.java
@@ -92,6 +92,9 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
     private final List<Volume> volumes;
 
     @Valid
+    private final List<PlatformSidecar> platformSidecars;
+
+    @Valid
     private final E extensions;
 
     public JobDescriptor(Owner owner,
@@ -104,6 +107,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                          NetworkConfiguration networkConfiguration,
                          List<BasicContainer> extraContainers,
                          List<Volume> volumes,
+                         List<PlatformSidecar> platformSidecars,
                          E extensions) {
         this.owner = owner;
         this.applicationName = applicationName;
@@ -130,10 +134,16 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
             extraContainers = Collections.emptyList();
         }
         this.extraContainers = extraContainers;
+
         if (volumes == null) {
             volumes = Collections.emptyList();
         }
         this.volumes = volumes;
+
+        if (platformSidecars == null) {
+            platformSidecars = Collections.emptyList();
+        }
+        this.platformSidecars = platformSidecars;
     }
 
     /**
@@ -202,10 +212,17 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
     }
 
     /**
-     * Extra containers to be run alongside the main container for a job
+     * Volumes represent a list of volumes that are available for containers in a job to volumeMount
      */
     public List<Volume> getVolumes() {
         return volumes;
+    }
+
+    /**
+     * Volumes represent a list of volumes that are available for containers in a job to volumeMount
+     */
+    public List<PlatformSidecar> getPlatformSidecars() {
+        return platformSidecars;
     }
 
     /**
@@ -234,12 +251,13 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 Objects.equals(networkConfiguration, that.networkConfiguration) &&
                 Objects.equals(extraContainers, that.extraContainers) &&
                 Objects.equals(volumes, that.volumes) &&
+                Objects.equals(platformSidecars, that.platformSidecars) &&
                 Objects.equals(extensions, that.extensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extraContainers, volumes, extensions);
+        return Objects.hash(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extraContainers, volumes, platformSidecars, extensions);
     }
 
     @Override
@@ -255,6 +273,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 ", networkConfiguration=" + networkConfiguration +
                 ", extraContainers=" + extraContainers +
                 ", volumes=" + volumes +
+                ", platformSidecars=" + platformSidecars +
                 ", extensions=" + extensions +
                 '}';
     }
@@ -341,6 +360,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                 .withNetworkConfiguration(jobDescriptor.getNetworkConfiguration())
                 .withExtraContainers(jobDescriptor.getExtraContainers())
                 .withVolumes(jobDescriptor.getVolumes())
+                .withPlatformSidecars(jobDescriptor.getPlatformSidecars())
                 .withExtensions(jobDescriptor.getExtensions());
     }
 
@@ -355,6 +375,7 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
         private NetworkConfiguration networkConfiguration;
         private List<BasicContainer> extraContainers;
         private List<Volume> volumes;
+        private List<PlatformSidecar> platformSidecars;
         private E extensions;
 
         private Builder() {
@@ -410,6 +431,11 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
             return this;
         }
 
+        public Builder<E> withPlatformSidecars(List<PlatformSidecar> platformSidecars) {
+            this.platformSidecars = platformSidecars;
+            return this;
+        }
+
         public Builder<E> withExtensions(E extensions) {
             this.extensions = extensions;
             return this;
@@ -427,11 +453,12 @@ public class JobDescriptor<E extends JobDescriptor.JobDescriptorExt> {
                     .withNetworkConfiguration(networkConfiguration)
                     .withExtraContainers(extraContainers)
                     .withVolumes(volumes)
+                    .withPlatformSidecars(platformSidecars)
                     .withExtensions(extensions);
         }
 
         public JobDescriptor<E> build() {
-            JobDescriptor<E> jobDescriptor = new JobDescriptor<>(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extraContainers, volumes, extensions);
+            JobDescriptor<E> jobDescriptor = new JobDescriptor<>(owner, applicationName, capacityGroup, jobGroupInfo, attributes, container, disruptionBudget, networkConfiguration, extraContainers, volumes, platformSidecars, extensions);
             return jobDescriptor;
         }
     }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/PlatformSidecar.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/PlatformSidecar.java
@@ -8,7 +8,6 @@ import javax.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -123,7 +122,7 @@ class ProtoStructSerializer extends JsonSerializer<Struct> {
 
 class ProtoStructDeserializer extends JsonDeserializer<Struct> {
     @Override
-    public Struct deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public Struct deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         Struct.Builder argsBuilder = Struct.newBuilder();
         Map m = p.readValueAs(Map.class);
         JsonFormat.parser().merge(m.toString(), argsBuilder);

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/PlatformSidecar.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/PlatformSidecar.java
@@ -1,21 +1,8 @@
 package com.netflix.titus.api.jobmanager.model.job;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.Objects;
 import javax.validation.Valid;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.protobuf.Struct;
-import com.google.protobuf.util.JsonFormat;
 
 public class PlatformSidecar {
 
@@ -26,16 +13,9 @@ public class PlatformSidecar {
     private final String channel;
 
     @Valid
-    @JsonSerialize(using = ProtoStructSerializer.class)
-    @JsonDeserialize(using = ProtoStructDeserializer.class)
-//    @JsonSerialize(using = MyMessageSerializer.class)
-//    @JsonDeserialize(using = MyMessageDeserializer.class, as = Struct.class, keyAs = String.class, contentAs = Value.class)
-//    @JsonSerialize(as = Struct.class, keyAs = String.class, contentAs = Value.class)
-//    @JsonDeserialize(as = Struct.class, keyAs = String.class, contentAs = Value.class)
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public final Struct arguments;
+    public final String arguments;
 
-    public PlatformSidecar(String name, String channel, Struct arguments) {
+    public PlatformSidecar(String name, String channel, String arguments) {
         this.name = name;
         this.channel = channel;
         this.arguments = arguments;
@@ -49,7 +29,7 @@ public class PlatformSidecar {
         return channel;
     }
 
-    public Struct getArguments() {
+    public String getArguments() {
         return arguments;
     }
 
@@ -89,7 +69,7 @@ public class PlatformSidecar {
     public static final class Builder {
         private String name;
         private String channel;
-        private Struct arguments;
+        private String arguments;
 
         public Builder withName(String name) {
             this.name = name;
@@ -101,7 +81,7 @@ public class PlatformSidecar {
             return this;
         }
 
-        public Builder withArguments(Struct arguments) {
+        public Builder withArguments(String arguments) {
             this.arguments = arguments;
             return this;
         }
@@ -111,21 +91,4 @@ public class PlatformSidecar {
         }
     }
 
-}
-
-class ProtoStructSerializer extends JsonSerializer<Struct> {
-    @Override
-    public void serialize(Struct message, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        gen.writeRawValue(JsonFormat.printer().print(message));
-    }
-}
-
-class ProtoStructDeserializer extends JsonDeserializer<Struct> {
-    @Override
-    public Struct deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        Struct.Builder argsBuilder = Struct.newBuilder();
-        Map m = p.readValueAs(Map.class);
-        JsonFormat.parser().merge(m.toString(), argsBuilder);
-        return argsBuilder.build();
-    }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/PlatformSidecar.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/PlatformSidecar.java
@@ -1,0 +1,105 @@
+package com.netflix.titus.api.jobmanager.model.job;
+
+import java.util.Objects;
+import javax.validation.Valid;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Struct;
+import com.google.protobuf.util.JsonFormat;
+
+public class PlatformSidecar {
+
+    @Valid
+    private final String name;
+
+    @Valid
+    private final String channel;
+
+    @Valid
+    private final Struct arguments;
+
+    public PlatformSidecar(String name, String channel, Struct arguments) {
+        this.name = name;
+        this.channel = channel;
+        this.arguments = arguments;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public Struct getArguments() {
+        return arguments;
+    }
+
+    public String getArgumentsJson() {
+        try {
+            return JsonFormat.printer().omittingInsignificantWhitespace().print(arguments);
+        } catch (InvalidProtocolBufferException e) {
+            return "BAD: " + e.getMessage();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PlatformSidecar that = (PlatformSidecar) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(channel, that.channel) &&
+                Objects.equals(arguments, that.arguments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, channel, arguments);
+    }
+
+    @Override
+    public String toString() {
+        return "PlatformSidecar{" +
+                "name='" + name + '\'' +
+                ", channel='" + channel + '\'' +
+                ", arguments=" + arguments +
+                '}';
+    }
+
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String name;
+        private String channel;
+        private Struct arguments;
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withChannel(String channel) {
+            this.channel = channel;
+            return this;
+        }
+
+        public Builder withArguments(Struct arguments) {
+            this.arguments = arguments;
+            return this;
+        }
+
+        public PlatformSidecar build() {
+            return new PlatformSidecar(name, channel, arguments);
+        }
+    }
+
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/JobDescriptorMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/JobDescriptorMixin.java
@@ -27,6 +27,7 @@ import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobGroupInfo;
 import com.netflix.titus.api.jobmanager.model.job.NetworkConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.Owner;
+import com.netflix.titus.api.jobmanager.model.job.PlatformSidecar;
 import com.netflix.titus.api.jobmanager.model.job.volume.Volume;
 import com.netflix.titus.api.jobmanager.model.job.disruptionbudget.DisruptionBudget;
 
@@ -42,6 +43,7 @@ public abstract class JobDescriptorMixin {
                               @JsonProperty("networkConfiguration") NetworkConfiguration networkConfiguration,
                               @JsonProperty("extraContainers") List<BasicContainer> extraContainers,
                               @JsonProperty("volumes") List<Volume> volumes,
+                              @JsonProperty("platformSidecars") List<PlatformSidecar> platformSidecars,
                               @JsonProperty("extensions") JobDescriptor.JobDescriptorExt extensions) {
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
@@ -1,0 +1,14 @@
+package com.netflix.titus.api.jobmanager.store.mixin;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PlatformSidecarMixin {
+    @JsonCreator
+    public PlatformSidecarMixin(
+            @JsonProperty("name") String name,
+            @JsonProperty("channel") String channel,
+            @JsonProperty("arguments") String arguments
+    ) {
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
@@ -9,7 +9,7 @@ public class PlatformSidecarMixin {
     public PlatformSidecarMixin(
             @JsonProperty("name") String name,
             @JsonProperty("channel") String channel,
-            @JsonProperty("arguments") Struct arguments
+            @JsonProperty("arguments") String arguments
     ) {
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
@@ -13,4 +13,3 @@ public class PlatformSidecarMixin {
     ) {
     }
 }
-

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/PlatformSidecarMixin.java
@@ -2,13 +2,15 @@ package com.netflix.titus.api.jobmanager.store.mixin;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.protobuf.Struct;
 
 public class PlatformSidecarMixin {
     @JsonCreator
     public PlatformSidecarMixin(
             @JsonProperty("name") String name,
             @JsonProperty("channel") String channel,
-            @JsonProperty("arguments") String arguments
+            @JsonProperty("arguments") Struct arguments
     ) {
     }
 }
+

--- a/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
@@ -59,6 +59,7 @@ import com.netflix.titus.api.jobmanager.model.job.JobGroupInfo;
 import com.netflix.titus.api.jobmanager.model.job.JobStatus;
 import com.netflix.titus.api.jobmanager.model.job.NetworkConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.Owner;
+import com.netflix.titus.api.jobmanager.model.job.PlatformSidecar;
 import com.netflix.titus.api.jobmanager.model.job.SecurityProfile;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobTask;
@@ -127,6 +128,7 @@ import com.netflix.titus.api.jobmanager.store.mixin.MigrationPolicyMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.NetworkConfigurationMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.OwnerMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.PercentagePerHourDisruptionBudgetRateMixIn;
+import com.netflix.titus.api.jobmanager.store.mixin.PlatformSidecarMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.RatePerIntervalDisruptionBudgetRateMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.RatePercentagePerIntervalDisruptionBudgetRateMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.RelocationLimitDisruptionBudgetPolicyMixIn;
@@ -290,6 +292,7 @@ public class ObjectMappers {
         objectMapper.addMixIn(VolumeMount.class, VolumeMountMixin.class);
         objectMapper.addMixIn(VolumeSource.class, VolumeSourceMixin.class);
         objectMapper.addMixIn(SharedContainerVolumeSource.class, SharedContainerVolumeSourceMixin.class);
+        objectMapper.addMixIn(PlatformSidecar.class, PlatformSidecarMixin.class);
 
         objectMapper.addMixIn(IpAddressLocation.class, IpAddressLocationMixin.class);
         objectMapper.addMixIn(IpAddressAllocation.class, IpAddressAllocationMixin.class);

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Struct;
 import com.netflix.titus.api.jobmanager.model.job.BasicContainer;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
 import com.netflix.titus.api.jobmanager.model.job.CapacityAttributes;
@@ -41,6 +42,7 @@ import com.netflix.titus.api.jobmanager.model.job.JobStatus;
 import com.netflix.titus.api.jobmanager.model.job.LogStorageInfo;
 import com.netflix.titus.api.jobmanager.model.job.NetworkConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.Owner;
+import com.netflix.titus.api.jobmanager.model.job.PlatformSidecar;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobProcesses;
 import com.netflix.titus.api.jobmanager.model.job.ServiceJobTask;
 import com.netflix.titus.api.jobmanager.model.job.Task;
@@ -185,6 +187,7 @@ public final class GrpcJobManagementModelConverters {
                 .withDisruptionBudget(toCoreDisruptionBudget(grpcJobDescriptor.getDisruptionBudget()))
                 .withExtraContainers(toCoreBasicContainers(grpcJobDescriptor.getExtraContainersList()))
                 .withVolumes(toCoreVolumes(grpcJobDescriptor.getVolumesList()))
+                .withPlatformSidecars(toCorePlatformSidecars(grpcJobDescriptor.getPlatformSidecarsList()))
                 .withExtensions(toCoreJobExtensions(grpcJobDescriptor))
                 .build();
 
@@ -431,7 +434,24 @@ public final class GrpcJobManagementModelConverters {
                 .build();
     }
 
-    public static DisruptionBudget toCoreDisruptionBudget(com.netflix.titus.grpc.protogen.JobDisruptionBudget grpcDisruptionBudget) {
+    private static List<PlatformSidecar> toCorePlatformSidecars(List<com.netflix.titus.grpc.protogen.PlatformSidecar> platformSidecarList) {
+        List<PlatformSidecar> platformSidecars = new ArrayList<>();
+        for (com.netflix.titus.grpc.protogen.PlatformSidecar ps : platformSidecarList) {
+            platformSidecars.add(toCorePlatformSidecar(ps));
+        }
+        return platformSidecars;
+    }
+
+    private static PlatformSidecar toCorePlatformSidecar(com.netflix.titus.grpc.protogen.PlatformSidecar ps) {
+        return PlatformSidecar.newBuilder()
+                .withName(ps.getName())
+                .withChannel(ps.getChannel())
+                .withArguments(ps.getArguments())
+                .build();
+    }
+
+    public static DisruptionBudget toCoreDisruptionBudget(com.netflix.titus.grpc.protogen.JobDisruptionBudget
+                                                                  grpcDisruptionBudget) {
         if (JobDisruptionBudget.getDefaultInstance().equals(grpcDisruptionBudget)) {
             return DisruptionBudget.none();
         }
@@ -1042,6 +1062,7 @@ public final class GrpcJobManagementModelConverters {
                 .setDisruptionBudget(toGrpcDisruptionBudget(jobDescriptor.getDisruptionBudget()))
                 .addAllExtraContainers(toGrpcBasicContainers(jobDescriptor.getExtraContainers()))
                 .addAllVolumes(toGrpcVolumes(jobDescriptor.getVolumes()))
+                .addAllPlatformSidecars(toGrpcPlatformSidecars(jobDescriptor.getPlatformSidecars()))
                 .putAllAttributes(jobDescriptor.getAttributes());
 
         if (jobDescriptor.getExtensions() instanceof BatchJobExt) {
@@ -1115,6 +1136,22 @@ public final class GrpcJobManagementModelConverters {
         return com.netflix.titus.grpc.protogen.SharedContainerVolumeSource.newBuilder()
                 .setSourceContainer(source.getSourceContainer())
                 .setSourcePath(source.getSourcePath())
+                .build();
+    }
+
+    private static List<com.netflix.titus.grpc.protogen.PlatformSidecar> toGrpcPlatformSidecars(List<PlatformSidecar> platformSidecarList) {
+        List<com.netflix.titus.grpc.protogen.PlatformSidecar> platformSidecars = new ArrayList<>();
+        for (PlatformSidecar ps : platformSidecarList) {
+            platformSidecars.add(toGrpcPlatformSidecar(ps));
+        }
+        return platformSidecars;
+    }
+
+    private static com.netflix.titus.grpc.protogen.PlatformSidecar toGrpcPlatformSidecar(PlatformSidecar ps) {
+        return com.netflix.titus.grpc.protogen.PlatformSidecar.newBuilder()
+                .setName(ps.getName())
+                .setChannel(ps.getChannel())
+                .setArguments(ps.getArguments())
                 .build();
     }
 

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -90,6 +90,7 @@ import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressAllocation;
 import com.netflix.titus.api.jobmanager.model.job.vpc.IpAddressLocation;
 import com.netflix.titus.api.jobmanager.model.job.vpc.SignedIpAddressAllocation;
 import com.netflix.titus.api.model.EfsMount;
+import com.netflix.titus.api.service.TitusServiceException;
 import com.netflix.titus.common.util.Evaluators;
 import com.netflix.titus.common.util.StringExt;
 import com.netflix.titus.common.util.tuple.Either;
@@ -461,7 +462,7 @@ public final class GrpcJobManagementModelConverters {
         try {
             return JsonFormat.printer().omittingInsignificantWhitespace().print(arguments);
         } catch (InvalidProtocolBufferException e) {
-            throw new IllegalArgumentException("Unable to serialize arguments for the " + sidecarName + " sidecar: " + e.getMessage());
+            throw TitusServiceException.newBuilder(TitusServiceException.ErrorCode.INVALID_JOB, "Unable to serialize arguments for the " + sidecarName + " sidecar: " + e.getMessage()).build();
         }
     }
 

--- a/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
+++ b/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
@@ -538,7 +538,7 @@ public class CassandraJobStoreTest {
         PlatformSidecar ps1 = PlatformSidecar.newBuilder()
                 .withName("testSidecar")
                 .withChannel("testChannel")
-                .withArguments(args.build())
+                .withArguments("{\"foo\":true,\"bar\":3.0}")
                 .build();
         List<PlatformSidecar> platformSidecars = Collections.singletonList(ps1);
         JobDescriptor<ServiceJobExt> jobDescriptor = JobDescriptorGenerator.oneTaskServiceJobDescriptor().but(jd ->

--- a/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
+++ b/titus-ext/cassandra/src/test/java/com/netflix/titus/ext/cassandra/store/CassandraJobStoreTest.java
@@ -66,25 +66,22 @@ import static org.assertj.core.api.Assertions.fail;
 @Category(IntegrationNotParallelizableTest.class)
 public class CassandraJobStoreTest {
 
+    public static final int MAX_CONCURRENCY = 10;
     private static final long STARTUP_TIMEOUT_MS = 30_000L;
     private static final int INITIAL_BUCKET_COUNT = 1;
     private static final int MAX_BUCKET_SIZE = 10;
-
     /**
      * As Cassandra uses memory mapped files there are sometimes issues with virtual disks storing the project files.
      * To solve this issue, we relocate the default embedded Cassandra folder to /var/tmp/embeddedCassandra.
      */
     private static final String CONFIGURATION_FILE_NAME = "relocated-cassandra.yaml";
-    public static final int MAX_CONCURRENCY = 10;
-
+    private static final CassandraStoreConfiguration CONFIGURATION = new TestCassandraStoreConfiguration();
     @Rule
     public CassandraCQLUnit cassandraCqlUnit = new CassandraCQLUnit(
             new ClassPathCQLDataSet("tables.cql", "titus_integration_tests"),
             CONFIGURATION_FILE_NAME,
             STARTUP_TIMEOUT_MS
     );
-
-    private static final CassandraStoreConfiguration CONFIGURATION = new TestCassandraStoreConfiguration();
 
     @Test
     public void testRetrieveJobs() {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -169,12 +169,18 @@ public class KubePodUtil {
 
     private static Map<String, String> createSinglePlatformSidecarAnnotations(PlatformSidecar ps) {
         Map<String, String> annotations = new HashMap<>();
-        String name = ps.getName() + KubeConstants.PLATFORM_SIDECAR_SUFFIX;
-        annotations.put(name, "true");
-        String channel = ps.getName() + KubeConstants.PLATFORM_SIDECAR_CHANNEL_SUFFIX;
-        annotations.put(channel, ps.getChannel());
-        String arguments = ps.getName() + KubeConstants.PLATFORM_SIDECAR_ARGS_SUFFIX;
-        annotations.put(arguments, ps.getArgumentsJson());
+        String nameKey = ps.getName() + KubeConstants.PLATFORM_SIDECAR_SUFFIX;
+        annotations.put(nameKey, "true");
+        String channelKey = ps.getName() + KubeConstants.PLATFORM_SIDECAR_CHANNEL_SUFFIX;
+        annotations.put(channelKey, ps.getChannel());
+        String argumentsKey = ps.getName() + KubeConstants.PLATFORM_SIDECAR_ARGS_SUFFIX;
+        String argumentsJson;
+        try {
+            argumentsJson = JsonFormat.printer().omittingInsignificantWhitespace().print(ps.getArguments());
+        } catch (InvalidProtocolBufferException e) {
+            argumentsJson = "BAD: " + e.getMessage();
+        }
+        annotations.put(argumentsKey, argumentsJson);
         return annotations;
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -32,6 +32,7 @@ import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.PlatformSidecar;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.VolumeMount;
 import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
@@ -155,6 +156,29 @@ public class KubePodUtil {
     }
 
     /**
+     * Looks at a job's PlatformSidecars and converts them to the correct annotations
+     * for the platform sidecar mutator to use.
+     */
+    public static Map<String, String> createPlatformSidecarAnnotations(Job<?> job) {
+        Map<String, String> annotations = new HashMap<>();
+        for (PlatformSidecar ps : job.getJobDescriptor().getPlatformSidecars()) {
+            annotations.putAll(createSinglePlatformSidecarAnnotations(ps));
+        }
+        return annotations;
+    }
+
+    private static Map<String, String> createSinglePlatformSidecarAnnotations(PlatformSidecar ps) {
+        Map<String, String> annotations = new HashMap<>();
+        String name = ps.getName() + KubeConstants.PLATFORM_SIDECAR_SUFFIX;
+        annotations.put(name, "true");
+        String channel = ps.getName() + KubeConstants.PLATFORM_SIDECAR_CHANNEL_SUFFIX;
+        annotations.put(channel, ps.getChannel());
+        String arguments = ps.getName() + KubeConstants.PLATFORM_SIDECAR_ARGS_SUFFIX;
+        annotations.put(arguments, ps.getArgumentsJson());
+        return annotations;
+    }
+
+    /**
      * Returns a job descriptor with fields unnecessary for inclusion on the pod removed.
      */
     public static com.netflix.titus.api.jobmanager.model.job.JobDescriptor<?> filterPodJobDescriptor(com.netflix.titus.api.jobmanager.model.job.JobDescriptor<?> jobDescriptor) {
@@ -236,4 +260,5 @@ public class KubePodUtil {
                 .map(entry -> new V1EnvVar().name(entry.getKey()).value(entry.getValue()))
                 .collect(Collectors.toList());
     }
+
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -174,13 +174,7 @@ public class KubePodUtil {
         String channelKey = ps.getName() + KubeConstants.PLATFORM_SIDECAR_CHANNEL_SUFFIX;
         annotations.put(channelKey, ps.getChannel());
         String argumentsKey = ps.getName() + KubeConstants.PLATFORM_SIDECAR_ARGS_SUFFIX;
-        String argumentsJson;
-        try {
-            argumentsJson = JsonFormat.printer().omittingInsignificantWhitespace().print(ps.getArguments());
-        } catch (InvalidProtocolBufferException e) {
-            argumentsJson = "BAD: " + e.getMessage();
-        }
-        annotations.put(argumentsKey, argumentsJson);
+        annotations.put(argumentsKey, ps.getArguments());
         return annotations;
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -74,6 +74,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.RESOURCE_
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.RESOURCE_MEMORY;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.RESOURCE_NETWORK;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1VolumeInfo;
+import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createPlatformSidecarAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.toV1EnvVar;
 
 @Singleton
@@ -117,6 +118,7 @@ public class V0SpecPodFactory implements PodFactory {
 
         Pair<V1Affinity, Map<String, String>> affinityWithMetadata = podAffinityFactory.buildV1Affinity(job, task);
         annotations.putAll(affinityWithMetadata.getRight());
+        annotations.putAll(createPlatformSidecarAnnotations(job));
 
         Map<String, String> labels = new HashMap<>();
         labels.put(KubeConstants.POD_LABEL_JOB_ID, job.getId());

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -45,7 +45,6 @@ import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.VolumeMount;
 import com.netflix.titus.api.jobmanager.model.job.volume.SharedContainerVolumeSource;
 import com.netflix.titus.api.jobmanager.model.job.volume.Volume;
-import com.netflix.titus.api.jobmanager.model.job.volume.VolumeSource;
 import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.api.model.Tier;
 import com.netflix.titus.common.util.CollectionsExt;
@@ -142,6 +141,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_STACK;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1VolumeInfo;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createEbsPodAnnotations;
+import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createPlatformSidecarAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.toV1EnvVar;
 
 @Singleton
@@ -476,6 +476,7 @@ public class V1SpecPodFactory implements PodFactory {
 
         annotations.putAll(createEbsPodAnnotations(job, task));
         annotations.putAll(PerformanceToolUtil.toAnnotations(job));
+        annotations.putAll(createPlatformSidecarAnnotations(job));
 
         return annotations;
     }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
@@ -23,12 +23,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Struct;
+import com.google.protobuf.util.JsonFormat;
 import com.netflix.titus.api.jobmanager.model.job.BasicContainer;
 import com.netflix.titus.api.jobmanager.model.job.BatchJobTask;
 import com.netflix.titus.api.jobmanager.model.job.Container;
 import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.VolumeMount;
+import com.netflix.titus.api.jobmanager.model.job.PlatformSidecar;
 import com.netflix.titus.api.jobmanager.model.job.volume.SharedContainerVolumeSource;
 import com.netflix.titus.api.jobmanager.model.job.volume.Volume;
 import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
@@ -41,6 +45,7 @@ import com.netflix.titus.master.kubernetes.pod.taint.TaintTolerationFactory;
 import com.netflix.titus.master.kubernetes.pod.topology.TopologyFactory;
 import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
 import com.netflix.titus.master.kubernetes.pod.env.DefaultPodEnvFactory;
+import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import com.netflix.titus.testkit.model.job.JobGenerator;
 import io.kubernetes.client.openapi.models.V1Affinity;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -154,6 +159,37 @@ public class V1SpecPodFactoryTest {
         Map<String, String> flexVolumeOptions = flexVolume.getOptions();
         assertThat(flexVolumeOptions.get("sourceContainer")).isEqualTo("main");
         assertThat(flexVolumeOptions.get("sourcePath")).isEqualTo("/main-root");
+    }
+
+    @Test
+    public void podHasSidecarAnnotations() {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob();
+        BatchJobTask task = JobGenerator.oneBatchTask();
+        Struct.Builder args = Struct.newBuilder();
+        String json_args = "{\"foo\":true,\"bar\":3.0}";
+        try {
+            JsonFormat.parser().merge(json_args, args);
+        } catch (InvalidProtocolBufferException e) {
+            e.printStackTrace();
+        }
+
+        List<PlatformSidecar> platformSidecars = Arrays.asList(
+                new PlatformSidecar("mysidecar", "stable", args.build())
+        );
+        job = job.toBuilder().withJobDescriptor(job.getJobDescriptor().toBuilder().withPlatformSidecars(platformSidecars).build()).build();
+
+        when(podAffinityFactory.buildV1Affinity(job, task)).thenReturn(Pair.of(new V1Affinity(), new HashMap<>()));
+        V1Pod pod = podFactory.buildV1Pod(job, task, true, false);
+
+        Map<String, String> annotations = pod.getMetadata().getAnnotations();
+        String expectedSidecarAnnodation = "mysidecar" + KubeConstants.PLATFORM_SIDECAR_SUFFIX;
+        assertThat(annotations.get(expectedSidecarAnnodation)).isEqualTo("true");
+
+        String expectedChannelAnnotation = "mysidecar" + KubeConstants.PLATFORM_SIDECAR_CHANNEL_SUFFIX;
+        assertThat(annotations.get(expectedChannelAnnotation)).isEqualTo("stable");
+
+        String expectedArgsAnnotation = "mysidecar" + KubeConstants.PLATFORM_SIDECAR_ARGS_SUFFIX;
+        assertThat(annotations.get(expectedArgsAnnotation)).isEqualTo(json_args);
     }
 
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
@@ -165,16 +165,9 @@ public class V1SpecPodFactoryTest {
     public void podHasSidecarAnnotations() {
         Job<BatchJobExt> job = JobGenerator.oneBatchJob();
         BatchJobTask task = JobGenerator.oneBatchTask();
-        Struct.Builder args = Struct.newBuilder();
         String json_args = "{\"foo\":true,\"bar\":3.0}";
-        try {
-            JsonFormat.parser().merge(json_args, args);
-        } catch (InvalidProtocolBufferException e) {
-            e.printStackTrace();
-        }
-
         List<PlatformSidecar> platformSidecars = Arrays.asList(
-                new PlatformSidecar("mysidecar", "stable", args.build())
+                new PlatformSidecar("mysidecar", "stable", json_args)
         );
         job = job.toBuilder().withJobDescriptor(job.getJobDescriptor().toBuilder().withPlatformSidecars(platformSidecars).build()).build();
 
@@ -182,8 +175,8 @@ public class V1SpecPodFactoryTest {
         V1Pod pod = podFactory.buildV1Pod(job, task, true, false);
 
         Map<String, String> annotations = pod.getMetadata().getAnnotations();
-        String expectedSidecarAnnodation = "mysidecar" + KubeConstants.PLATFORM_SIDECAR_SUFFIX;
-        assertThat(annotations.get(expectedSidecarAnnodation)).isEqualTo("true");
+        String expectedSidecarAnnotation = "mysidecar" + KubeConstants.PLATFORM_SIDECAR_SUFFIX;
+        assertThat(annotations.get(expectedSidecarAnnotation)).isEqualTo("true");
 
         String expectedChannelAnnotation = "mysidecar" + KubeConstants.PLATFORM_SIDECAR_CHANNEL_SUFFIX;
         assertThat(annotations.get(expectedChannelAnnotation)).isEqualTo("stable");

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/jobmanager/gateway/SanitizingJobServiceGateway.java
@@ -63,11 +63,16 @@ public class SanitizingJobServiceGateway extends JobServiceGatewayDelegate {
 
     @Override
     public Observable<String> createJob(JobDescriptor jobDescriptor, CallMetadata callMetadata) {
+        com.netflix.titus.api.jobmanager.model.job.JobDescriptor coreJobDescriptorUnfiltered;
+        try {
+            coreJobDescriptorUnfiltered = GrpcJobManagementModelConverters.toCoreJobDescriptor(jobDescriptor);
+        } catch (Exception e) {
+            return Observable.error(TitusServiceException.invalidArgument("Error creating core job descriptor: " + e.getMessage()));
+        }
+
         com.netflix.titus.api.jobmanager.model.job.JobDescriptor coreJobDescriptor;
         try {
-            coreJobDescriptor = JobFunctions.filterOutGeneratedAttributes(
-                    GrpcJobManagementModelConverters.toCoreJobDescriptor(jobDescriptor)
-            );
+            coreJobDescriptor = JobFunctions.filterOutGeneratedAttributes(coreJobDescriptorUnfiltered);
         } catch (Exception e) {
             return Observable.error(TitusServiceException.invalidArgument("Error when filtering out generated attributes: " + e.getMessage()));
         }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -140,7 +140,6 @@ public final class KubeConstants {
 
     /**
      * Nodes with this taint are in the process of being decommissioned. Effects have different meaning:
-     *
      * - <code>PreferNoSchedule</code>: nodes being drained, and capacity is preserved if needed
      * - <code>NoSchedule</code>: used to avoid placing tasks with the {@link com.netflix.titus.api.jobmanager.JobConstraints#ACTIVE_HOST} onto nodes being decommissioned
      * - <code>NoExecute</code>: nodes being actively evacuated by task relocation
@@ -221,4 +220,13 @@ public final class KubeConstants {
     public static final String NETWORK_DOMAIN = "network." + NETFLIX_DOMAIN;
     public static final String STATIC_IP_ALLOCATION_ID = NETWORK_DOMAIN + "static-ip-allocation-uuid";
     public static final String NETWORK_MODE = NETWORK_DOMAIN + "network-mode";
+
+    /**
+     * Platform Sidecar annotations, from
+     * https://github.com/Netflix/titus-kube-common/blob/master/pod/annotations.go
+     */
+    public static final String PLATFORM_SIDECAR_SUFFIX = ".platform-sidecars.netflix.com";
+    public static final String PLATFORM_SIDECAR_CHANNEL_SUFFIX = PLATFORM_SIDECAR_SUFFIX + "/channel";
+    public static final String PLATFORM_SIDECAR_ARGS_SUFFIX = PLATFORM_SIDECAR_SUFFIX + "/args.";
+    ;
 }

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -227,6 +227,6 @@ public final class KubeConstants {
      */
     public static final String PLATFORM_SIDECAR_SUFFIX = ".platform-sidecars.netflix.com";
     public static final String PLATFORM_SIDECAR_CHANNEL_SUFFIX = PLATFORM_SIDECAR_SUFFIX + "/channel";
-    public static final String PLATFORM_SIDECAR_ARGS_SUFFIX = PLATFORM_SIDECAR_SUFFIX + "/args.";
+    public static final String PLATFORM_SIDECAR_ARGS_SUFFIX = PLATFORM_SIDECAR_SUFFIX + "/arguments";
     ;
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobDescriptorGenerator.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobDescriptorGenerator.java
@@ -203,6 +203,7 @@ public final class JobDescriptorGenerator {
                         .build()
                 )
                 .withExtraContainers(jobDescriptor.getExtraContainers())
+                .withPlatformSidecars(jobDescriptor.getPlatformSidecars())
                 .build();
     }
 


### PR DESCRIPTION
This new feature takes the new PlatformSidecar objects from the
Titus API proto definition and populates the appropriate
annotations on the pod. No additional processing is required by
the control-plane, because we want to stay pretty close to
the "the pod spec is the api" vision.

Two big things we need to iron out:

1. Annotation format. It would be nice to get some good conventions,
and hopefully not change them over time. Luckily in the webhook
we can parse multiple annotations and merge them together as we change.

2. This whole `Struct` stuff. The reasoning behind using a protobuf
[Struct](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Struct)
field was to preserve the structured data that would come in
from the API, and not treat it like a "string" of escaped json.

I think this is still probably a good idea, and only stringify
it out at the last second sounds also like a good idea?
But I've never done something like this in java, so it needs
extra scrutiny. Also I don't know if it is kosher for the actual
POJO to "just" be a struct, but it sure simplifies things!