### PR TITLE
Removed the useBytes toggle, always set bytes on pods

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
@@ -130,13 +130,6 @@ public interface KubePodConfiguration {
     String getDefaultS3WriterRole();
 
     /**
-     * Set to true to enable setting pod resources in byte units as defined in
-     * https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
-     */
-    @DefaultValue("true")
-    boolean isBytePodResourceEnabled();
-
-    /**
      * A regular expression pattern for capacity groups for which job spreading should be disabled.
      */
     @DefaultValue("NONE")

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -128,10 +128,6 @@ public class V0SpecPodFactory implements PodFactory {
         String capacityGroup = JobManagerUtil.getCapacityGroupDescriptorName(job.getJobDescriptor(), capacityGroupManagement).toLowerCase();
         labels.put(KubeConstants.LABEL_CAPACITY_GROUP, capacityGroup);
 
-        if (configuration.isBytePodResourceEnabled()) {
-            labels.put(KubeConstants.POD_LABEL_BYTE_UNITS, "true");
-        }
-
         V1ObjectMeta metadata = new V1ObjectMeta()
                 .name(taskId)
                 .annotations(annotations)
@@ -233,15 +229,10 @@ public class V0SpecPodFactory implements PodFactory {
         Quantity memory;
         Quantity disk;
         Quantity network;
-        if (configuration.isBytePodResourceEnabled()) {
-            memory = new Quantity(containerResources.getMemoryMB() + "Mi");
-            disk = new Quantity(containerResources.getDiskMB() + "Mi");
-            network = new Quantity(containerResources.getNetworkMbps() + "M");
-        } else {
-            memory = new Quantity(String.valueOf(containerResources.getMemoryMB()));
-            disk = new Quantity(String.valueOf(containerResources.getDiskMB()));
-            network = new Quantity(String.valueOf(containerResources.getNetworkMbps()));
-        }
+
+        memory = new Quantity(containerResources.getMemoryMB() + "Mi");
+        disk = new Quantity(containerResources.getDiskMB() + "Mi");
+        network = new Quantity(containerResources.getNetworkMbps() + "M");
 
         requests.put(RESOURCE_MEMORY, memory);
         limits.put(RESOURCE_MEMORY, memory);

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -67,9 +67,7 @@ public final class KubeConstants {
     /*
      * Titus pod labels and annotations.
      */
-
-    public static final String POD_LABEL_BYTE_UNITS = TITUS_POD_DOMAIN + "byteUnits";
-
+    
     public static final String POD_LABEL_ACCOUNT_ID = TITUS_POD_DOMAIN + "accountId";
 
     public static final String POD_LABEL_SUBNETS = TITUS_POD_DOMAIN + "subnets";


### PR DESCRIPTION
Now that we have 100% rollout of this feature, we are
ready to remove the toggle.

This change must be deployed *after* the titus-executor
change to always use bytes
