### PR TITLE
Handle network mode annotations to v1 pod specs

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -400,6 +400,10 @@ public class V1SpecPodFactory implements PodFactory {
                 task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_IP_ALLOCATION_ID),
                 id -> annotations.put(KubeConstants.STATIC_IP_ALLOCATION_ID, id)
         );
+        Evaluators.acceptNotNull(
+                job.getJobDescriptor().getNetworkConfiguration().getNetworkModeName(),
+                modeName -> annotations.put(KubeConstants.NETWORK_MODE, modeName)
+        );
 
         // convert container attributes into annotations
         container.getAttributes().forEach((k, v) -> {


### PR DESCRIPTION
This got missed (I think) when I first implemented it.

This should fix two of the failing v1 pod spec tests.
