### PR TITLE
Added support for filtering based on platformSidecar channel

### DIFF
--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/JobQueryCriteria.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/JobQueryCriteria.java
@@ -52,6 +52,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
     private final boolean needsMigration;
     private final boolean skipSystemFailures;
     private final Optional<String> platformSidecar;
+    private final Optional<String> platformSidecarChannel;
     private final int limit;
 
     private JobQueryCriteria(Set<String> jobIds,
@@ -74,6 +75,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                              boolean needsMigration,
                              boolean skipSystemFailures,
                              String platformSidecar,
+                             String platformSidecarChannel,
                              int limit) {
         this.jobIds = nonNull(jobIds);
         this.taskIds = nonNull(taskIds);
@@ -94,6 +96,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
         this.jobGroupSequence = Optional.ofNullable(jobGroupSequence);
         this.needsMigration = needsMigration;
         this.platformSidecar = Optional.ofNullable(platformSidecar);
+        this.platformSidecarChannel = Optional.ofNullable(platformSidecarChannel);
         this.skipSystemFailures = skipSystemFailures;
         this.limit = limit;
     }
@@ -182,6 +185,10 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
         return platformSidecar;
     }
 
+    public Optional<String> getPlatformSidecarChannel() {
+        return platformSidecarChannel;
+    }
+
     public int getLimit() {
         return limit;
     }
@@ -205,6 +212,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                 .withJobGroupSequence(this.jobGroupSequence.orElse(null))
                 .withNeedsMigration(needsMigration)
                 .withPlatformSidecar(this.platformSidecar.orElse(null))
+                .withPlatformSidecarChannel(this.platformSidecarChannel.orElse(null))
                 .withLimit(this.limit);
     }
 
@@ -225,6 +233,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                 && !jobGroupSequence.isPresent()
                 && !needsMigration
                 && !platformSidecar.isPresent()
+                && !platformSidecarChannel.isPresent()
                 && limit < 1;
     }
 
@@ -257,12 +266,13 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                 Objects.equals(jobGroupStack, that.jobGroupStack) &&
                 Objects.equals(jobGroupDetail, that.jobGroupDetail) &&
                 Objects.equals(jobGroupSequence, that.jobGroupSequence) &&
-                Objects.equals(platformSidecar, that.platformSidecar);
+                Objects.equals(platformSidecar, that.platformSidecar) &&
+                Objects.equals(platformSidecarChannel, that.platformSidecarChannel);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobIds, taskIds, includeArchived, jobState, taskStates, taskStateReasons, owner, labels, labelsAndOp, imageName, imageTag, appName, capacityGroup, jobType, jobGroupStack, jobGroupDetail, jobGroupSequence, needsMigration, skipSystemFailures, platformSidecar, limit);
+        return Objects.hash(jobIds, taskIds, includeArchived, jobState, taskStates, taskStateReasons, owner, labels, labelsAndOp, imageName, imageTag, appName, capacityGroup, jobType, jobGroupStack, jobGroupDetail, jobGroupSequence, needsMigration, skipSystemFailures, platformSidecar, platformSidecarChannel, limit);
     }
 
     @Override
@@ -288,6 +298,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                 ", needsMigration=" + needsMigration +
                 ", skipSystemFailures=" + skipSystemFailures +
                 ", platformSidecar=" + platformSidecar +
+                ", platformSidecarChannel=" + platformSidecarChannel +
                 ", limit=" + limit +
                 '}';
     }
@@ -313,6 +324,7 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
         private boolean needsMigration;
         private boolean skipSystemFailures;
         private String platformSidecar;
+        private String platformSidecarChannel;
         private int limit;
 
         private Builder() {
@@ -378,6 +390,11 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
             return this;
         }
 
+        public Builder<TASK_STATE, JOB_TYPE> withPlatformSidecarChannel(String platformSidecarChannel) {
+            this.platformSidecarChannel = platformSidecarChannel;
+            return this;
+        }
+
         public Builder<TASK_STATE, JOB_TYPE> withAppName(String appName) {
             this.appName = appName;
             return this;
@@ -438,13 +455,14 @@ public class JobQueryCriteria<TASK_STATE, JOB_TYPE extends Enum<JOB_TYPE>> {
                     .withNeedsMigration(needsMigration)
                     .withSkipSystemFailures(skipSystemFailures)
                     .withPlatformSidecar(platformSidecar)
+                    .withPlatformSidecarChannel(platformSidecarChannel)
                     .withLimit(limit);
         }
 
         public JobQueryCriteria<TASK_STATE, JOB_TYPE> build() {
             return new JobQueryCriteria<>(jobIds, taskIds, includeArchived, jobState, taskStates, taskStateReasons, owner, labels,
                     labelsAndOp, imageName, imageTag, appName, capacityGroup, jobType, jobGroupStack, jobGroupDetail, jobGroupSequence,
-                    needsMigration, skipSystemFailures, platformSidecar, limit);
+                    needsMigration, skipSystemFailures, platformSidecar, platformSidecarChannel, limit);
         }
     }
 }

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobQueryModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobQueryModelConverters.java
@@ -51,7 +51,7 @@ public class GrpcJobQueryModelConverters extends CommonRuntimeGrpcModelConverter
             "jobIds", "taskIds", "owner", "appName", "applicationName", "imageName", "imageTag", "capacityGroup",
             "jobGroupStack", "jobGroupDetail", "jobGroupSequence",
             "jobType", "attributes", "attributes.op", "labels", "labels.op", "jobState", "taskStates", "taskStateReasons",
