### PR TITLE
Make the name of the 'main' container be 'main' in V1 schema pods

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -220,7 +220,7 @@ public class V1SpecPodFactory implements PodFactory {
                 .labels(labels);
 
         V1Container container = new V1Container()
-                .name(taskId)
+                .name("main")
                 .image(KubePodUtil.buildImageString(configuration.getRegistryUrl(), jobDescriptor.getContainer().getImage()))
                 .env(envVarsList)
                 .resources(buildV1ResourceRequirements(job.getJobDescriptor().getContainer().getContainerResources()))


### PR DESCRIPTION
I want to make this name change before we have too many things
keying off of container names in the newer multi-container world.

Remember, we already have a unique identifier for the pod, the pod ID
is the task uuid, that is great.

The container name though, I think it would be better to have a consistent
string we can key off of: "main". This simplifies a lot of future code
that has to detect "which" container they are on, or making a volumeMount
that needs to reference "which" container to attach.

For all things that ever need to ask "what is the name of the main container"
or "am I running on the main container", they will not need to *also* look
up the taskid var and compare.

----

Keep in mind this will break nobody if merged today, and only *may* break
people as I roll out v1 pod spec, so we'll have an easy rollback/forward.

But, because of the tiny (today) number of users doing multi-container work,
I'm confident that the breakage will be minimal.

In summary, this is an easy change to make today, and will be painful to try to make a year from now.