### PR TITLE
Bump titus-api-definitions to include BasicImage changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.2-rc.14'
+        titusApiDefinitionsVersion = '0.0.3-rc.4'
 
         springVersion = '5.2.11.RELEASE'
         springSecurityVersion = '5.3.6.RELEASE'

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -245,6 +245,14 @@ public final class GrpcJobManagementModelConverters {
                 .build();
     }
 
+    public static Image toCoreImage(com.netflix.titus.grpc.protogen.BasicImage grpcImage) {
+        return JobModel.newImage()
+                .withName(grpcImage.getName())
+                .withTag(grpcImage.getTag())
+                .withDigest(grpcImage.getDigest())
+                .build();
+    }
+
     public static EfsMount toCoreEfsMount(com.netflix.titus.grpc.protogen.ContainerResources.EfsMount grpcEfsMount) {
         return EfsMount.newBuilder()
                 .withEfsId(grpcEfsMount.getEfsId())
@@ -794,6 +802,14 @@ public final class GrpcJobManagementModelConverters {
         return builder.build();
     }
 
+    private static com.netflix.titus.grpc.protogen.BasicImage toGrpcBasicImage(Image image) {
+        com.netflix.titus.grpc.protogen.BasicImage.Builder builder = com.netflix.titus.grpc.protogen.BasicImage.newBuilder();
+        builder.setName(image.getName());
+        acceptNotNull(image.getTag(), builder::setTag);
+        acceptNotNull(image.getDigest(), builder::setDigest);
+        return builder.build();
+    }
+
     private static com.netflix.titus.grpc.protogen.NetworkConfiguration toGrpcNetworkConfiguration
             (NetworkConfiguration networkConfiguration) {
         com.netflix.titus.grpc.protogen.NetworkConfiguration.Builder builder = com.netflix.titus.grpc.protogen.NetworkConfiguration.newBuilder();
@@ -1098,7 +1114,7 @@ public final class GrpcJobManagementModelConverters {
     private static com.netflix.titus.grpc.protogen.BasicContainer toGrpcBasicContainer(BasicContainer basicContainer) {
         return com.netflix.titus.grpc.protogen.BasicContainer.newBuilder()
                 .setName(basicContainer.getName())
-                .setImage(toGrpcImage(basicContainer.getImage()))
+                .setImage(toGrpcBasicImage(basicContainer.getImage()))
                 .addAllEntryPoint(basicContainer.getEntryPoint())
                 .addAllCommand(basicContainer.getCommand())
                 .putAllEnv(basicContainer.getEnv())


### PR DESCRIPTION
Since I've split out all these new features out of the titus_job_api,
so that they can shared with other systems (cmb), I had to make this
one small breaking change to extract out the Image stuff -> BasicImage.

Everything else (proto stuff) is the same because they are all part of the same Java package, just in different files.