### PR TITLE
Add per event stream counter metric

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -654,7 +654,10 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
                     }
                 })
                 .subscribe(
-                        responseObserver::onNext,
+                        event -> {
+                            metrics.observeJobsEventEmitted(trxId);
+                            responseObserver.onNext(event);
+                        },
                         e -> {
                             if (!closingProcessed.getAndSet(true)) {
                                 metrics.observeJobsError(trxId, start.elapsed(TimeUnit.MILLISECONDS), e);


### PR DESCRIPTION
Adds a counter metric to track how many events are being emitted for an observeJobs stream.