### PR TITLE
relocation de-scheduler fix

### DIFF
--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/CachedReadOnlyJobOperations.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/CachedReadOnlyJobOperations.java
@@ -18,6 +18,7 @@ package com.netflix.titus.runtime.connector.jobmanager;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -70,7 +71,13 @@ public class CachedReadOnlyJobOperations implements ReadOnlyJobOperations {
 
     @Override
     public List<Pair<Job, List<Task>>> getJobsAndTasks() {
-        return (List) replicator.getCurrent().getJobsAndTasks();
+        List<Pair<Job<?>, Map<String, Task>>> jobsAndTasks = replicator.getCurrent().getJobsAndTasks();
+        List<Pair<Job, List<Task>>> allJobsAndTasks = new ArrayList<>(jobsAndTasks.size());
+        jobsAndTasks.forEach(jobMapPair -> {
+            Pair<Job, List<Task>> pair = Pair.of(jobMapPair.getLeft(), new ArrayList<>(jobMapPair.getRight().values()));
+            allJobsAndTasks.add(pair);
+        });
+        return allJobsAndTasks;
     }
 
     @Override

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
@@ -77,11 +77,8 @@ public class DefaultDeschedulerService implements DeschedulerService {
 
     @Override
     public List<DeschedulingResult> deschedule(Map<String, TaskRelocationPlan> plannedAheadTaskRelocationPlans) {
-        List<Pair<Job, List<Task>>> allJobsAndTasks = jobOperations.getJobsAndTasks();
-        Map<String, Job<?>> jobs = allJobsAndTasks.stream().map(Pair::getLeft).collect(Collectors.toMap(Job::getId, j -> j));
-        Map<String, Task> tasksById = allJobsAndTasks.stream()
-                .flatMap(p -> p.getRight().stream())
-                .collect(Collectors.toMap(Task::getId, t -> t));
+        Map<String, Job<?>> jobs = jobOperations.getJobs().stream().collect(Collectors.toMap(Job::getId, j -> (Job<?>) j));
+        Map<String, Task> tasksById = jobOperations.getTasks().stream().collect(Collectors.toMap(Task::getId, t -> t));
 
         EvacuatedAgentsAllocationTracker evacuatedAgentsAllocationTracker = new EvacuatedAgentsAllocationTracker(nodeDataResolver.resolve(), tasksById);
         EvictionQuotaTracker evictionQuotaTracker = new EvictionQuotaTracker(evictionOperations, jobs);

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/descheduler/DefaultDeschedulerService.java
@@ -77,9 +77,11 @@ public class DefaultDeschedulerService implements DeschedulerService {
 
     @Override
     public List<DeschedulingResult> deschedule(Map<String, TaskRelocationPlan> plannedAheadTaskRelocationPlans) {
-        Map<String, Job<?>> jobs = jobOperations.getJobs().stream().collect(Collectors.toMap(Job::getId, j -> (Job<?>) j));
-        Map<String, Task> tasksById = jobOperations.getTasks().stream().collect(Collectors.toMap(Task::getId, t -> t));
-
+        List<Pair<Job, List<Task>>> allJobsAndTasks = jobOperations.getJobsAndTasks();
+        Map<String, Job<?>> jobs = allJobsAndTasks.stream().map(Pair::getLeft).collect(Collectors.toMap(Job::getId, j -> j));
+        Map<String, Task> tasksById = allJobsAndTasks.stream()
+                .flatMap(p -> p.getRight().stream())
+                .collect(Collectors.toMap(Task::getId, t -> t));
         EvacuatedAgentsAllocationTracker evacuatedAgentsAllocationTracker = new EvacuatedAgentsAllocationTracker(nodeDataResolver.resolve(), tasksById);
         EvictionQuotaTracker evictionQuotaTracker = new EvictionQuotaTracker(evictionOperations, jobs);
 

--- a/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/step/RelocationMetricsStep.java
+++ b/titus-supplementary-component/task-relocation/src/main/java/com/netflix/titus/supplementary/relocation/workflow/step/RelocationMetricsStep.java
@@ -69,9 +69,10 @@ public class RelocationMetricsStep {
 
         Set<String> jobIds = new HashSet<>();
 
-        jobOperations.getJobs().forEach(job -> {
+        jobOperations.getJobsAndTasks().forEach(jobAndTask -> {
+            Job<?> job = jobAndTask.getLeft();
             jobIds.add(job.getId());
-            metrics.computeIfAbsent(job.getId(), jid -> new JobMetrics(job)).update(job, jobOperations.getTasks(job.getId()), taskToInstanceMap);
+            metrics.computeIfAbsent(job.getId(), jid -> new JobMetrics(job)).update(job, jobAndTask.getRight(), taskToInstanceMap);
         });
 
         // Remove jobs no longer running.


### PR DESCRIPTION
### Runtime type error fix

Relocation service runs into the runtime type error while de-scheduling eligible tasks from marked or unhealthy agents. This change is similar in nature to the bug-fix done to Metrics step code in order avoid incorrect casting of Map to a List from PCollectionJobSnapsho