### PR TITLE
Updating titus-api-definitions to 0.0.3-rc.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.3-rc.4'
+        titusApiDefinitionsVersion = '0.0.3-rc.5'
 
         springVersion = '5.2.11.RELEASE'
         springSecurityVersion = '5.3.6.RELEASE'


### PR DESCRIPTION
### Description of the Change

Upgrade titus-api-definitions version to consume the new FCG Api