### PR TITLE
Updated the titus-kube-scheduler-reserved-binpacking string

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
@@ -89,9 +89,9 @@ public interface KubePodConfiguration {
     /**
      * This string corresponds to a kube-scheduler profile name which implements exact same set of scheduler plugins as
      * the standard reserved capacity scheduler (titus-kube-scheduler-reserved) except
-     * the bin-packing behavior based on security group affinity.
+     * with bin-packing plugins enabled.
      */
-    @DefaultValue("titus-kube-scheduler-reserved")
+    @DefaultValue("titus-kube-scheduler-reserved-binpacking")
     String getReservedCapacityKubeSchedulerNameForBinPacking();
 
     /**


### PR DESCRIPTION
I find it a bit confusing that the default for this string *isn't*
`titus-kube-scheduler-reserved-binpacking`. We have properties set
in many places (not all?) that "overrides" it to be correct.

I think it might be easier to understand if it is correct here,
and we ony set a property to override the behavior.

If shipit, after this change is deployed, I'll delete the properties.
