### PR TITLE
Relocation metric step fix

### DIFF
--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/step/RelocationMetricsStep.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/step/RelocationMetricsStep.java
@@ -68,10 +68,10 @@ public class RelocationMetricsStep {
         Map<String, Node> taskToInstanceMap = RelocationUtil.buildTasksToInstanceMap(nodes, jobOperations);
 
         Set<String> jobIds = new HashSet<>();
-        jobOperations.getJobsAndTasks().forEach(jobAndTask -> {
-            Job<?> job = jobAndTask.getLeft();
+
+        jobOperations.getJobs().forEach(job -> {
             jobIds.add(job.getId());
-            metrics.computeIfAbsent(job.getId(), jid -> new JobMetrics(job)).update(job, jobAndTask.getRight(), taskToInstanceMap);
+            metrics.computeIfAbsent(job.getId(), jid -> new JobMetrics(job)).update(job, jobOperations.getTasks(job.getId()), taskToInstanceMap);
         });
 
         // Remove jobs no longer running.


### PR DESCRIPTION
### Relocation metric step fix

Because PCollectionJobSnapshot -> getJobsAndTasks returns a Map<String, Task> instead of a List<Task>, an invalid runtime cast cause error in Relocation metric step execution.
This code change is aimed at avoiding it by going through each jobId and fetching tasks for each Job, instead of working through the entire job & tasks list.