### PR TITLE
RFC: Always binpack on v4 transition containers

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -64,6 +64,7 @@ import io.titanframework.messages.TitanProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.netflix.titus.grpc.protogen.NetworkConfiguration.NetworkMode.Ipv6AndIpv4Fallback;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.DEFAULT_DNS_POLICY;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.DEFAULT_IMAGE_PULL_POLICY;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.FENZO_SCHEDULER;
@@ -159,6 +160,11 @@ public class V0SpecPodFactory implements PodFactory {
                 }
             } else {
                 schedulerName = configuration.getKubeSchedulerName();
+            }
+            // Final override for any job in v4 transition mode, we *always* do binpacking, otherwise
+            // it defeats the purpose of v4 savings
+            if (job.getJobDescriptor().getNetworkConfiguration().getNetworkModeName() == Ipv6AndIpv4Fallback.toString()) {
+                schedulerName = configuration.getReservedCapacityKubeSchedulerNameForBinPacking();
             }
         }
 


### PR DESCRIPTION
This is not for merging, but RFC.

This scheduler selection code needs to be cleaned up a bit
first, but in general we can always do binpacking with
jobs in ipv4 transition mode, so that they *always* save IPv4
address, regardless of what tier, time of day, moon phase, or
failover status.
