### PR TITLE
Support consistent reads from the TitusGateway job cache

### DIFF
--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -49,7 +49,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew build --max-workers 4 --parallel --no-daemon --stacktrace
+        run: ./gradlew -i build --max-workers 4 --stacktrace
   integrationTestExcludeMaster:
     if: |
       github.event_name == 'pull_request' ||
@@ -119,7 +119,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -PintegrationTestScope=onlyMaster1 integrationTest
+        run: ./gradlew -i -PintegrationTestScope=onlyMaster1 integrationTest
   integrationTestMaster2:
     if: |
       github.event_name == 'pull_request' ||
@@ -154,7 +154,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -PintegrationTestScope=onlyMaster2 integrationTest
+        run: ./gradlew -i -PintegrationTestScope=onlyMaster2 integrationTest
   integrationTestMaster3:
     if: |
       github.event_name == 'pull_request' ||
@@ -189,7 +189,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -PintegrationTestScope=onlyMaster3 integrationTest
+        run: ./gradlew -i -PintegrationTestScope=onlyMaster3 integrationTest
   integrationTestNonParallelizable:
     if: |
       github.event_name == 'pull_request' ||
@@ -224,7 +224,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew integrationNotParallelizableTest
+        run: ./gradlew -i integrationNotParallelizableTest
   publish:
     if: |
       github.event_name != 'pull_request' &&

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ javadoc.noqualifier=java.lang:java.util:com.netflix.type
 javadoc.access=protected
 
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx8g -Xms1g -XX:MaxPermSize=1g -XX:+UnlockExperimentalVMOptions
+org.gradle.jvmargs=-Xmx4g -Xms1g -XX:MaxPermSize=1g -XX:+UnlockExperimentalVMOptions
 
 nebula.release.features.replaceDevWithImmutableSnapshot=true
 nebula.features.publishing.immutableSnapshotsEnabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ javadoc.noqualifier=java.lang:java.util:com.netflix.type
 javadoc.access=protected
 
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx4g -Xms1g -XX:MaxPermSize=1g -XX:+UnlockExperimentalVMOptions
+org.gradle.jvmargs=-Xmx8g -Xms1g -XX:MaxPermSize=1g -XX:+UnlockExperimentalVMOptions
 
 nebula.release.features.replaceDevWithImmutableSnapshot=true
 nebula.features.publishing.immutableSnapshotsEnabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ javadoc.noqualifier=java.lang:java.util:com.netflix.type
 javadoc.access=protected
 
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx3g -Xms1g -XX:MaxPermSize=1g -XX:+UnlockExperimentalVMOptions
+org.gradle.jvmargs=-Xmx4g -Xms1g -XX:MaxPermSize=1g -XX:+UnlockExperimentalVMOptions
 
 nebula.release.features.replaceDevWithImmutableSnapshot=true
 nebula.features.publishing.immutableSnapshotsEnabled=true

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobKeepAliveEvent.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobKeepAliveEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job.event;
+
+import java.util.Optional;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
+
+public class JobKeepAliveEvent extends JobManagerEvent<Job> {
+
+    private static final CallMetadata KEEP_ALIVE_CALL_METADATA = CallMetadata.newBuilder()
+            .withCallerId("KeepAliveEvent")
+            .withCallReason("keep alive event")
+            .build();
+
+    private final long timestamp;
+
+    JobKeepAliveEvent(long timestamp) {
+        super(Job.newBuilder().build(), Optional.empty(), KEEP_ALIVE_CALL_METADATA);
+        this.timestamp = timestamp;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "JobKeepAliveEvent{" +
+                "timestamp=" + timestamp +
+                '}';
+    }
+
+    public static JobKeepAliveEvent keepAliveEvent(long timestamp) {
+        return new JobKeepAliveEvent(timestamp);
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobManagerEvent.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobManagerEvent.java
@@ -26,7 +26,6 @@ import com.netflix.titus.api.model.callmetadata.CallMetadata;
 public abstract class JobManagerEvent<TYPE> {
 
     private static final SnapshotMarkerEvent SNAPSHOT_MARKER = new SnapshotMarkerEvent();
-    private static final KeepAliveEvent KEEP_ALIVE_EVENT = new KeepAliveEvent();
 
     private final TYPE current;
     private final Optional<TYPE> previous;
@@ -75,8 +74,8 @@ public abstract class JobManagerEvent<TYPE> {
         return SNAPSHOT_MARKER;
     }
 
-    public static JobManagerEvent<Job> keepAliveEvent() {
-        return KEEP_ALIVE_EVENT;
+    public static JobManagerEvent<Job> keepAliveEvent(long timestamp) {
+        return new JobKeepAliveEvent(timestamp);
     }
 
     private static class SnapshotMarkerEvent extends JobManagerEvent<Job> {
@@ -86,10 +85,4 @@ public abstract class JobManagerEvent<TYPE> {
         }
     }
 
-    private static class KeepAliveEvent extends JobManagerEvent<Job> {
-
-        private KeepAliveEvent() {
-            super(Job.newBuilder().build(), Optional.empty(), CallMetadata.newBuilder().withCallerId("KeepAliveEvent").withCallReason("keep alive event").build());
-        }
-    }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/ReadOnlyJobOperations.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/ReadOnlyJobOperations.java
@@ -52,21 +52,22 @@ public interface ReadOnlyJobOperations {
     Optional<Pair<Job<?>, Task>> findTaskById(String taskId);
 
     default Observable<JobManagerEvent<?>> observeJobs() {
-        return observeJobs(alwaysTrue(), alwaysTrue());
+        return observeJobs(alwaysTrue(), alwaysTrue(), false);
     }
 
     Observable<JobManagerEvent<?>> observeJobs(Predicate<Pair<Job<?>, List<Task>>> jobsPredicate,
-                                               Predicate<Pair<Job<?>, Task>> tasksPredicate);
+                                               Predicate<Pair<Job<?>, Task>> tasksPredicate,
+                                               boolean withCheckpoints);
 
     Observable<JobManagerEvent<?>> observeJob(String jobId);
 
     default Flux<JobManagerEvent<?>> observeJobsReactor() {
-        return ReactorExt.toFlux(observeJobs(alwaysTrue(), alwaysTrue()));
+        return ReactorExt.toFlux(observeJobs(alwaysTrue(), alwaysTrue(), false));
     }
 
     default Flux<JobManagerEvent<?>> observeJobsReactor(Predicate<Pair<Job<?>, List<Task>>> jobsPredicate,
                                                         Predicate<Pair<Job<?>, Task>> tasksPredicate) {
-        return ReactorExt.toFlux(observeJobs(jobsPredicate, tasksPredicate));
+        return ReactorExt.toFlux(observeJobs(jobsPredicate, tasksPredicate, false));
     }
 
     default Flux<JobManagerEvent<?>> observeJobReactor(String jobId) {

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/DataReplicator.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/DataReplicator.java
@@ -31,15 +31,26 @@ public interface DataReplicator<SNAPSHOT extends ReplicatedSnapshot, TRIGGER> ex
     SNAPSHOT getCurrent();
 
     /**
-     * Returns the number of milliseconds since the last data refresh time.
+     * Equivalent to calling "clock.wallTime() - getLastCheckpointTimestamp()".
      */
     long getStalenessMs();
 
     /**
-     * Emits periodically the number of milliseconds since the last data refresh time. Emits an error when the
-     * cache refresh process fails, and cannot resume.
+     * Returns the timestamp for which all server side changes that happened before it are guaranteed to be in cache.
+     * The actual cache state may be more up to date, so this is an upper bound on the replication latency.
+     * Returns -1 if the value is not known.
+     */
+    long getLastCheckpointTimestamp();
+
+    /**
+     * Equivalent to "observeLastCheckpointTimestamp().map(timestamp -> clock.wallTime() - timestamp)".
      */
     Flux<Long> observeDataStalenessMs();
+
+    /**
+     * Emits a value when a new checkpoint marker is received.
+     */
+    Flux<Long> observeLastCheckpointTimestamp();
 
     /**
      * Emits events that triggered snapshot updates.

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/DataReplicatorDelegate.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/DataReplicatorDelegate.java
@@ -45,8 +45,18 @@ public class DataReplicatorDelegate<SNAPSHOT extends ReplicatedSnapshot, TRIGGER
     }
 
     @Override
+    public long getLastCheckpointTimestamp() {
+        return delegate.getLastCheckpointTimestamp();
+    }
+
+    @Override
     public Flux<Long> observeDataStalenessMs() {
         return delegate.observeDataStalenessMs();
+    }
+
+    @Override
+    public Flux<Long> observeLastCheckpointTimestamp() {
+        return delegate.observeLastCheckpointTimestamp();
     }
 
     @Override

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/ReplicatorEvent.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/ReplicatorEvent.java
@@ -23,11 +23,17 @@ public class ReplicatorEvent<SNAPSHOT, TRIGGER> {
     private final SNAPSHOT snapshot;
     private final TRIGGER trigger;
     private final long lastUpdateTime;
+    private final long lastCheckpointTimestamp;
 
     public ReplicatorEvent(SNAPSHOT snapshot, TRIGGER trigger, long lastUpdateTime) {
+        this(snapshot, trigger, lastUpdateTime, -1);
+    }
+
+    public ReplicatorEvent(SNAPSHOT snapshot, TRIGGER trigger, long lastUpdateTime, long lastCheckpointTimestamp) {
         this.snapshot = snapshot;
         this.trigger = trigger;
         this.lastUpdateTime = lastUpdateTime;
+        this.lastCheckpointTimestamp = lastCheckpointTimestamp;
     }
 
     public SNAPSHOT getSnapshot() {
@@ -42,6 +48,10 @@ public class ReplicatorEvent<SNAPSHOT, TRIGGER> {
         return lastUpdateTime;
     }
 
+    public long getLastCheckpointTimestamp() {
+        return lastCheckpointTimestamp;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -51,14 +61,12 @@ public class ReplicatorEvent<SNAPSHOT, TRIGGER> {
             return false;
         }
         ReplicatorEvent<?, ?> that = (ReplicatorEvent<?, ?>) o;
-        return lastUpdateTime == that.lastUpdateTime &&
-                Objects.equals(snapshot, that.snapshot) &&
-                Objects.equals(trigger, that.trigger);
+        return lastUpdateTime == that.lastUpdateTime && lastCheckpointTimestamp == that.lastCheckpointTimestamp && Objects.equals(snapshot, that.snapshot) && Objects.equals(trigger, that.trigger);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshot, trigger, lastUpdateTime);
+        return Objects.hash(snapshot, trigger, lastUpdateTime, lastCheckpointTimestamp);
     }
 
     @Override
@@ -67,6 +75,7 @@ public class ReplicatorEvent<SNAPSHOT, TRIGGER> {
                 "snapshot=" + snapshot +
                 ", trigger=" + trigger +
                 ", lastUpdateTime=" + lastUpdateTime +
+                ", lastCheckpointTimestamp=" + lastCheckpointTimestamp +
                 '}';
     }
 }

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicator.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicator.java
@@ -16,6 +16,7 @@
 
 package com.netflix.titus.runtime.connector.common.replicator;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.netflix.titus.common.runtime.TitusRuntime;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 
 /**
  * {@link DataReplicator} implementation that wraps {@link ReplicatorEventStream}. The latter is provided
@@ -38,6 +40,7 @@ public class StreamDataReplicator<SNAPSHOT extends ReplicatedSnapshot, TRIGGER> 
     private final TitusRuntime titusRuntime;
     private final boolean useCheckpointTimestamp;
     private final Disposable internalSubscription;
+    private final Sinks.Many<ReplicatorEvent<SNAPSHOT, TRIGGER>> shutdownSink = Sinks.many().multicast().directAllOrNothing();
 
     private final Flux<ReplicatorEvent<SNAPSHOT, TRIGGER>> eventStream;
     private final AtomicReference<ReplicatorEvent<SNAPSHOT, TRIGGER>> lastReplicatorEventRef;
@@ -47,7 +50,7 @@ public class StreamDataReplicator<SNAPSHOT extends ReplicatedSnapshot, TRIGGER> 
                                 Disposable internalSubscription,
                                 AtomicReference<ReplicatorEvent<SNAPSHOT, TRIGGER>> lastReplicatorEventRef,
                                 TitusRuntime titusRuntime) {
-        this.eventStream = eventStream;
+        this.eventStream = eventStream.mergeWith(shutdownSink.asFlux());
         this.useCheckpointTimestamp = useCheckpointTimestamp;
         this.internalSubscription = internalSubscription;
         this.lastReplicatorEventRef = lastReplicatorEventRef;
@@ -56,6 +59,7 @@ public class StreamDataReplicator<SNAPSHOT extends ReplicatedSnapshot, TRIGGER> 
 
     @Override
     public void close() {
+        shutdownSink.emitError(new IllegalStateException("Data replicator closed"), Sinks.EmitFailureHandler.FAIL_FAST);
         internalSubscription.dispose();
     }
 
@@ -121,11 +125,15 @@ public class StreamDataReplicator<SNAPSHOT extends ReplicatedSnapshot, TRIGGER> 
         return Flux.defer(() -> {
             AtomicReference<ReplicatorEvent<SNAPSHOT, TRIGGER>> lastReplicatorEventRef = new AtomicReference<>();
 
-            Flux<ReplicatorEvent<SNAPSHOT, TRIGGER>> eventStream = replicatorEventStream.connect().publish().autoConnect(2);
-            Disposable internalSubscription = newMonitoringSubscription(metrics, lastReplicatorEventRef, eventStream);
+            AtomicReference<Disposable> publisherDisposable = new AtomicReference<>();
+            Flux<ReplicatorEvent<SNAPSHOT, TRIGGER>> eventStream = replicatorEventStream.connect().
+                    publish()
+                    .autoConnect(2, publisherDisposable::set);
+            newMonitoringSubscription(metrics, lastReplicatorEventRef, eventStream);
 
-            return eventStream.filter(e -> isFresh(e, titusRuntime)).take(1).map(e ->
-                    new StreamDataReplicator<>(eventStream, useCheckpointTimestamp, internalSubscription, lastReplicatorEventRef, titusRuntime)
+            return eventStream.filter(e -> isFresh(e, titusRuntime)).take(1).map(e -> {
+                        return new StreamDataReplicator<>(eventStream, useCheckpointTimestamp, publisherDisposable.get(), lastReplicatorEventRef, titusRuntime);
+                    }
             );
         });
     }
@@ -144,7 +152,11 @@ public class StreamDataReplicator<SNAPSHOT extends ReplicatedSnapshot, TRIGGER> 
                             metrics.event(next);
                         },
                         e -> {
-                            logger.error("Unexpected error in the replicator event stream", e);
+                            if (e instanceof CancellationException) {
+                                logger.info("Data replication stream subscription cancelled");
+                            } else {
+                                logger.error("Unexpected error in the replicator event stream", e);
+                            }
                             metrics.disconnected(e);
                         },
                         () -> {

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/replicator/EvictionDataReplicatorProvider.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/replicator/EvictionDataReplicatorProvider.java
@@ -52,6 +52,7 @@ public class EvictionDataReplicatorProvider implements Provider<EvictionDataRepl
     public EvictionDataReplicatorProvider(EvictionServiceClient client, TitusRuntime titusRuntime) {
         StreamDataReplicator<EvictionDataSnapshot, EvictionEvent> original = StreamDataReplicator.newStreamDataReplicator(
                 newReplicatorEventStream(client, titusRuntime),
+                false,
                 new EvictionDataReplicatorMetrics(EVICTION_REPLICATOR, titusRuntime),
                 titusRuntime
         ).blockFirst(Duration.ofMillis(EVICTION_BOOTSTRAP_TIMEOUT_MS));
@@ -94,7 +95,7 @@ public class EvictionDataReplicatorProvider implements Provider<EvictionDataRepl
     private static class EvictionDataReplicatorMetrics extends DataReplicatorMetrics<EvictionDataSnapshot, EvictionEvent> {
 
         private EvictionDataReplicatorMetrics(String source, TitusRuntime titusRuntime) {
-            super(source, titusRuntime);
+            super(source, false, titusRuntime);
         }
 
         @Override

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/replicator/GrpcEvictionReplicatorEventStream.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/eviction/replicator/GrpcEvictionReplicatorEventStream.java
@@ -55,7 +55,7 @@ public class GrpcEvictionReplicatorEventStream extends AbstractReplicatorEventSt
                                              DataReplicatorMetrics metrics,
                                              TitusRuntime titusRuntime,
                                              Scheduler scheduler) {
-        super(EvictionKeepAliveEvent.getInstance(), metrics, titusRuntime, scheduler);
+        super(false, EvictionKeepAliveEvent.getInstance(), metrics, titusRuntime, scheduler);
         this.client = client;
     }
 

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/CachedReadOnlyJobOperations.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/CachedReadOnlyJobOperations.java
@@ -109,7 +109,9 @@ public class CachedReadOnlyJobOperations implements ReadOnlyJobOperations {
      */
     @Override
     @Experimental(deadline = "03/2019")
-    public Observable<JobManagerEvent<?>> observeJobs(Predicate<Pair<Job<?>, List<Task>>> jobsPredicate, Predicate<Pair<Job<?>, Task>> tasksPredicate) {
+    public Observable<JobManagerEvent<?>> observeJobs(Predicate<Pair<Job<?>, List<Task>>> jobsPredicate,
+                                                      Predicate<Pair<Job<?>, Task>> tasksPredicate,
+                                                      boolean withCheckpoints) {
         Flux<JobManagerEvent<?>> fluxStream = replicator.events()
                 .filter(event -> {
                     if (event.getRight() instanceof JobUpdateEvent) {
@@ -134,7 +136,7 @@ public class CachedReadOnlyJobOperations implements ReadOnlyJobOperations {
     @Override
     @Experimental(deadline = "03/2019")
     public Observable<JobManagerEvent<?>> observeJob(String jobId) {
-        return observeJobs(jobTasks -> jobTasks.getLeft().getId().equals(jobId), jobTask -> jobTask.getLeft().getId().equals(jobId))
+        return observeJobs(jobTasks -> jobTasks.getLeft().getId().equals(jobId), jobTask -> jobTask.getLeft().getId().equals(jobId), false)
                 .takeUntil(event -> {
                     if (event instanceof JobUpdateEvent) {
                         JobUpdateEvent jobUpdateEvent = (JobUpdateEvent) event;

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobConnectorConfiguration.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobConnectorConfiguration.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.titus.runtime.connector.jobmanager.replicator;
+package com.netflix.titus.runtime.connector.jobmanager;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
 
 @Configuration(prefix = "titus.connector.jobService")
-public interface JobDataReplicatorConfiguration {
+public interface JobConnectorConfiguration {
 
     /**
      * Set to true to enable connection timeout if the first event is not emitted in the configured amount of time.
@@ -33,4 +33,16 @@ public interface JobDataReplicatorConfiguration {
      */
     @DefaultValue("30000")
     long getConnectionTimeoutMs();
+
+    /**
+     * Enable {@link JobDataReplicator} with the server side keep alive mechanism. Use only in TitusGateway.
+     */
+    @DefaultValue("true")
+    boolean isKeepAliveReplicatedStreamEnabled();
+
+    /**
+     * Internal at which the keep alive requests are sent over the GRPC channel.
+     */
+    @DefaultValue("100")
+    long getKeepAliveIntervalMs();
 }

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagementDataReplicationComponent.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagementDataReplicationComponent.java
@@ -20,7 +20,6 @@ import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
 import com.netflix.titus.common.environment.MyEnvironment;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.archaius2.Archaius2Ext;
-import com.netflix.titus.runtime.connector.jobmanager.replicator.JobDataReplicatorConfiguration;
 import com.netflix.titus.runtime.connector.jobmanager.replicator.JobDataReplicatorProvider;
 import com.netflix.titus.runtime.connector.jobmanager.snapshot.JobSnapshotFactories;
 import com.netflix.titus.runtime.connector.jobmanager.snapshot.JobSnapshotFactory;
@@ -31,8 +30,8 @@ import org.springframework.context.annotation.Configuration;
 public class JobManagementDataReplicationComponent {
 
     @Bean
-    public JobDataReplicatorConfiguration getJobDataReplicatorConfiguration(MyEnvironment environment) {
-        return Archaius2Ext.newConfiguration(JobDataReplicatorConfiguration.class, environment);
+    public JobConnectorConfiguration getJobDataReplicatorConfiguration(MyEnvironment environment) {
+        return Archaius2Ext.newConfiguration(JobConnectorConfiguration.class, environment);
     }
 
     @Bean
@@ -41,7 +40,7 @@ public class JobManagementDataReplicationComponent {
     }
 
     @Bean
-    public JobDataReplicator getJobDataReplicator(JobDataReplicatorConfiguration configuration,
+    public JobDataReplicator getJobDataReplicator(JobConnectorConfiguration configuration,
                                                   JobManagementClient jobManagementClient,
                                                   JobSnapshotFactory jobSnapshotFactory,
                                                   TitusRuntime titusRuntime) {

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagerConnectorModule.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagerConnectorModule.java
@@ -34,6 +34,8 @@ public class JobManagerConnectorModule extends AbstractModule {
 
     public static final String MANAGED_CHANNEL_NAME = "ManagedChannel";
 
+    public static final String KEEP_ALIVE_ENABLED = "keepAliveEnabled";
+
     private final String clientName;
 
     public JobManagerConnectorModule(String clientName) {
@@ -50,6 +52,16 @@ public class JobManagerConnectorModule extends AbstractModule {
     @Singleton
     public JobManagementClient getJobManagementClient(ReactorJobManagementServiceStub stub, TitusRuntime titusRuntime) {
         return new RemoteJobManagementClient(clientName, stub, titusRuntime);
+    }
+
+    @Provides
+    @Singleton
+    @Named(KEEP_ALIVE_ENABLED)
+    public JobManagementClient getJobManagementClient(JobConnectorConfiguration configuration,
+                                                      JobManagementServiceGrpc.JobManagementServiceStub stub,
+                                                      ReactorJobManagementServiceStub reactorStub,
+                                                      TitusRuntime titusRuntime) {
+        return new RemoteJobManagementClientWithKeepAlive(clientName, configuration, stub, reactorStub, titusRuntime);
     }
 
     @Provides

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/RemoteJobManagementClientWithKeepAlive.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/RemoteJobManagementClientWithKeepAlive.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.jobmanager;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.grpc.protogen.JobChangeNotification;
+import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc.JobManagementServiceStub;
+import com.netflix.titus.grpc.protogen.KeepAliveRequest;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
+import com.netflix.titus.grpc.protogen.ObserveJobsWithKeepAliveRequest;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.StreamObserver;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Extension of {@link RemoteJobManagementClient} that uses the new observeJobsWithKeepAlive GRPC method.
+ * Its usage is limited now to communication between TitusGateway and TJC.
+ */
+public class RemoteJobManagementClientWithKeepAlive extends RemoteJobManagementClient {
+
+    private final JobConnectorConfiguration configuration;
+
+    /**
+     * Reactor bridge does not support input streams, so we have to use the GRPC stub directly here.
+     */
+    private final JobManagementServiceStub stub;
+
+    private final TitusRuntime titusRuntime;
+
+    private final AtomicLong keepAliveIdGen = new AtomicLong();
+
+    public RemoteJobManagementClientWithKeepAlive(String clientName,
+                                                  JobConnectorConfiguration configuration,
+                                                  JobManagementServiceStub stub,
+                                                  ReactorJobManagementServiceStub reactorStub,
+                                                  TitusRuntime titusRuntime) {
+        super(clientName, reactorStub, titusRuntime);
+        this.configuration = configuration;
+        this.stub = stub;
+        this.titusRuntime = titusRuntime;
+    }
+
+    @Override
+    protected Flux<JobChangeNotification> connectObserveJobs(Map<String, String> filteringCriteria) {
+        return Flux.create(sink -> {
+            AtomicReference<ClientCallStreamObserver> requestStreamRef = new AtomicReference<>();
+            StreamObserver<JobChangeNotification> grpcStreamObserver = new ClientResponseObserver<JobChangeNotification, JobChangeNotification>() {
+                @Override
+                public void beforeStart(ClientCallStreamObserver requestStream) {
+                    requestStreamRef.set(requestStream);
+                }
+
+                @Override
+                public void onNext(JobChangeNotification value) {
+                    sink.next(value);
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    sink.error(error);
+                }
+
+                @Override
+                public void onCompleted() {
+                    sink.complete();
+                }
+            };
+
+            StreamObserver<ObserveJobsWithKeepAliveRequest> clientStreamObserver = stub.observeJobsWithKeepAlive(grpcStreamObserver);
+            clientStreamObserver.onNext(ObserveJobsWithKeepAliveRequest.newBuilder()
+                    .setQuery(ObserveJobsQuery.newBuilder().putAllFilteringCriteria(filteringCriteria).build())
+                    .build()
+            );
+
+            // Now emit keep alive requests periodically
+            Disposable keepAliveSubscription = Flux.interval(Duration.ofMillis(configuration.getKeepAliveIntervalMs())).subscribe(
+                    next -> {
+                        try {
+                            clientStreamObserver.onNext(ObserveJobsWithKeepAliveRequest.newBuilder()
+                                    .setKeepAliveRequest(KeepAliveRequest.newBuilder()
+                                            .setRequestId(keepAliveIdGen.getAndIncrement())
+                                            .setTimestamp(titusRuntime.getClock().wallTime())
+                                            .build()
+                                    )
+                                    .build()
+                            );
+                        } catch (Exception error) {
+                            clientStreamObserver.onError(error);
+                        }
+                    },
+                    sink::error,
+                    () -> sink.error(new IllegalArgumentException("Keep alive stream terminated. Closing the event stream"))
+            );
+
+            sink.onCancel(() -> {
+                keepAliveSubscription.dispose();
+                if (requestStreamRef.get() != null) {
+                    requestStreamRef.get().cancel("ObserveJobs stream cancelled by the client", null);
+                }
+            });
+        });
+    }
+}

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/relocation/replicator/GrpcRelocationReplicatorEventStream.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/relocation/replicator/GrpcRelocationReplicatorEventStream.java
@@ -45,7 +45,7 @@ public class GrpcRelocationReplicatorEventStream extends AbstractReplicatorEvent
                                                DataReplicatorMetrics metrics,
                                                TitusRuntime titusRuntime,
                                                Scheduler scheduler) {
-        super(TaskRelocationEvent.newKeepAliveEvent(), metrics, titusRuntime, scheduler);
+        super(false, TaskRelocationEvent.newKeepAliveEvent(), metrics, titusRuntime, scheduler);
         this.client = client;
     }
 

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/relocation/replicator/RelocationDataReplicatorProvider.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/relocation/replicator/RelocationDataReplicatorProvider.java
@@ -59,6 +59,7 @@ public class RelocationDataReplicatorProvider implements Provider<RelocationData
         StreamDataReplicator<TaskRelocationSnapshot, TaskRelocationEvent> original = StreamDataReplicator.newStreamDataReplicator(
                 new ReplicatorEvent<>(TaskRelocationSnapshot.empty(), STARTUP_EVENT, 0L),
                 newReplicatorEventStream(client, titusRuntime),
+                false,
                 new RelocationDataReplicatorMetrics(RELOCATION_REPLICATOR, titusRuntime),
                 titusRuntime
         );
@@ -79,14 +80,14 @@ public class RelocationDataReplicatorProvider implements Provider<RelocationData
     private static RetryableReplicatorEventStream<TaskRelocationSnapshot, TaskRelocationEvent> newReplicatorEventStream(RelocationServiceClient client, TitusRuntime titusRuntime) {
         GrpcRelocationReplicatorEventStream grpcEventStream = new GrpcRelocationReplicatorEventStream(
                 client,
-                new DataReplicatorMetrics<>(RELOCATION_REPLICATOR_GRPC_STREAM, titusRuntime),
+                new DataReplicatorMetrics<>(RELOCATION_REPLICATOR_GRPC_STREAM, false, titusRuntime),
                 titusRuntime,
                 Schedulers.parallel()
         );
 
         return new RetryableReplicatorEventStream<>(
                 grpcEventStream,
-                new DataReplicatorMetrics<>(RELOCATION_REPLICATOR_RETRYABLE_STREAM, titusRuntime),
+                new DataReplicatorMetrics<>(RELOCATION_REPLICATOR_RETRYABLE_STREAM, false, titusRuntime),
                 titusRuntime,
                 Schedulers.parallel()
         );
@@ -101,7 +102,7 @@ public class RelocationDataReplicatorProvider implements Provider<RelocationData
     private static class RelocationDataReplicatorMetrics extends DataReplicatorMetrics<TaskRelocationSnapshot, TaskRelocationEvent> {
 
         private RelocationDataReplicatorMetrics(String source, TitusRuntime titusRuntime) {
-            super(source, titusRuntime);
+            super(source, false, titusRuntime);
         }
 
         @Override

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/RetryableReplicatorEventStreamTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/RetryableReplicatorEventStreamTest.java
@@ -121,7 +121,7 @@ public class RetryableReplicatorEventStreamTest {
         }));
 
         return new RetryableReplicatorEventStream<>(
-                delegate, new DataReplicatorMetrics("test", titusRuntime), titusRuntime, Schedulers.parallel()
+                delegate, new DataReplicatorMetrics("test", false, titusRuntime), titusRuntime, Schedulers.parallel()
         );
     }
 

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicatorPerf.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicatorPerf.java
@@ -28,7 +28,7 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.runtime.connector.jobmanager.JobDataReplicator;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
-import com.netflix.titus.runtime.connector.jobmanager.replicator.JobDataReplicatorConfiguration;
+import com.netflix.titus.runtime.connector.jobmanager.JobConnectorConfiguration;
 import com.netflix.titus.runtime.connector.jobmanager.replicator.JobDataReplicatorProvider;
 import com.netflix.titus.runtime.connector.jobmanager.snapshot.JobSnapshotFactories;
 import com.netflix.titus.testkit.model.job.JobGenerator;
@@ -48,7 +48,7 @@ public class StreamDataReplicatorPerf {
         TitusRuntime titusRuntime = TitusRuntimes.internal();
 
         JobManagementClient client = Mockito.mock(JobManagementClient.class);
-        JobDataReplicatorConfiguration configuration = Mockito.mock(JobDataReplicatorConfiguration.class);
+        JobConnectorConfiguration configuration = Mockito.mock(JobConnectorConfiguration.class);
 
         Mockito.when(client.observeJobs(ArgumentMatchers.any())).thenAnswer(invocation -> Flux.defer(() -> {
 

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicatorTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicatorTest.java
@@ -34,14 +34,14 @@ public class StreamDataReplicatorTest {
 
     private final ReplicatorEventStreamStub replicatorEventStream = new ReplicatorEventStreamStub();
 
-    private final DataReplicatorMetrics metrics = new DataReplicatorMetrics("test", titusRuntime);
+    private final DataReplicatorMetrics metrics = new DataReplicatorMetrics("test", false, titusRuntime);
 
     private final DirectProcessor<ReplicatorEvent<StringSnapshot, String>> eventPublisher = DirectProcessor.create();
 
     @Test
     public void testBootstrap() {
         StepVerifier
-                .withVirtualTime(() -> StreamDataReplicator.newStreamDataReplicator(replicatorEventStream, metrics, titusRuntime))
+                .withVirtualTime(() -> StreamDataReplicator.newStreamDataReplicator(replicatorEventStream, false, metrics, titusRuntime))
                 .expectSubscription()
                 .expectNoEvent(Duration.ofSeconds(1))
 

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicatorTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/common/replicator/StreamDataReplicatorTest.java
@@ -18,12 +18,13 @@ package com.netflix.titus.runtime.connector.common.replicator;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import org.junit.Test;
-import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +37,7 @@ public class StreamDataReplicatorTest {
 
     private final DataReplicatorMetrics metrics = new DataReplicatorMetrics("test", false, titusRuntime);
 
-    private final DirectProcessor<ReplicatorEvent<StringSnapshot, String>> eventPublisher = DirectProcessor.create();
+    private final Sinks.Many<ReplicatorEvent<StringSnapshot, String>> eventSink = Sinks.many().multicast().directAllOrNothing();
 
     @Test
     public void testBootstrap() {
@@ -45,13 +46,36 @@ public class StreamDataReplicatorTest {
                 .expectSubscription()
                 .expectNoEvent(Duration.ofSeconds(1))
 
-                .then(() -> eventPublisher.onNext(new ReplicatorEvent<>(new StringSnapshot("firstUpdate"), "firstTrigger", 0)))
+                .then(() -> eventSink.emitNext(new ReplicatorEvent<>(new StringSnapshot("firstUpdate"), "firstTrigger", 0), Sinks.EmitFailureHandler.FAIL_FAST))
                 .assertNext(replicator -> {
                     assertThat(replicator.getCurrent()).isEqualTo(new StringSnapshot("firstUpdate"));
                 })
 
                 .thenCancel()
                 .verify();
+    }
+
+    @Test
+    public void testShutdown() {
+        AtomicReference<StreamDataReplicator> replicatorRef = new AtomicReference<>();
+        StepVerifier
+                .withVirtualTime(() ->
+                        StreamDataReplicator.newStreamDataReplicator(replicatorEventStream, false, metrics, titusRuntime)
+                                .flatMap(replicator -> {
+                                    replicatorRef.set(replicator);
+                                    return replicator.events();
+                                })
+                )
+                .expectSubscription()
+                .then(() -> eventSink.emitNext(new ReplicatorEvent<>(new StringSnapshot("firstUpdate"), "firstTrigger", 0), Sinks.EmitFailureHandler.FAIL_FAST))
+
+                .then(() -> {
+                    assertThat(eventSink.currentSubscriberCount()).isEqualTo(1);
+                    replicatorRef.get().close();
+                    assertThat(eventSink.currentSubscriberCount()).isZero();
+
+                })
+                .verifyErrorMatches(error -> error.getMessage().equals("Data replicator closed"));
     }
 
     private static class StringSnapshot extends ReplicatedSnapshot {
@@ -89,7 +113,7 @@ public class StreamDataReplicatorTest {
 
         @Override
         public Flux<ReplicatorEvent<StringSnapshot, String>> connect() {
-            return eventPublisher;
+            return eventSink.asFlux();
         }
     }
 }

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/eviction/replicator/GrpcEvictionReplicatorEventStreamTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/eviction/replicator/GrpcEvictionReplicatorEventStreamTest.java
@@ -102,7 +102,7 @@ public class GrpcEvictionReplicatorEventStreamTest {
     }
 
     private GrpcEvictionReplicatorEventStream newStream() {
-        return new GrpcEvictionReplicatorEventStream(client, new DataReplicatorMetrics("test", titusRuntime), titusRuntime, Schedulers.parallel());
+        return new GrpcEvictionReplicatorEventStream(client, new DataReplicatorMetrics("test", false, titusRuntime), titusRuntime, Schedulers.parallel());
     }
 
     private StepVerifier.FirstStep<ReplicatorEvent<EvictionDataSnapshot, EvictionEvent>> newConnectVerifier() {

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/RemoteJobManagementClientWithKeepAliveTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/RemoteJobManagementClientWithKeepAliveTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.runtime.connector.jobmanager;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.common.util.Evaluators;
+import com.netflix.titus.common.util.archaius2.Archaius2Ext;
+import com.netflix.titus.grpc.protogen.Job;
+import com.netflix.titus.grpc.protogen.JobChangeNotification;
+import com.netflix.titus.grpc.protogen.JobManagementServiceGrpc;
+import com.netflix.titus.grpc.protogen.KeepAliveRequest;
+import com.netflix.titus.grpc.protogen.KeepAliveResponse;
+import com.netflix.titus.grpc.protogen.ObserveJobsWithKeepAliveRequest;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.Disposable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class RemoteJobManagementClientWithKeepAliveTest {
+
+    private static final Object COMPLETED = new Object();
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test();
+
+    private final JobConnectorConfiguration configuration = Archaius2Ext.newConfiguration(JobConnectorConfiguration.class);
+
+    private final ReactorJobManagementServiceStub reactorStub = mock(ReactorJobManagementServiceStub.class);
+
+    private RemoteJobManagementClientWithKeepAlive client;
+    private Server server;
+    private ManagedChannel channel;
+
+    private ServerCallStreamObserver<JobChangeNotification> responseObserver;
+
+    private final StreamObserver<ObserveJobsWithKeepAliveRequest> requestObserver = new StreamObserver<ObserveJobsWithKeepAliveRequest>() {
+        @Override
+        public void onNext(ObserveJobsWithKeepAliveRequest value) {
+            receivedFromClient.add(value);
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            receivedFromClient.add(error);
+        }
+
+        @Override
+        public void onCompleted() {
+            receivedFromClient.add(COMPLETED);
+        }
+    };
+
+    private final BlockingQueue<Object> receivedFromClient = new LinkedBlockingDeque<>();
+    private boolean clientCancelled;
+
+    @Before
+    public void setUp() {
+        this.server = newServerConnection();
+        this.channel = InProcessChannelBuilder.forName("test").directExecutor().build();
+        this.client = new RemoteJobManagementClientWithKeepAlive(
+                "test",
+                configuration,
+                JobManagementServiceGrpc.newStub(channel),
+                reactorStub,
+                titusRuntime
+        );
+    }
+
+    @After
+    public void tearDown() {
+        Evaluators.acceptNotNull(channel, ManagedChannel::shutdown);
+        Evaluators.acceptNotNull(server, Server::shutdown);
+    }
+
+    @Test
+    public void testJobEvent() throws InterruptedException {
+        Iterator<JobChangeNotification> it = newClientConnection();
+        responseObserver.onNext(newJobUpdateEvent("job1"));
+        expectJobChangeNotification(it, JobChangeNotification.NotificationCase.JOBUPDATE);
+    }
+
+    @Test
+    public void testKeepAlive() throws InterruptedException {
+        Iterator<JobChangeNotification> it = newClientConnection();
+        KeepAliveRequest keepAliveRequest = waitForClientKeepAliveRequest();
+        responseObserver.onNext(JobChangeNotification.newBuilder()
+                .setKeepAliveResponse(KeepAliveResponse.newBuilder().setRequest(keepAliveRequest).build())
+                .build()
+        );
+        KeepAliveResponse keepAliveResponse = expectJobChangeNotification(it,
+                JobChangeNotification.NotificationCase.KEEPALIVERESPONSE).getKeepAliveResponse();
+        assertThat(keepAliveResponse.getRequest()).isEqualTo(keepAliveRequest);
+    }
+
+    @Test
+    public void testClientCancel() throws InterruptedException {
+        Disposable disposable = client.connectObserveJobs(Collections.emptyMap()).subscribe();
+        // Read and discard the query message
+        receivedFromClient.poll(30, TimeUnit.SECONDS);
+        disposable.dispose();
+        Object value = receivedFromClient.poll(30, TimeUnit.SECONDS);
+        assertThat(value).isInstanceOf(StatusRuntimeException.class);
+        assertThat(((StatusRuntimeException) value).getStatus().getCode()).isEqualTo(Status.Code.CANCELLED);
+        assertThat(clientCancelled).isTrue();
+    }
+
+    @Test
+    public void testServerError() throws InterruptedException {
+        Iterator<JobChangeNotification> it = newClientConnection();
+        // Read and discard the query message
+        receivedFromClient.poll(30, TimeUnit.SECONDS);
+
+        responseObserver.onError(new StatusRuntimeException(Status.ABORTED.augmentDescription("simulated error")));
+        try {
+            it.next();
+        } catch (StatusRuntimeException e) {
+            assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.ABORTED);
+        }
+    }
+
+    private Server newServerConnection() {
+        try {
+            return InProcessServerBuilder.forName("test")
+                    .directExecutor()
+                    .addService(new GrpcJobServiceStub())
+                    .build()
+                    .start();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Iterator<JobChangeNotification> newClientConnection() throws InterruptedException {
+        Iterator<JobChangeNotification> it = client.connectObserveJobs(Collections.emptyMap()).toIterable().iterator();
+
+        Object clientRequestEvent = receivedFromClient.poll(30, TimeUnit.SECONDS);
+        assertThat(clientRequestEvent).isNotNull().isInstanceOf(ObserveJobsWithKeepAliveRequest.class);
+        assertThat(((ObserveJobsWithKeepAliveRequest) clientRequestEvent).getKindCase()).isEqualTo(ObserveJobsWithKeepAliveRequest.KindCase.QUERY);
+        return it;
+    }
+
+    private JobChangeNotification expectJobChangeNotification(Iterator<JobChangeNotification> it, JobChangeNotification.NotificationCase eventCase) {
+        JobChangeNotification jobEvent = it.next();
+        assertThat(jobEvent).isNotNull();
+        assertThat(jobEvent.getNotificationCase()).isEqualTo(eventCase);
+        return jobEvent;
+    }
+
+    private KeepAliveRequest waitForClientKeepAliveRequest() throws InterruptedException {
+        Object value = receivedFromClient.poll(30, TimeUnit.SECONDS);
+        assertThat(value).isNotNull().isInstanceOf(ObserveJobsWithKeepAliveRequest.class);
+        ObserveJobsWithKeepAliveRequest event = (ObserveJobsWithKeepAliveRequest) value;
+        assertThat(event.getKindCase()).isEqualTo(ObserveJobsWithKeepAliveRequest.KindCase.KEEPALIVEREQUEST);
+        return event.getKeepAliveRequest();
+    }
+
+    private JobChangeNotification newJobUpdateEvent(String jobId) {
+        return JobChangeNotification.newBuilder()
+                .setJobUpdate(JobChangeNotification.JobUpdate.newBuilder()
+                        .setJob(Job.newBuilder()
+                                .setId(jobId)
+                                .build()
+                        )
+                        .build()
+                )
+                .build();
+    }
+
+    private class GrpcJobServiceStub extends JobManagementServiceGrpc.JobManagementServiceImplBase {
+        @Override
+        public StreamObserver<ObserveJobsWithKeepAliveRequest> observeJobsWithKeepAlive(StreamObserver<JobChangeNotification> responseObserver) {
+            ServerCallStreamObserver<JobChangeNotification> responseObserver2 = (ServerCallStreamObserver<JobChangeNotification>) responseObserver;
+            RemoteJobManagementClientWithKeepAliveTest.this.responseObserver = responseObserver2;
+            responseObserver2.setOnCancelHandler(() -> RemoteJobManagementClientWithKeepAliveTest.this.clientCancelled = true);
+            return requestObserver;
+        }
+    }
+}

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
@@ -44,6 +44,7 @@ import com.netflix.titus.common.util.rx.ReactorExt;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.runtime.connector.common.replicator.DataReplicatorMetrics;
 import com.netflix.titus.runtime.connector.common.replicator.ReplicatorEvent;
+import com.netflix.titus.runtime.connector.jobmanager.JobConnectorConfiguration;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagementClient;
 import com.netflix.titus.runtime.connector.jobmanager.replicator.GrpcJobReplicatorEventStream.CacheUpdater;
 import com.netflix.titus.runtime.connector.jobmanager.snapshot.JobSnapshot;
@@ -73,7 +74,7 @@ public class GrpcJobReplicatorEventStreamTest {
 
     private final TitusRuntime titusRuntime = TitusRuntimes.test();
 
-    private final JobDataReplicatorConfiguration configuration = Mockito.mock(JobDataReplicatorConfiguration.class);
+    private final JobConnectorConfiguration configuration = Mockito.mock(JobConnectorConfiguration.class);
 
     private final JobComponentStub jobServiceStub = new JobComponentStub(titusRuntime);
 
@@ -270,7 +271,7 @@ public class GrpcJobReplicatorEventStreamTest {
 
     private GrpcJobReplicatorEventStream newStream() {
         when(client.observeJobs(any())).thenReturn(ReactorExt.toFlux(jobServiceStub.observeJobs(true)));
-        return new GrpcJobReplicatorEventStream(client, JobSnapshotFactories.newDefault(titusRuntime), configuration, new DataReplicatorMetrics("test", titusRuntime), titusRuntime, Schedulers.parallel());
+        return new GrpcJobReplicatorEventStream(client, JobSnapshotFactories.newDefault(titusRuntime), configuration, new DataReplicatorMetrics("test", false, titusRuntime), titusRuntime, Schedulers.parallel());
     }
 
     private StepVerifier.FirstStep<ReplicatorEvent<JobSnapshot, JobManagerEvent<?>>> newConnectVerifier() {

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/relocation/replicator/GrpcRelocationReplicatorEventStreamTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/relocation/replicator/GrpcRelocationReplicatorEventStreamTest.java
@@ -73,7 +73,7 @@ public class GrpcRelocationReplicatorEventStreamTest {
     }
 
     private GrpcRelocationReplicatorEventStream newStream() {
-        return new GrpcRelocationReplicatorEventStream(client, new DataReplicatorMetrics("test", titusRuntime), titusRuntime, Schedulers.parallel());
+        return new GrpcRelocationReplicatorEventStream(client, new DataReplicatorMetrics("test", false, titusRuntime), titusRuntime, Schedulers.parallel());
     }
 
     private StepVerifier.FirstStep<ReplicatorEvent<TaskRelocationSnapshot, TaskRelocationEvent>> newConnectVerifier() {

--- a/titus-common/src/main/java/com/netflix/titus/common/framework/reconciler/ReconcileEventFactory.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/framework/reconciler/ReconcileEventFactory.java
@@ -27,6 +27,8 @@ import java.util.Optional;
  */
 public interface ReconcileEventFactory<EVENT> {
 
+    EVENT newCheckpointEvent(long timestamp);
+
     /**
      * Called when a new {@link ChangeAction} is registered, but not executed yet.
      */

--- a/titus-common/src/main/java/com/netflix/titus/common/framework/reconciler/internal/DefaultReconciliationFramework.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/framework/reconciler/internal/DefaultReconciliationFramework.java
@@ -45,6 +45,7 @@ import com.netflix.titus.common.framework.reconciler.ChangeAction;
 import com.netflix.titus.common.framework.reconciler.EntityHolder;
 import com.netflix.titus.common.framework.reconciler.ModelActionHolder;
 import com.netflix.titus.common.framework.reconciler.MultiEngineChangeAction;
+import com.netflix.titus.common.framework.reconciler.ReconcileEventFactory;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
 import com.netflix.titus.common.framework.reconciler.ReconciliationFramework;
 import com.netflix.titus.common.util.ExceptionExt;
@@ -101,7 +102,9 @@ public class DefaultReconciliationFramework<EVENT> implements ReconciliationFram
                                           Function<EntityHolder, InternalReconciliationEngine<EVENT>> engineFactory,
                                           long idleTimeoutMs,
                                           long activeTimeoutMs,
+                                          long checkpointIntervalMs,
                                           Map<Object, Comparator<EntityHolder>> indexComparators,
+                                          ReconcileEventFactory<EVENT> eventFactory,
                                           Registry registry,
                                           Optional<Scheduler> optionalScheduler) {
         Preconditions.checkArgument(idleTimeoutMs > 0, "idleTimeout <= 0 (%s)", idleTimeoutMs);
@@ -127,7 +130,7 @@ public class DefaultReconciliationFramework<EVENT> implements ReconciliationFram
 
         this.worker = scheduler.createWorker();
 
-        this.eventDistributor = new EventDistributor<>(registry);
+        this.eventDistributor = new EventDistributor<>(eventFactory, checkpointIntervalMs, registry);
 
         this.loopExecutionTime = registry.timer(LOOP_EXECUTION_TIME_METRIC);
         this.lastFullCycleExecutionTimeMs = scheduler.now() - idleTimeoutMs;

--- a/titus-common/src/main/java/com/netflix/titus/common/framework/reconciler/internal/EventDistributor.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/framework/reconciler/internal/EventDistributor.java
@@ -33,6 +33,7 @@ import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 import com.netflix.spectator.api.patterns.PolledMeter;
+import com.netflix.titus.common.framework.reconciler.ReconcileEventFactory;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
 import com.netflix.titus.common.util.ExceptionExt;
 import org.slf4j.Logger;
@@ -49,6 +50,9 @@ class EventDistributor<EVENT> {
     private static final Logger logger = LoggerFactory.getLogger(EventDistributor.class);
 
     private static final String ROOT_METRIC_NAME = DefaultReconciliationFramework.ROOT_METRIC_NAME + "eventDistributor.";
+
+    private final ReconcileEventFactory<EVENT> eventFactory;
+    private final long checkpointIntervalMs;
 
     // This collection is observed by Spectator poller, so we have to use ConcurrentMap.
     private final ConcurrentMap<String, EngineHolder> engineHolders = new ConcurrentHashMap<>();
@@ -68,7 +72,11 @@ class EventDistributor<EVENT> {
     private final Timer metricLoopExecutionTime;
     private final Counter metricEmittedEvents;
 
-    EventDistributor(Registry registry) {
+    EventDistributor(ReconcileEventFactory<EVENT> eventFactory,
+                     long checkpointIntervalMs,
+                     Registry registry) {
+        this.eventFactory = eventFactory;
+        this.checkpointIntervalMs = checkpointIntervalMs;
         PolledMeter.using(registry).withName(ROOT_METRIC_NAME + "connectedEngines").monitorSize(engineHolders);
         this.metricLoopExecutionTime = registry.timer(ROOT_METRIC_NAME + "executionTime");
         PolledMeter.using(registry).withName(ROOT_METRIC_NAME + "eventQueue").monitorValue(this, self -> self.eventQueueDepth.get());
@@ -129,6 +137,7 @@ class EventDistributor<EVENT> {
     }
 
     private void doLoop() {
+        long keepAliveTimestamp = 0;
         while (true) {
             if (shutdown) {
                 completeEmitters();
@@ -146,6 +155,11 @@ class EventDistributor<EVENT> {
                     events.add(event);
                 }
             } catch (InterruptedException ignore) {
+            }
+            long now = System.currentTimeMillis();
+            if (keepAliveTimestamp + checkpointIntervalMs < now) {
+                keepAliveTimestamp = now;
+                events.add(eventFactory.newCheckpointEvent(System.nanoTime()));
             }
             eventQueue.drainTo(events);
             eventQueueDepth.accumulateAndGet(events.size(), (current, delta) -> current - delta);

--- a/titus-common/src/test/java/com/netflix/titus/common/framework/reconciler/internal/SimpleReconcilerEvent.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/framework/reconciler/internal/SimpleReconcilerEvent.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 public class SimpleReconcilerEvent {
 
     enum EventType {
+        Checkpoint,
         ChangeRequest,
         Changed,
         ChangeError,

--- a/titus-common/src/test/java/com/netflix/titus/common/framework/reconciler/internal/SimpleReconcilerEventFactory.java
+++ b/titus-common/src/test/java/com/netflix/titus/common/framework/reconciler/internal/SimpleReconcilerEventFactory.java
@@ -25,8 +25,14 @@ import com.netflix.titus.common.framework.reconciler.ReconcileEventFactory;
 import com.netflix.titus.common.framework.reconciler.ReconciliationEngine;
 
 /**
+ *
  */
 public class SimpleReconcilerEventFactory implements ReconcileEventFactory<SimpleReconcilerEvent> {
+
+    @Override
+    public SimpleReconcilerEvent newCheckpointEvent(long timestamp) {
+        return new SimpleReconcilerEvent(SimpleReconcilerEvent.EventType.Checkpoint, "checkpoint: " + timestamp, Optional.empty());
+    }
 
     @Override
     public SimpleReconcilerEvent newBeforeChangeEvent(ReconciliationEngine engine, ChangeAction changeAction, String transactionId) {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayConfiguration.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayConfiguration.java
@@ -45,4 +45,12 @@ public interface GatewayConfiguration {
      */
     @DefaultValue("NONE")
     String getQueryFromCacheCallerId();
+
+    /**
+     * Thread pool size handling client requests from the local cache. The {@link LocalCacheQueryProcessor} sync method
+     * most of the time completes with TJC GRPC callback when handling the keep alive message. Using that GRPC thread
+     * for further processing would cause a bottleneck on both sides.
+     */
+    @DefaultValue("100")
+    int getLocalCacheSchedulerThreadPoolSize();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsContext.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsContext.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.jobmanager.endpoint.v3.grpc;
+
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.grpc.protogen.JobChangeNotification;
+import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcObjectsCache;
+import rx.Scheduler;
+
+/**
+ * A helper class to deal with job event stream subscriptions.
+ */
+class ObserveJobsContext {
+
+    static final JobChangeNotification SNAPSHOT_END_MARKER = JobChangeNotification.newBuilder()
+            .setSnapshotEnd(JobChangeNotification.SnapshotEnd.newBuilder())
+            .build();
+
+    private final V3JobOperations jobOperations;
+    private final CallMetadataResolver callMetadataResolver;
+    private final GrpcObjectsCache grpcObjectsCache;
+    private final Scheduler observeJobsScheduler;
+    private final DefaultJobManagementServiceGrpcMetrics metrics;
+    private final TitusRuntime titusRuntime;
+
+    ObserveJobsContext(V3JobOperations jobOperations,
+                       CallMetadataResolver callMetadataResolver,
+                       GrpcObjectsCache grpcObjectsCache,
+                       Scheduler observeJobsScheduler,
+                       DefaultJobManagementServiceGrpcMetrics metrics,
+                       TitusRuntime titusRuntime) {
+        this.jobOperations = jobOperations;
+        this.callMetadataResolver = callMetadataResolver;
+        this.grpcObjectsCache = grpcObjectsCache;
+        this.observeJobsScheduler = observeJobsScheduler;
+        this.metrics = metrics;
+        this.titusRuntime = titusRuntime;
+    }
+
+    public V3JobOperations getJobOperations() {
+        return jobOperations;
+    }
+
+    public CallMetadataResolver getCallMetadataResolver() {
+        return callMetadataResolver;
+    }
+
+    public GrpcObjectsCache getGrpcObjectsCache() {
+        return grpcObjectsCache;
+    }
+
+    public Scheduler getObserveJobsScheduler() {
+        return observeJobsScheduler;
+    }
+
+    public DefaultJobManagementServiceGrpcMetrics getMetrics() {
+        return metrics;
+    }
+
+    public TitusRuntime getTitusRuntime() {
+        return titusRuntime;
+    }
+
+
+    JobChangeNotification toJobChangeNotification(com.netflix.titus.api.jobmanager.model.job.Job<?> coreJob, long now) {
+        com.netflix.titus.grpc.protogen.Job grpcJob = grpcObjectsCache.getJob(coreJob);
+        return JobChangeNotification.newBuilder()
+                .setJobUpdate(JobChangeNotification.JobUpdate.newBuilder().setJob(grpcJob))
+                .setTimestamp(now)
+                .build();
+    }
+
+    JobChangeNotification toJobChangeNotification(com.netflix.titus.api.jobmanager.model.job.Task coreTask, long now) {
+        com.netflix.titus.grpc.protogen.Task grpcTask = grpcObjectsCache.getTask(coreTask);
+        return JobChangeNotification.newBuilder()
+                .setTaskUpdate(JobChangeNotification.TaskUpdate.newBuilder().setTask(grpcTask))
+                .setTimestamp(now)
+                .build();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscription.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscription.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.jobmanager.endpoint.v3.grpc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
+import com.netflix.titus.api.model.callmetadata.CallMetadataConstants;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.ExceptionExt;
+import com.netflix.titus.common.util.rx.ObservableExt;
+import com.netflix.titus.common.util.tuple.Pair;
+import com.netflix.titus.grpc.protogen.JobChangeNotification;
+import com.netflix.titus.grpc.protogen.JobDescriptor;
+import com.netflix.titus.grpc.protogen.KeepAliveRequest;
+import com.netflix.titus.grpc.protogen.KeepAliveResponse;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
+import com.netflix.titus.grpc.protogen.ObserveJobsWithKeepAliveRequest;
+import com.netflix.titus.grpc.protogen.TaskStatus;
+import com.netflix.titus.runtime.endpoint.JobQueryCriteria;
+import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobManagementModelConverters;
+import com.netflix.titus.runtime.endpoint.v3.grpc.query.V3JobQueryCriteriaEvaluator;
+import com.netflix.titus.runtime.endpoint.v3.grpc.query.V3TaskQueryCriteriaEvaluator;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Subscription;
+
+import static com.netflix.titus.master.jobmanager.endpoint.v3.grpc.ObserveJobsContext.SNAPSHOT_END_MARKER;
+import static com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobQueryModelConverters.toJobQueryCriteria;
+
+class ObserveJobsSubscription {
+
+    private static final Logger logger = LoggerFactory.getLogger(ObserveJobsSubscription.class);
+
+    private final ObserveJobsContext context;
+    private final DefaultJobManagementServiceGrpcMetrics metrics;
+    private final TitusRuntime titusRuntime;
+
+    // GRPC channel
+    private final BlockingQueue<ObserveJobsWithKeepAliveRequest> grpcClientEvents = new LinkedBlockingDeque<>();
+    private volatile StreamObserver<JobChangeNotification> grpcResponseObserver;
+    private volatile boolean grpcStreamInitiated;
+    private volatile boolean grpcSnapshotMarkerSent;
+    private volatile boolean grpcStreamCancelled;
+
+    // Job service
+    private final BlockingQueue<JobChangeNotification> jobServiceEvents = new LinkedBlockingDeque<>();
+    private volatile Throwable jobServiceError;
+    private volatile boolean jobServiceCompleted;
+    @VisibleForTesting
+    volatile Subscription jobServiceSubscription;
+
+    private final AtomicLong wip = new AtomicLong();
+
+    ObserveJobsSubscription(ObserveJobsContext context) {
+        this.context = context;
+        this.metrics = context.getMetrics();
+        this.titusRuntime = context.getTitusRuntime();
+    }
+
+    void observeJobs(ObserveJobsQuery query, StreamObserver<JobChangeNotification> responseObserver) {
+        grpcClientEvents.add(ObserveJobsWithKeepAliveRequest.newBuilder()
+                .setQuery(query)
+                .build()
+        );
+        connect(responseObserver);
+        drain();
+    }
+
+    StreamObserver<ObserveJobsWithKeepAliveRequest> observeJobsWithKeepAlive(StreamObserver<JobChangeNotification> responseObserver) {
+        connect(responseObserver);
+        return new StreamObserver<ObserveJobsWithKeepAliveRequest>() {
+            @Override
+            public void onNext(ObserveJobsWithKeepAliveRequest request) {
+                grpcClientEvents.add(request);
+                drain();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                grpcStreamCancelled = true;
+                drain();
+            }
+
+            @Override
+            public void onCompleted() {
+                // It is ok that the GRPC input stream is closed. We will continue sending events to the client.
+            }
+        };
+    }
+
+    private void connect(StreamObserver<JobChangeNotification> responseObserver) {
+        this.grpcResponseObserver = responseObserver;
+        ServerCallStreamObserver<JobChangeNotification> serverObserver = (ServerCallStreamObserver<JobChangeNotification>) responseObserver;
+        serverObserver.setOnCancelHandler(() -> {
+            grpcStreamCancelled = true;
+            drain();
+        });
+    }
+
+    private void drain() {
+        try {
+            drainInternal();
+        } catch (Throwable error) {
+            logger.error("Unexpected error in the job event stream", error);
+            grpcStreamCancelled = true;
+            checkTerminated(true, true);
+        }
+    }
+
+    /**
+     * Based on: https://akarnokd.blogspot.com/2015/05/operator-concurrency-primitives_9.html
+     */
+    private void drainInternal() {
+        if (wip.getAndIncrement() == 0) {
+            do {
+                if (checkTerminated(jobServiceCompleted, jobServiceEvents.isEmpty())) {
+                    return;
+                }
+
+                wip.lazySet(1);
+
+                if (grpcStreamInitiated || tryInitialize()) {
+                    while (true) {
+                        boolean completed = jobServiceCompleted;
+                        JobChangeNotification jobServiceEvent = jobServiceEvents.poll();
+                        if (checkTerminated(completed, jobServiceEvent == null)) {
+                            return;
+                        } else if (jobServiceEvent != null) {
+                            if (jobServiceEvent.getNotificationCase() == JobChangeNotification.NotificationCase.SNAPSHOTEND) {
+                                this.grpcSnapshotMarkerSent = true;
+                            }
+                        } else if (grpcSnapshotMarkerSent) {
+                            // No more job service events to send. We can drain the GRPC input stream to process
+                            // keep alive requests.
+                            KeepAliveRequest keepAliveRequest = getLastKeepAliveEvent();
+                            if (keepAliveRequest == null) {
+                                break;
+                            }
+                            jobServiceEvent = toGrpcKeepAliveResponse(keepAliveRequest);
+                        }
+
+                        grpcResponseObserver.onNext(jobServiceEvent);
+                    }
+                }
+            } while (wip.decrementAndGet() != 0);
+        }
+    }
+
+    private boolean tryInitialize() {
+        ObserveJobsQuery query = getLastObserveJobsQueryEvent();
+        if (query == null) {
+            return false;
+        }
+
+        Stopwatch start = Stopwatch.createStarted();
+
+        String trxId = UUID.randomUUID().toString();
+        CallMetadata callMetadata = context.getCallMetadataResolver().resolve().orElse(CallMetadataConstants.UNDEFINED_CALL_METADATA);
+        metrics.observeJobsStarted(trxId, callMetadata);
+
+        JobQueryCriteria<TaskStatus.TaskState, JobDescriptor.JobSpecCase> criteria = toJobQueryCriteria(query);
+        V3JobQueryCriteriaEvaluator jobsPredicate = new V3JobQueryCriteriaEvaluator(criteria, titusRuntime);
+        V3TaskQueryCriteriaEvaluator tasksPredicate = new V3TaskQueryCriteriaEvaluator(criteria, titusRuntime);
+
+        Observable<JobChangeNotification> eventStream = context.getJobOperations().observeJobs(jobsPredicate, tasksPredicate)
+                // avoid clogging the computation scheduler
+                .observeOn(context.getObserveJobsScheduler())
+                .subscribeOn(context.getObserveJobsScheduler(), false)
+                .map(event -> GrpcJobManagementModelConverters.toGrpcJobChangeNotification(event, context.getGrpcObjectsCache(), titusRuntime.getClock().wallTime()))
+                .compose(ObservableExt.head(() -> {
+                    List<JobChangeNotification> snapshot = createJobsSnapshot(jobsPredicate, tasksPredicate);
+                    snapshot.add(SNAPSHOT_END_MARKER);
+                    return snapshot;
+                }))
+                .doOnError(e -> logger.error("Unexpected error in jobs event stream", e));
+
+        AtomicBoolean closingProcessed = new AtomicBoolean();
+        this.jobServiceSubscription = eventStream
+                .doOnUnsubscribe(() -> {
+                    if (!closingProcessed.getAndSet(true)) {
+                        metrics.observeJobsUnsubscribed(trxId, start.elapsed(TimeUnit.MILLISECONDS));
+                    }
+                })
+                .subscribe(
+                        event -> {
+                            metrics.observeJobsEventEmitted(trxId);
+                            jobServiceEvents.add(event);
+                            drain();
+                        },
+                        e -> {
+                            if (!closingProcessed.getAndSet(true)) {
+                                metrics.observeJobsError(trxId, start.elapsed(TimeUnit.MILLISECONDS), e);
+                            }
+                            jobServiceCompleted = true;
+                            jobServiceError = new StatusRuntimeException(Status.INTERNAL
+                                    .withDescription("All jobs monitoring stream terminated with an error")
+                                    .withCause(e));
+                            drain();
+                        },
+                        () -> {
+                            if (!closingProcessed.getAndSet(true)) {
+                                metrics.observeJobsCompleted(trxId, start.elapsed(TimeUnit.MILLISECONDS));
+                            }
+                            jobServiceCompleted = true;
+                            drain();
+                        }
+                );
+        this.grpcStreamInitiated = true;
+        return true;
+    }
+
+    private ObserveJobsQuery getLastObserveJobsQueryEvent() {
+        ObserveJobsQuery jobsQuery = null;
+        ObserveJobsWithKeepAliveRequest event;
+        while ((event = grpcClientEvents.poll()) != null) {
+            if (event.getKindCase() == ObserveJobsWithKeepAliveRequest.KindCase.QUERY) {
+                jobsQuery = event.getQuery();
+            }
+        }
+        return jobsQuery;
+    }
+
+    private KeepAliveRequest getLastKeepAliveEvent() {
+        KeepAliveRequest keepAliveRequest = null;
+        ObserveJobsWithKeepAliveRequest event;
+        while ((event = grpcClientEvents.poll()) != null) {
+            if (event.getKindCase() == ObserveJobsWithKeepAliveRequest.KindCase.KEEPALIVEREQUEST) {
+                keepAliveRequest = event.getKeepAliveRequest();
+            }
+        }
+        return keepAliveRequest;
+    }
+
+    private boolean checkTerminated(boolean isDone, boolean isEmpty) {
+        if (grpcStreamCancelled) {
+            ObservableExt.safeUnsubscribe(jobServiceSubscription);
+            return true;
+        }
+        if (isDone) {
+            Throwable e = jobServiceError;
+            if (e != null) {
+                jobServiceEvents.clear();
+                ExceptionExt.silent(() -> grpcResponseObserver.onError(e));
+                return true;
+            } else if (isEmpty) {
+                ExceptionExt.silent(() -> grpcResponseObserver.onCompleted());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<JobChangeNotification> createJobsSnapshot(
+            Predicate<Pair<Job<?>, List<Task>>> jobsPredicate,
+            Predicate<Pair<com.netflix.titus.api.jobmanager.model.job.Job<?>, com.netflix.titus.api.jobmanager.model.job.Task>> tasksPredicate) {
+        long now = titusRuntime.getClock().wallTime();
+        List<JobChangeNotification> snapshot = new ArrayList<>();
+
+        // Generics casting issue
+        List allJobsAndTasksRaw = context.getJobOperations().getJobsAndTasks();
+        List<Pair<com.netflix.titus.api.jobmanager.model.job.Job<?>, List<com.netflix.titus.api.jobmanager.model.job.Task>>> allJobsAndTasks = allJobsAndTasksRaw;
+        allJobsAndTasks.forEach(pair -> {
+            com.netflix.titus.api.jobmanager.model.job.Job<?> job = pair.getLeft();
+            List<com.netflix.titus.api.jobmanager.model.job.Task> tasks = pair.getRight();
+            if (jobsPredicate.test(pair)) {
+                snapshot.add(context.toJobChangeNotification(job, now));
+            }
+            tasks.forEach(task -> {
+                if (tasksPredicate.test(Pair.of(job, task))) {
+                    snapshot.add(context.toJobChangeNotification(task, now));
+                }
+            });
+        });
+
+        return snapshot;
+    }
+
+    private JobChangeNotification toGrpcKeepAliveResponse(KeepAliveRequest keepAliveRequest) {
+        return JobChangeNotification.newBuilder()
+                .setKeepAliveResponse(KeepAliveResponse.newBuilder()
+                        .setRequest(keepAliveRequest)
+                        .setTimestamp(titusRuntime.getClock().wallTime())
+                        .build()
+                )
+                .build();
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscription.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscription.java
@@ -283,10 +283,10 @@ class ObserveJobsSubscription {
             grpcClientEvents.poll();
         }
 
-        if (lastKeepAliveRequest != null) {
+        if (lastKeepAliveRequest != null && logger.isDebugEnabled()) {
             KeepAliveRequest firstKeepAliveRequest = firstKeepAliveRequestPair.getRight().getKeepAliveRequest();
             long internalSyncDelayMs = (System.nanoTime() - firstKeepAliveRequestPair.getLeft()) / 1_000_000;
-            logger.info("Acknowledging the keep alive request(s): count={}, requestId(first)={}, requestTimestamp={}, internalSyncDelayMs={}",
+            logger.debug("Acknowledging the keep alive request(s): count={}, requestId(first)={}, requestTimestamp={}, internalSyncDelayMs={}",
                     count, firstKeepAliveRequest.getRequestId(), firstKeepAliveRequest.getTimestamp(), internalSyncDelayMs
             );
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerConfiguration.java
@@ -34,6 +34,9 @@ public interface JobManagerConfiguration {
     @DefaultValue("1")
     long getReconcilerActiveTimeoutMs();
 
+    @DefaultValue("10")
+    long getCheckpointIntervalMs();
+
     /**
      * How many active tasks in the transient state (in other words not Started and not Finished) are allowed in a job.
      * If the number of active tasks in the transient state goes above this limit, no new tasks are created.

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobReconciliationFrameworkFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobReconciliationFrameworkFactory.java
@@ -200,7 +200,9 @@ public class JobReconciliationFrameworkFactory {
                 bootstrapModel -> newEngine(bootstrapModel, true),
                 jobManagerConfiguration.getReconcilerIdleTimeoutMs(),
                 jobManagerConfiguration.getReconcilerActiveTimeoutMs(),
+                jobManagerConfiguration.getCheckpointIntervalMs(),
                 INDEX_COMPARATORS,
+                JOB_EVENT_FACTORY,
                 registry,
                 optionalScheduler
         );

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobTransactionLogger.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobTransactionLogger.java
@@ -30,6 +30,7 @@ import com.netflix.titus.common.util.time.Clock;
 import com.netflix.titus.master.jobmanager.service.common.action.TitusChangeAction;
 import com.netflix.titus.master.jobmanager.service.common.action.TitusModelAction;
 import com.netflix.titus.master.jobmanager.service.event.JobChangeReconcilerEvent;
+import com.netflix.titus.master.jobmanager.service.event.JobCheckpointReconcilerEvent;
 import com.netflix.titus.master.jobmanager.service.event.JobManagerReconcilerEvent;
 import com.netflix.titus.master.jobmanager.service.event.JobModelReconcilerEvent;
 import org.slf4j.Logger;
@@ -66,7 +67,13 @@ class JobTransactionLogger {
                             return eventStreamWithBackpressure(reconciliationFramework);
                         }))
                 .subscribe(
-                        event -> logger.info(doFormat(event)),
+                        event -> {
+                            if (event instanceof JobCheckpointReconcilerEvent) {
+                                logger.debug("Checkpoint: {}", event);
+                            } else {
+                                logger.info(doFormat(event));
+                            }
+                        },
                         e -> logger.error("Event stream terminated with an error", e),
                         () -> logger.info("Event stream completed")
                 );

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/event/JobCheckpointReconcilerEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/event/JobCheckpointReconcilerEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.jobmanager.service.event;
+
+import java.util.Collections;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
+import com.netflix.titus.api.model.callmetadata.Caller;
+import com.netflix.titus.api.model.callmetadata.CallerType;
+
+public class JobCheckpointReconcilerEvent extends JobManagerReconcilerEvent {
+
+    private static final Job<?> SENTINEL_JOB = Job.newBuilder().build();
+
+    private static final CallMetadata CHECKPOINT_CALL_METADATA = CallMetadata.newBuilder()
+            .withCallers(Collections.singletonList(
+                    Caller.newBuilder()
+                            .withId("reconciler")
+                            .withCallerType(CallerType.Application)
+                            .build()
+            ))
+            .withCallReason("Job event stream checkpoint")
+            .build();
+
+    private final long timestampNano;
+
+    public JobCheckpointReconcilerEvent(long timestampNano) {
+        super(SENTINEL_JOB, "no-trx:checkpoint", CHECKPOINT_CALL_METADATA);
+        this.timestampNano = timestampNano;
+    }
+
+    public long getTimestampNano() {
+        return timestampNano;
+    }
+
+    @Override
+    public String toString() {
+        return "JobCheckpointReconcilerEvent{" +
+                "timestampNano=" + timestampNano +
+                '}';
+    }
+}

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/event/JobEventFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/event/JobEventFactory.java
@@ -30,8 +30,14 @@ import com.netflix.titus.master.jobmanager.service.event.JobChangeReconcilerEven
 import com.netflix.titus.master.jobmanager.service.event.JobChangeReconcilerEvent.JobChangeErrorReconcilerEvent;
 
 /**
+ *
  */
 public class JobEventFactory implements ReconcileEventFactory<JobManagerReconcilerEvent> {
+
+    @Override
+    public JobManagerReconcilerEvent newCheckpointEvent(long timestampNano) {
+        return new JobCheckpointReconcilerEvent(timestampNano);
+    }
 
     @Override
     public JobManagerReconcilerEvent newBeforeChangeEvent(ReconciliationEngine<JobManagerReconcilerEvent> engine,

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/watcher/KubeAndJobServiceSyncStatusWatcherMain.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/watcher/KubeAndJobServiceSyncStatusWatcherMain.java
@@ -29,8 +29,8 @@ import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.archaius2.Archaius2Ext;
 import com.netflix.titus.common.util.tuple.Pair;
-import com.netflix.titus.master.mesos.MesosConfiguration;
 import com.netflix.titus.master.kubernetes.DefaultContainerResultCodeResolver;
+import com.netflix.titus.master.mesos.MesosConfiguration;
 import com.netflix.titus.runtime.connector.kubernetes.DefaultKubeApiFacade;
 import com.netflix.titus.runtime.connector.kubernetes.KubeApiClients;
 import com.netflix.titus.runtime.connector.kubernetes.KubeConnectorConfiguration;
@@ -92,7 +92,9 @@ public class KubeAndJobServiceSyncStatusWatcherMain {
         }
 
         @Override
-        public Observable<JobManagerEvent<?>> observeJobs(Predicate<Pair<Job<?>, List<Task>>> jobsPredicate, Predicate<Pair<Job<?>, Task>> tasksPredicate) {
+        public Observable<JobManagerEvent<?>> observeJobs(Predicate<Pair<Job<?>, List<Task>>> jobsPredicate,
+                                                          Predicate<Pair<Job<?>, Task>> tasksPredicate,
+                                                          boolean withCheckpoints) {
             return null;
         }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/basic/JobSubmitAndControlBasicTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/basic/JobSubmitAndControlBasicTest.java
@@ -87,7 +87,7 @@ public class JobSubmitAndControlBasicTest extends BaseIntegrationTest {
         final JobDescriptor<BatchJobExt> expectedJob = tmpJob;
 
         jobsScenarioBuilder.schedule(ONE_TASK_BATCH_JOB, jobScenarioBuilder -> jobScenarioBuilder
-                .inJob(job -> assertThat(job.getJobDescriptor()).isEqualTo(expectedJob))
+                .inStrippedJob(job -> assertThat(job.getJobDescriptor()).isEqualTo(expectedJob))
                 .template(ScenarioTemplates.startTasksInNewJob())
                 .assertEachPod(
                         podWithResources(ONE_TASK_BATCH_JOB.getContainer().getContainerResources(), jobConfiguration.getMinDiskSizeMB()),

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscriptionTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscriptionTest.java
@@ -173,6 +173,10 @@ public class ObserveJobsSubscriptionTest {
         assertThat(expectJobUpdateEvent().getJob().getId()).isEqualTo(job1.getId());
         assertThat(expectTaskUpdateEvent().getTask().getId()).isEqualTo(task1.getId());
         expectSnapshotEvent();
+        triggerActions(1);
+
+        jobComponentStub.emitCheckpoint();
+        triggerActions(1);
         expectKeepAlive(2);
         triggerActions(1);
 
@@ -183,6 +187,8 @@ public class ObserveJobsSubscriptionTest {
 
         // Now keep alive
         request.onNext(newKeepAliveRequest(3));
+        jobComponentStub.emitCheckpoint();
+        triggerActions(1);
         expectKeepAlive(3);
     }
 
@@ -210,7 +216,13 @@ public class ObserveJobsSubscriptionTest {
 
         // Now keep alive
         request.onNext(newKeepAliveRequest(123));
+        triggerActions(5);
         JobChangeNotification nextEvent = responseEvents.poll();
+        assertThat(nextEvent).isNull();
+
+        jobComponentStub.emitCheckpoint();
+        triggerActions(5);
+        nextEvent = responseEvents.poll();
         assertThat(nextEvent).isNotNull();
         assertThat(nextEvent.getNotificationCase()).isEqualTo(JobChangeNotification.NotificationCase.KEEPALIVERESPONSE);
         assertThat(nextEvent.getKeepAliveResponse().getRequest().getRequestId()).isEqualTo(123);

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscriptionTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscriptionTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.jobmanager.endpoint.v3.grpc;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.grpc.protogen.JobChangeNotification;
+import com.netflix.titus.grpc.protogen.JobChangeNotification.JobUpdate;
+import com.netflix.titus.grpc.protogen.JobChangeNotification.TaskUpdate;
+import com.netflix.titus.grpc.protogen.KeepAliveRequest;
+import com.netflix.titus.grpc.protogen.ObserveJobsQuery;
+import com.netflix.titus.grpc.protogen.ObserveJobsWithKeepAliveRequest;
+import com.netflix.titus.runtime.endpoint.metadata.AnonymousCallMetadataResolver;
+import com.netflix.titus.testkit.model.job.JobComponentStub;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import com.netflix.titus.testkit.model.job.NoOpGrpcObjectsCache;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.Before;
+import org.junit.Test;
+import rx.schedulers.Schedulers;
+import rx.schedulers.TestScheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObserveJobsSubscriptionTest {
+
+    private static final String SERVICE_JOB_WITH_ONE_TASK = "serviceJobWithOneTask";
+
+    private static final ObserveJobsQuery QUERY = ObserveJobsQuery.newBuilder().putFilteringCriteria("jobType", "service").build();
+
+    private static final ObserveJobsWithKeepAliveRequest QUERY_REQUEST = ObserveJobsWithKeepAliveRequest.newBuilder()
+            .setQuery(QUERY)
+            .build();
+
+    private final TitusRuntime titusRuntime = TitusRuntimes.test();
+
+    private final TestScheduler testScheduler = Schedulers.test();
+
+    private final JobComponentStub jobComponentStub = new JobComponentStub(titusRuntime);
+
+    private final ObserveJobsContext context = new ObserveJobsContext(
+            jobComponentStub.getJobOperations(),
+            AnonymousCallMetadataResolver.getInstance(),
+            new NoOpGrpcObjectsCache(),
+            testScheduler,
+            new DefaultJobManagementServiceGrpcMetrics(titusRuntime),
+            titusRuntime
+    );
+
+    private final ObserveJobsSubscription jobsSubscription = new ObserveJobsSubscription(context);
+
+    private StreamObserver<JobChangeNotification> responseStreamObserver;
+    private final BlockingQueue<JobChangeNotification> responseEvents = new LinkedBlockingDeque<>();
+    private Throwable responseError;
+    private boolean responseCompleted;
+
+    @Before
+    public void setUp() throws Exception {
+        jobComponentStub.addJobTemplate(SERVICE_JOB_WITH_ONE_TASK,
+                JobDescriptorGenerator.serviceJobDescriptors()
+                        .map(jd -> JobFunctions.changeServiceJobCapacity(jd, 1))
+                        .cast(JobDescriptor.class)
+        );
+
+        this.responseStreamObserver = new ServerCallStreamObserver<JobChangeNotification>() {
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+
+            @Override
+            public void setOnCancelHandler(Runnable onCancelHandler) {
+            }
+
+            @Override
+            public void setCompression(String compression) {
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setOnReadyHandler(Runnable onReadyHandler) {
+            }
+
+            @Override
+            public void disableAutoInboundFlowControl() {
+            }
+
+            @Override
+            public void request(int count) {
+            }
+
+            @Override
+            public void setMessageCompression(boolean enable) {
+            }
+
+            @Override
+            public void onNext(JobChangeNotification event) {
+                responseEvents.add(event);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                responseError = error;
+            }
+
+            @Override
+            public void onCompleted() {
+                responseCompleted = true;
+            }
+        };
+    }
+
+    @Test
+    public void testObserveJobsSnapshot() {
+        Job<?> job1 = jobComponentStub.createJob(SERVICE_JOB_WITH_ONE_TASK);
+        Task task1 = jobComponentStub.createDesiredTasks(job1).get(0);
+
+        // First snapshot
+        jobsSubscription.observeJobs(QUERY, responseStreamObserver);
+        assertThat(expectJobUpdateEvent().getJob().getId()).isEqualTo(job1.getId());
+        assertThat(expectTaskUpdateEvent().getTask().getId()).isEqualTo(task1.getId());
+        expectSnapshotEvent();
+        triggerActions(1);
+
+        // Now changes
+        Job<?> job2 = jobComponentStub.createJob(SERVICE_JOB_WITH_ONE_TASK);
+        triggerActions(1);
+        assertThat(expectJobUpdateEvent().getJob().getId()).isEqualTo(job2.getId());
+    }
+
+    @Test
+    public void testObserveJobsWithKeepAliveSnapshot() {
+        Job<?> job1 = jobComponentStub.createJob(SERVICE_JOB_WITH_ONE_TASK);
+        Task task1 = jobComponentStub.createDesiredTasks(job1).get(0);
+
+        StreamObserver<ObserveJobsWithKeepAliveRequest> request = jobsSubscription.observeJobsWithKeepAlive(responseStreamObserver);
+
+        // Check that nothing is emitted until we send the query request
+        request.onNext(newKeepAliveRequest(1));
+        triggerActions(5);
+        assertThat(responseEvents.poll()).isNull();
+
+        // Now send the request and read the snapshot
+        request.onNext(QUERY_REQUEST);
+        request.onNext(newKeepAliveRequest(2));
+
+        assertThat(expectJobUpdateEvent().getJob().getId()).isEqualTo(job1.getId());
+        assertThat(expectTaskUpdateEvent().getTask().getId()).isEqualTo(task1.getId());
+        expectSnapshotEvent();
+        expectKeepAlive(2);
+        triggerActions(1);
+
+        // Now changes
+        Job<?> job2 = jobComponentStub.createJob(SERVICE_JOB_WITH_ONE_TASK);
+        triggerActions(1);
+        assertThat(expectJobUpdateEvent().getJob().getId()).isEqualTo(job2.getId());
+
+        // Now keep alive
+        request.onNext(newKeepAliveRequest(3));
+        expectKeepAlive(3);
+    }
+
+    @Test
+    public void testClientRequestError() {
+        StreamObserver<ObserveJobsWithKeepAliveRequest> request = jobsSubscription.observeJobsWithKeepAlive(responseStreamObserver);
+        request.onNext(QUERY_REQUEST);
+
+        assertThat(jobsSubscription.jobServiceSubscription.isUnsubscribed()).isFalse();
+
+        request.onError(new RuntimeException("simulated client error"));
+        jobComponentStub.createJob(SERVICE_JOB_WITH_ONE_TASK);
+
+        // Check that job service event stream subscription is closed.
+        triggerActions(5);
+        assertThat(jobsSubscription.jobServiceSubscription.isUnsubscribed()).isTrue();
+    }
+
+    @Test
+    public void testKeepAlive() {
+        StreamObserver<ObserveJobsWithKeepAliveRequest> request = jobsSubscription.observeJobsWithKeepAlive(responseStreamObserver);
+        // Query first
+        request.onNext(QUERY_REQUEST);
+        expectSnapshotEvent();
+
+        // Now keep alive
+        request.onNext(newKeepAliveRequest(123));
+        JobChangeNotification nextEvent = responseEvents.poll();
+        assertThat(nextEvent).isNotNull();
+        assertThat(nextEvent.getNotificationCase()).isEqualTo(JobChangeNotification.NotificationCase.KEEPALIVERESPONSE);
+        assertThat(nextEvent.getKeepAliveResponse().getRequest().getRequestId()).isEqualTo(123);
+    }
+
+    private ObserveJobsWithKeepAliveRequest newKeepAliveRequest(long id) {
+        return ObserveJobsWithKeepAliveRequest.newBuilder().setKeepAliveRequest(
+                KeepAliveRequest.newBuilder().setRequestId(id).build()
+        ).build();
+    }
+
+    private void triggerActions(int count) {
+        for (int i = 0; i < count; i++) {
+            testScheduler.triggerActions();
+        }
+    }
+
+    private JobUpdate expectJobUpdateEvent() {
+        JobChangeNotification nextEvent = responseEvents.poll();
+        assertThat(nextEvent).isNotNull();
+        assertThat(nextEvent.getNotificationCase()).isEqualTo(JobChangeNotification.NotificationCase.JOBUPDATE);
+        return nextEvent.getJobUpdate();
+    }
+
+    private TaskUpdate expectTaskUpdateEvent() {
+        JobChangeNotification nextEvent = responseEvents.poll();
+        assertThat(nextEvent).isNotNull();
+        assertThat(nextEvent.getNotificationCase()).isEqualTo(JobChangeNotification.NotificationCase.TASKUPDATE);
+        return nextEvent.getTaskUpdate();
+    }
+
+    private void expectSnapshotEvent() {
+        JobChangeNotification nextEvent = responseEvents.poll();
+        assertThat(nextEvent).isNotNull();
+        assertThat(nextEvent.getNotificationCase()).isEqualTo(JobChangeNotification.NotificationCase.SNAPSHOTEND);
+    }
+
+    private void expectKeepAlive(int keepAliveRequestId) {
+        JobChangeNotification nextEvent = responseEvents.poll();
+        assertThat(nextEvent).isNotNull();
+        assertThat(nextEvent.getNotificationCase()).isEqualTo(JobChangeNotification.NotificationCase.KEEPALIVERESPONSE);
+        assertThat(nextEvent.getKeepAliveResponse().getRequest().getRequestId()).isEqualTo(keepAliveRequestId);
+
+    }
+}

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
@@ -184,6 +184,9 @@ public class EmbeddedTitusGateway {
         if (injector != null) {
             injector.close();
         }
+        if (grpcChannel != null) {
+            grpcChannel.shutdownNow();
+        }
         return this;
     }
 

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/cell/gateway/EmbeddedTitusGateway.java
@@ -34,6 +34,9 @@ import com.netflix.governator.InjectorBuilder;
 import com.netflix.governator.LifecycleInjector;
 import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.store.JobStore;
+import com.netflix.titus.common.model.admission.AdmissionSanitizer;
+import com.netflix.titus.common.model.admission.AdmissionValidator;
+import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.gateway.endpoint.v3.grpc.TitusGatewayGrpcServer;
 import com.netflix.titus.gateway.startup.TitusGatewayModule;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
@@ -45,11 +48,8 @@ import com.netflix.titus.grpc.protogen.LoadBalancerServiceGrpc;
 import com.netflix.titus.grpc.protogen.SchedulerServiceGrpc;
 import com.netflix.titus.grpc.protogen.v4.MachineServiceGrpc;
 import com.netflix.titus.master.TitusMaster;
-import com.netflix.titus.common.model.admission.AdmissionSanitizer;
-import com.netflix.titus.common.model.admission.AdmissionValidator;
 import com.netflix.titus.runtime.endpoint.admission.AggregatingSanitizer;
 import com.netflix.titus.runtime.endpoint.admission.PassJobValidator;
-import com.netflix.titus.common.model.admission.TitusValidatorConfiguration;
 import com.netflix.titus.runtime.endpoint.common.rest.EmbeddedJettyModule;
 import com.netflix.titus.runtime.endpoint.metadata.V3HeaderInterceptor;
 import com.netflix.titus.testkit.embedded.cell.master.EmbeddedTitusMaster;
@@ -272,6 +272,11 @@ public class EmbeddedTitusGateway {
     public static Builder aDefaultTitusGateway() {
         return new Builder()
                 .withProperty("titusGateway.endpoint.grpc.shutdownTimeoutMs", "0");
+        // TODO Uncomment when TitusGateway cache is enabled
+//                .withProperty("titus.connector.jobService.keepAliveReplicatedStreamEnabled", "true")
+//                .withProperty("titus.connector.jobService.keepAliveIntervalMs", "10")
+//                .withProperty("titusGateway.maxAcceptableCacheStalenessMs", "30000")
+//                .withProperty("titusGateway.queryFromCacheCallerId", ".*");
     }
 
     public static class Builder {

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedTitusFederation.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/embedded/federation/EmbeddedTitusFederation.java
@@ -52,8 +52,6 @@ import io.grpc.stub.MetadataUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Named;
-
 /**
  * Run embedded version of TitusFederation.
  */
@@ -141,6 +139,9 @@ public class EmbeddedTitusFederation {
     public EmbeddedTitusFederation shutdown() {
         if (injector != null) {
             injector.close();
+        }
+        if (grpcChannel != null) {
+            grpcChannel.shutdownNow();
         }
         return this;
     }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/junit/master/TitusStackResource.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/junit/master/TitusStackResource.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.base.Preconditions;
+import com.netflix.titus.common.util.ExceptionExt;
 import com.netflix.titus.testkit.embedded.EmbeddedTitusOperations;
 import com.netflix.titus.testkit.embedded.cell.EmbeddedTitusCell;
 import com.netflix.titus.testkit.embedded.cell.gateway.EmbeddedTitusGateway;

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/JobComponentStub.java
@@ -233,4 +233,8 @@ public class JobComponentStub {
             return GrpcJobManagementModelConverters.toGrpcJobChangeNotification(coreEvent, grpcObjectsCache, clock.wallTime());
         });
     }
+
+    public void emitCheckpoint() {
+        stubbedJobData.emitCheckpoint();
+    }
 }

--- a/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/StubbedJobData.java
+++ b/titus-testkit/src/main/java/com/netflix/titus/testkit/model/job/StubbedJobData.java
@@ -172,6 +172,10 @@ class StubbedJobData {
         return snapshot ? ObservableExt.fromCollection(this::getEventSnapshot).concatWith(observeJobsSubject) : observeJobsSubject;
     }
 
+    public void emitCheckpoint() {
+        observeJobsSubject.onNext(JobManagerEvent.keepAliveEvent(System.nanoTime()));
+    }
+
     private JobHolder getJobHolderByJobId(String jobId) {
         JobHolder jobHolder = jobHoldersById.get(jobId);
         if (jobHolder == null) {


### PR DESCRIPTION
Consistent reads are implemented by two mechanisms:
* TitusGateway cache connector sends periodically keep alive requests to TJC. A keep alive response when received is guaranteed to come after all events proceeding its creation.
* The internal TJC job service emits checkpoint events that are used to decide when a keep alive response can be sent