### PR TITLE
Sanitize v1 pod efs volumes that end in a '/'

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -268,7 +268,9 @@ public class KubePodUtil {
      * Sanitize name based on Kubernetes regex: [a-z0-9]([-a-z0-9]*[a-z0-9])?.
      */
     public static String sanitizeVolumeName(String name) {
-        return name.toLowerCase().replaceAll("[^a-z0-9]([^-a-z0-9]*[^a-z0-9])?", "-");
+        String replaced = name.toLowerCase().replaceAll("[^a-z0-9]([^-a-z0-9]*[^a-z0-9])?", "-");
+        // All volume names *must* end with a normal char, so we always append something to the end
+        return replaced + "-vol";
     }
 
     public static String selectScheduler(SchedulerConfiguration schedulerConfiguration, ApplicationSLA capacityGroupDescriptor, KubePodConfiguration configuration) {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/KubePodUtilTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/KubePodUtilTest.java
@@ -52,7 +52,7 @@ public class KubePodUtilTest {
 
     @Test
     public void testSanitizeVolumeName() {
-        String name = "Ab9bac3e:6ea1:4bc3:a803:e0070ca434c3";
-        assertThat(KubePodUtil.sanitizeVolumeName(name)).matches("ab9bac3e-6ea1-4bc3-a803-e0070ca434c3");
+        String name = "Ab9bac3e:6ea1:4bc3:a803:e0070ca434c3/";
+        assertThat(KubePodUtil.sanitizeVolumeName(name)).matches("ab9bac3e-6ea1-4bc3-a803-e0070ca434c3--vol");
     }
 }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
@@ -218,7 +218,7 @@ public class V1SpecPodFactoryTest {
         Job<BatchJobExt> job = JobGenerator.oneBatchJob();
         BatchJobTask task = JobGenerator.oneBatchTask();
 
-        EfsMount newEfsMount = new EfsMount("1.2.3.4", "/mountpoint", EfsMount.MountPerm.RO, "/relative");
+        EfsMount newEfsMount = new EfsMount("1.2.3.4", "/mountpoint", EfsMount.MountPerm.RO, "/relative/");
         Container newContainer = job.getJobDescriptor().getContainer();
         ContainerResources newContainerResources = newContainer.getContainerResources();
         Container newContainerWithEFS = newContainer.toBuilder().withContainerResources(newContainerResources.newBuilder()
@@ -235,16 +235,16 @@ public class V1SpecPodFactoryTest {
         List<V1Volume> volumes = pod.getSpec().getVolumes();
         assertThat(volumes.size()).isEqualTo(2); // one for nfs, one for shm
         V1Volume v1NFSVolume = volumes.get(0);
-        assertThat(v1NFSVolume.getName()).isEqualTo("1-2-3-4-relative");
+        assertThat(v1NFSVolume.getName()).isEqualTo("1-2-3-4-relative--vol");
         assertThat(v1NFSVolume.getNfs().getServer()).isEqualTo("1.2.3.4");
-        assertThat(v1NFSVolume.getNfs().getPath()).isEqualTo("/relative");
+        assertThat(v1NFSVolume.getNfs().getPath()).isEqualTo("/relative/");
         assertThat(v1NFSVolume.getNfs().getReadOnly()).isEqualTo(true);
 
         // Part 2: the volume mount section needs to applied to the first container in the podspec
         List<V1VolumeMount> vms = pod.getSpec().getContainers().get(0).getVolumeMounts();
         assertThat(vms.size()).isEqualTo(2); // one for nfs, one for shm
         V1VolumeMount v1NFSvm = vms.get(0);
-        assertThat(v1NFSvm.getName()).isEqualTo("1-2-3-4-relative");
+        assertThat(v1NFSvm.getName()).isEqualTo("1-2-3-4-relative--vol");
         assertThat(v1NFSvm.getMountPath()).isEqualTo("/mountpoint");
     }
 


### PR DESCRIPTION
All volume names in k8s need to end on a normal character.

Before, a trailling '/' (or the default relative path if unset!)
would leave the volume name with a trailing '-'.

With this change, we always add `-vol` at the end of the volume name,
regardless of what wacky mount points we have.