-            "needsMigration", "skipSystemFailures", "platformSidecar"
+            "needsMigration", "skipSystemFailures", "platformSidecar", "platformSidecarChannel"
     );
 
     public static JobQueryCriteria<TaskStatus.TaskState, JobSpecCase> toJobQueryCriteria(ObserveJobsQuery query) {
@@ -94,6 +94,7 @@ public class GrpcJobQueryModelConverters extends CommonRuntimeGrpcModelConverter
 
         // PlatformSidecar-related criteria
         trimAndApplyIfNonEmpty(criteriaMap.get("platformSidecar"), criteriaBuilder::withPlatformSidecar);
+        trimAndApplyIfNonEmpty(criteriaMap.get("platformSidecarChannel"), criteriaBuilder::withPlatformSidecarChannel);
 
         // Job type
         String jobType = criteriaMap.get("jobType");

--- a/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCriteriaQueryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/integration/v3/job/query/JobCriteriaQueryTest.java
@@ -421,7 +421,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
 
     @Test(timeout = 30_000)
     public void testSearchByPlatformSidecarV3() {
-        List<PlatformSidecar> ps = Collections.singletonList(PlatformSidecar.newBuilder().withName("testPlatformSidecar").withChannel("").build());
+        List<PlatformSidecar> ps = Collections.singletonList(PlatformSidecar.newBuilder().withName("testPlatformSidecar").withChannel("testPSChannel").build());
         JobDescriptor<BatchJobExt> jobDescriptorWithTestSidecar = BATCH_JOB_TEMPLATE.toBuilder()
                 .withApplicationName("testAppThatDoesHavePlatformSidecar")
                 .withPlatformSidecars(ps)
@@ -432,6 +432,7 @@ public class JobCriteriaQueryTest extends BaseIntegrationTest {
 
         List<Job> foundJobs = client.findJobs(JobQuery.newBuilder()
                 .putFilteringCriteria("platformSidecar", "testPlatformSidecar")
+                .putFilteringCriteria("platformSidecarChannel", "testPSChannel")
                 .setPage(PAGE)
                 .build()
         ).getItemsList();

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/query/V3AbstractQueryCriteriaEvaluator.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/query/V3AbstractQueryCriteriaEvaluator.java
@@ -68,6 +68,7 @@ public abstract class V3AbstractQueryCriteriaEvaluator<TASK_OR_SET> implements P
         applyImageName(criteria.getImageName()).ifPresent(predicates::add);
         applyImageTag(criteria.getImageTag()).ifPresent(predicates::add);
         applyPlatformSidecar(criteria.getPlatformSidecar()).ifPresent(predicates::add);
+        applyPlatformSidecarChannel(criteria.getPlatformSidecarChannel()).ifPresent(predicates::add);
         applyJobDescriptorAttributes(criteria.getLabels(), criteria.isLabelsAndOp()).ifPresent(predicates::add);
 
         return predicates;
@@ -162,6 +163,19 @@ public abstract class V3AbstractQueryCriteriaEvaluator<TASK_OR_SET> implements P
                 jobTaskPair -> {
                     for (PlatformSidecar ps : jobTaskPair.getLeft().getJobDescriptor().getPlatformSidecars()) {
                         if (ps.getName().equals(platformSidecarName)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+        );
+    }
+
+    private Optional<Predicate<Pair<Job<?>, TASK_OR_SET>>> applyPlatformSidecarChannel(Optional<String> platformSidecarChannelOpt) {
+        return platformSidecarChannelOpt.map(platformSidecarChannel ->
+                jobTaskPair -> {
+                    for (PlatformSidecar ps : jobTaskPair.getLeft().getJobDescriptor().getPlatformSidecars()) {
+                        if (ps.getChannel().equals(platformSidecarChannel)) {
                             return true;
                         }
                     }


### PR DESCRIPTION
This is part2 of allowing platform sidecar (PS) authors to be
able to find jobs of interest to them.

Specifically, this will allow them to find jobs that are using
a particular channel, so those jobs can be bounced or hunted
down when a particular channel needs to be deprecated.

*Or* when that channel is upgraded, jobs/tasks using that channel
can be targeted for relocation, to force them to get the latest
version.

----

I didn't feel the need to go "all out" and write lots of integration tests
to verify this new code's interaction with "platformSidecar=", I think it
can be safely assumed that, like any other query filter, this is an "And"
filter, and will be applied *together* with a sidecar name to narrow the scope.

While technically possible for one to just query based on a channel name,
seems like it would be a little silly.
