### PR TITLE
Adding kube shared informer to gateway

### DIFF
--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -1296,8 +1296,7 @@ public final class GrpcJobManagementModelConverters {
                 .build();
     }
 
-    public static com.netflix.titus.grpc.protogen.Task toGrpcTask(Task
-                                                                          coreTask, LogStorageInfo<Task> logStorageInfo) {
+    public static com.netflix.titus.grpc.protogen.Task toGrpcTask(Task coreTask, LogStorageInfo<Task> logStorageInfo) {
         Map<String, String> taskContext = new HashMap<>(coreTask.getTaskContext());
         taskContext.put(TASK_ATTRIBUTES_TASK_ORIGINAL_ID, coreTask.getOriginalId());
         taskContext.put(TASK_ATTRIBUTES_RESUBMIT_NUMBER, Integer.toString(coreTask.getResubmitNumber()));

--- a/titus-server-gateway/build.gradle
+++ b/titus-server-gateway/build.gradle
@@ -10,6 +10,8 @@ dependencies {
 
     // Misc dependencies
     compile "com.github.spullara.cli-parser:cli-parser:${cliParserVersion}"
+    compile "io.fabric8:kubernetes-client:${fabric8ioKubeClient}"
+
 
     testCompile project(':titus-testkit')
     testCompile "com.netflix.governator:governator-test-junit:${governatorVersion}"

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GatewayGrpcModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GatewayGrpcModule.java
@@ -26,6 +26,7 @@ import com.netflix.titus.gateway.endpoint.v3.grpc.DefaultSchedulerServiceGrpc;
 import com.netflix.titus.gateway.endpoint.v3.grpc.GrpcEndpointConfiguration;
 import com.netflix.titus.gateway.endpoint.v3.grpc.TitusGatewayGrpcServer;
 import com.netflix.titus.gateway.eviction.EvictionModule;
+import com.netflix.titus.gateway.kubernetes.KubeApiConnector;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc.AgentManagementServiceImplBase;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
 import com.netflix.titus.grpc.protogen.HealthGrpc;
@@ -50,6 +51,7 @@ public class GatewayGrpcModule extends AbstractModule {
         bind(LoadBalancerServiceGrpc.LoadBalancerServiceImplBase.class).to(DefaultLoadBalancerServiceGrpc.class);
         bind(SchedulerServiceGrpc.SchedulerServiceImplBase.class).to(DefaultSchedulerServiceGrpc.class);
         bind(TitusGatewayGrpcServer.class).asEagerSingleton();
+        bind(KubeApiConnector.class).asEagerSingleton();
     }
 
     @Provides

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GatewayGrpcModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/GatewayGrpcModule.java
@@ -51,7 +51,6 @@ public class GatewayGrpcModule extends AbstractModule {
         bind(LoadBalancerServiceGrpc.LoadBalancerServiceImplBase.class).to(DefaultLoadBalancerServiceGrpc.class);
         bind(SchedulerServiceGrpc.SchedulerServiceImplBase.class).to(DefaultSchedulerServiceGrpc.class);
         bind(TitusGatewayGrpcServer.class).asEagerSingleton();
-        bind(KubeApiConnector.class).asEagerSingleton();
     }
 
     @Provides

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/grpc/TitusGatewayGrpcServer.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/endpoint/v3/grpc/TitusGatewayGrpcServer.java
@@ -30,6 +30,7 @@ import com.netflix.titus.common.framework.fit.adapter.GrpcFitInterceptor;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.ExecutorsExt;
 import com.netflix.titus.common.util.grpc.reactor.GrpcToReactorServerFactory;
+import com.netflix.titus.gateway.kubernetes.KubeApiConnector;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc;
 import com.netflix.titus.grpc.protogen.AgentManagementServiceGrpc.AgentManagementServiceImplBase;
 import com.netflix.titus.grpc.protogen.AutoScalingServiceGrpc;
@@ -73,6 +74,7 @@ public class TitusGatewayGrpcServer {
     private final GrpcEndpointConfiguration config;
     private final TitusRuntime titusRuntime;
     private final ExecutorService grpcCallbackExecutor;
+    private final KubeApiConnector kubeApiConnector;
 
     private final AtomicBoolean started = new AtomicBoolean();
     private Server server;
@@ -89,8 +91,8 @@ public class TitusGatewayGrpcServer {
             SchedulerServiceImplBase schedulerService,
             GrpcToReactorServerFactory reactorServerFactory,
             GrpcEndpointConfiguration config,
-            TitusRuntime titusRuntime
-    ) {
+            TitusRuntime titusRuntime,
+            KubeApiConnector kubeApiConnector) {
         this.healthService = healthService;
         this.evictionService = evictionService;
         this.jobManagementService = jobManagementService;
@@ -102,6 +104,7 @@ public class TitusGatewayGrpcServer {
         this.config = config;
         this.titusRuntime = titusRuntime;
         this.grpcCallbackExecutor = ExecutorsExt.instrumentedCachedThreadPool(titusRuntime.getRegistry(), "grpcCallbackExecutor");
+        this.kubeApiConnector = kubeApiConnector;
     }
 
     public int getPort() {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/F8KubeObjectFormatter.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/F8KubeObjectFormatter.java
@@ -1,0 +1,50 @@
+package com.netflix.titus.gateway.kubernetes;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+
+public class F8KubeObjectFormatter {
+
+    public static String formatPodEssentials(Pod pod) {
+        try {
+            return formatPodEssentialsInternal(pod);
+        } catch (Exception e) {
+            return "pod formatting error: " + e.getMessage();
+        }
+    }
+
+    private static String formatPodEssentialsInternal(Pod pod) {
+        StringBuilder builder = new StringBuilder("{");
+
+        appendMetadata(builder, pod.getMetadata());
+
+        PodSpec spec = pod.getSpec();
+        if (spec != null) {
+            builder.append(", nodeName=").append(spec.getNodeName());
+        }
+
+        PodStatus status = pod.getStatus();
+        if (status != null) {
+            builder.append(", phase=").append(status.getPhase());
+            builder.append(", reason=").append(status.getReason());
+        }
+
+        builder.append("}");
+        return builder.toString();
+    }
+
+    private static void appendMetadata(StringBuilder builder, ObjectMeta metadata) {
+        if (metadata != null) {
+            builder.append("name=").append(metadata.getName());
+            builder.append(", labels=").append(metadata.getLabels());
+        } else {
+            builder.append("name=").append("<no_metadata>");
+        }
+    }
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/F8KubeObjectFormatter.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/F8KubeObjectFormatter.java
@@ -4,10 +4,6 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodStatus;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1PodStatus;
 
 public class F8KubeObjectFormatter {
 

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiClient.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiClient.java
@@ -1,0 +1,8 @@
+package com.netflix.titus.gateway.kubernetes;
+
+import com.netflix.titus.runtime.connector.kubernetes.Fabric8IOClients;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+
+public interface KubeApiClient {
+    public NamespacedKubernetesClient getApiClient();
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiConnector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiConnector.java
@@ -28,7 +28,6 @@ import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.guice.annotation.Deactivator;
 import com.netflix.titus.common.util.rx.ReactorExt;
 import com.netflix.titus.common.util.tuple.Pair;
-import com.netflix.titus.gateway.service.v3.internal.GatewayConfiguration;
 import com.netflix.titus.gateway.startup.TitusGatewayConfiguration;
 import com.netflix.titus.grpc.protogen.TaskStatus;
 import io.fabric8.kubernetes.api.model.ContainerState;
@@ -270,7 +269,7 @@ public class KubeApiConnector {
                 .retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(1)))
                 .subscribe(
                         event -> {
-                            if(!gatewayConfiguration.isSharedInformerEnabled()){
+                            if(!gatewayConfiguration.isKubeSharedInformerEnabled()){
                                 deactivate();
                                 shutdown();
                             }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiConnector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiConnector.java
@@ -1,0 +1,261 @@
+package com.netflix.titus.gateway.kubernetes;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.naming.Name;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.netflix.titus.common.runtime.TitusRuntime;
+import com.netflix.titus.common.util.ExceptionExt;
+import com.netflix.titus.common.util.ExecutorsExt;
+import com.netflix.titus.common.util.StringExt;
+import com.netflix.titus.common.util.archaius2.Archaius2Ext;
+import com.netflix.titus.common.util.guice.annotation.Activator;
+import com.netflix.titus.common.util.guice.annotation.Deactivator;
+import com.netflix.titus.common.util.rx.ReactorExt;
+import com.netflix.titus.runtime.connector.kubernetes.Fabric8IOClients;
+import com.netflix.titus.runtime.connector.kubernetes.KubeConnectorConfiguration;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+import static com.netflix.titus.gateway.kubernetes.F8KubeObjectFormatter.formatPodEssentials;
+
+@Singleton
+public class KubeApiConnector {
+    private static final Logger logger = LoggerFactory.getLogger(KubeApiConnector.class);
+    private final NamespacedKubernetesClient kubernetesClient;
+    private final TitusRuntime titusRuntime;
+    private final ConcurrentMap<String, Pod> pods = new ConcurrentHashMap<>();
+    private volatile SharedInformerFactory sharedInformerFactory;
+    private volatile SharedIndexInformer<Pod> podInformer;
+    private volatile SharedIndexInformer<Node> nodeInformer;
+
+    private ExecutorService notificationHandlerExecutor;
+    private Scheduler scheduler;
+    private Disposable subscription;
+
+    @Inject
+    public KubeApiConnector(NamespacedKubernetesClient kubernetesClient, TitusRuntime titusRuntime) {
+        this.kubernetesClient = kubernetesClient;
+        this.titusRuntime = titusRuntime;
+    }
+
+    private final Object activationLock = new Object();
+    private volatile boolean deactivated;
+
+
+    public Map<String, Pod> getPods() {
+        return new HashMap<>(pods);
+    }
+
+    private SharedIndexInformer<Pod> createPodInformer(SharedInformerFactory sharedInformerFactory) {
+        return sharedInformerFactory.sharedIndexInformerFor(
+                Pod.class,
+                3000);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (sharedInformerFactory != null) {
+            sharedInformerFactory.stopAllRegisteredInformers();
+        }
+    }
+
+    @Deactivator
+    public void deactivate() {
+        if (!deactivated) {
+            synchronized (activationLock) {
+                shutdown();
+                this.deactivated = true;
+            }
+        }
+    }
+
+    public SharedIndexInformer<Pod> getPodInformer() {
+        activate();
+        return podInformer;
+    }
+
+    public SharedIndexInformer<Node> getNodeInformer() {
+        activate();
+        return nodeInformer;
+    }
+
+    private void activate() {
+        synchronized (activationLock) {
+            if (sharedInformerFactory != null) {
+                return;
+            }
+            try {
+                this.sharedInformerFactory = kubernetesClient.informers();
+                this.podInformer = createPodInformer(sharedInformerFactory);
+                sharedInformerFactory.startAllRegisteredInformers();
+                logger.info("Kube pod informer activated");
+            } catch (Exception e) {
+                logger.error("Could not intialize kubernetes shared informer", e);
+                if (sharedInformerFactory != null) {
+                    ExceptionExt.silent(() -> sharedInformerFactory.stopAllRegisteredInformers());
+                }
+                sharedInformerFactory = null;
+                podInformer = null;
+            }
+        }
+    }
+
+    private Optional<Node> findNode(Pod pod) {
+        String nodeName = pod.getSpec().getNodeName();
+        if (StringExt.isEmpty(nodeName)) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(this.getNodeInformer().getIndexer().getByKey(nodeName));
+    }
+
+
+    public Flux<PodEvent> events() {
+        return kubeInformerEvents().transformDeferred(ReactorExt.badSubscriberHandler(logger));
+    }
+
+    private Flux<PodEvent> kubeInformerEvents() {
+        return Flux.create(sink -> {
+            ResourceEventHandler<Pod> handler = new ResourceEventHandler<Pod>() {
+                @Override
+                public void onAdd(Pod pod) {
+                    Stopwatch stopwatch = Stopwatch.createStarted();
+                    try {
+
+                        String taskId = pod.getSpec().getContainers().get(0).getName();
+
+                        Pod old = pods.get(taskId);
+                        pods.put(taskId, pod);
+
+                        PodEvent podEvent;
+                        if (old != null) {
+                            podEvent = PodEvent.onUpdate(old, pod, findNode(pod));
+                            //metrics.onUpdate(pod);
+                        } else {
+                            podEvent = PodEvent.onAdd(pod);
+                            //metrics.onAdd(pod);
+                        }
+                        sink.next(podEvent);
+
+                        logger.info("Pod Added: pod={}, sequenceNumber={}", formatPodEssentials(pod), podEvent.getSequenceNumber());
+                        logger.debug("complete pod data: {}", pod);
+                    } finally {
+                        logger.info("Pod informer onAdd: pod={}, elapsedMs={}", pod.getMetadata().getName(), stopwatch.elapsed().toMillis());
+                    }
+                }
+
+                @Override
+                public void onUpdate(Pod oldPod, Pod newPod) {
+                    Stopwatch stopwatch = Stopwatch.createStarted();
+                    try {
+                        //metrics.onUpdate(newPod);
+
+                        pods.put(newPod.getSpec().getContainers().get(0).getName(), newPod);
+
+                        PodUpdatedEvent podEvent = PodEvent.onUpdate(oldPod, newPod, findNode(newPod));
+                        sink.next(podEvent);
+
+                        logger.info("Pod Updated: old={}, new={}, sequenceNumber={}", formatPodEssentials(oldPod), formatPodEssentials(newPod), podEvent.getSequenceNumber());
+                        logger.debug("Complete pod data: old={}, new={}", oldPod, newPod);
+                    } finally {
+                        logger.info("Pod informer onUpdate: pod={}, elapsedMs={}", newPod.getMetadata().getName(), stopwatch.elapsed().toMillis());
+                    }
+                }
+
+
+                @Override
+                public void onDelete(Pod pod, boolean deletedFinalStateUnknown) {
+                    Stopwatch stopwatch = Stopwatch.createStarted();
+                    try {
+                        //metrics.onDelete(pod);
+
+                        pods.remove(pod.getSpec().getContainers().get(0).getName());
+
+                        PodDeletedEvent podEvent = PodEvent.onDelete(pod, deletedFinalStateUnknown, findNode(pod));
+                        sink.next(podEvent);
+
+                        logger.info("Pod Deleted: {}, deletedFinalStateUnknown={}, sequenceNumber={}", formatPodEssentials(pod), deletedFinalStateUnknown, podEvent.getSequenceNumber());
+                        logger.debug("complete pod data: {}", pod);
+                    } finally {
+                        logger.info("Pod informer onDelete: pod={}, elapsedMs={}", pod.getMetadata().getName(), stopwatch.elapsed().toMillis());
+                    }
+                }
+            };
+            this.getPodInformer().addEventHandler(handler);
+
+            // A listener cannot be removed from shared informer.
+            // sink.onCancel(() -> ???);
+        });
+    }
+
+    @Activator
+    public void enterActiveMode() {
+        this.scheduler = initializeNotificationScheduler();
+        AtomicLong pendingCounter = new AtomicLong();
+        this.subscription = this.events().subscribeOn(scheduler)
+                .publishOn(scheduler)
+                .doOnError(error -> logger.warn("Kube integration event stream terminated with an error (retrying soon)", error))
+                .retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(1)))
+                .subscribe(
+                        event -> {
+                            Stopwatch stopwatch = Stopwatch.createStarted();
+                            pendingCounter.getAndIncrement();
+                            logger.info("New event [pending={}, lag={}]: {}", pendingCounter.get(), PodEvent.nextSequence() - event.getSequenceNumber(), event);
+                            processEvent(event)
+                                    .doAfterTerminate(() -> {
+                                        pendingCounter.decrementAndGet();
+                                        long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+                                        logger.info("Event processed [pending={}]: event={}, elapsed={}", pendingCounter.get(), event, elapsed);
+                                    })
+                                    .subscribe(
+                                            next -> {
+                                                // nothing
+                                            },
+                                            error -> {
+                                                logger.info("Kube api connector event state update error: event={}, error={}", event, error.getMessage());
+                                                logger.debug("Stack trace", error);
+                                            },
+                                            () -> {
+                                                // nothing
+                                            }
+                                    );
+                        },
+                        e -> logger.error("Event stream terminated"),
+                        () -> logger.info("Event stream completed")
+                );
+    }
+    private Mono<Void> processEvent(PodEvent event) {
+        return Mono.empty();
+    }
+
+    @VisibleForTesting
+    protected Scheduler initializeNotificationScheduler() {
+        this.notificationHandlerExecutor = ExecutorsExt.namedSingleThreadExecutor(KubeApiConnector.class.getSimpleName());
+        return Schedulers.fromExecutor(notificationHandlerExecutor);
+    }
+
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiConnector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/KubeApiConnector.java
@@ -12,26 +12,20 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.naming.Name;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
-import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
 import com.netflix.titus.api.jobmanager.service.ReadOnlyJobOperations;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.util.ExceptionExt;
 import com.netflix.titus.common.util.ExecutorsExt;
 import com.netflix.titus.common.util.StringExt;
-import com.netflix.titus.common.util.archaius2.Archaius2Ext;
 import com.netflix.titus.common.util.guice.annotation.Activator;
 import com.netflix.titus.common.util.guice.annotation.Deactivator;
 import com.netflix.titus.common.util.rx.ReactorExt;
-import com.netflix.titus.common.util.tuple.Either;
 import com.netflix.titus.common.util.tuple.Pair;
-import com.netflix.titus.runtime.connector.kubernetes.Fabric8IOClients;
-import com.netflix.titus.runtime.connector.kubernetes.KubeConnectorConfiguration;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
@@ -71,10 +65,6 @@ public class KubeApiConnector {
         this.titusRuntime = titusRuntime;
         this.jobService = jobService;
         enterActiveMode();
-        try {
-            Thread.sleep(3600_1000);
-        } catch (InterruptedException ignore) {
-        }
     }
 
     private final Object activationLock = new Object();
@@ -233,7 +223,9 @@ public class KubeApiConnector {
         });
     }
 
+    @Activator
     public void enterActiveMode() {
+        logger.info("Kube api connector entering active mode");
         this.scheduler = initializeNotificationScheduler();
         AtomicLong pendingCounter = new AtomicLong();
         this.subscription = this.events().subscribeOn(scheduler)

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodAddedEvent.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodAddedEvent.java
@@ -1,0 +1,19 @@
+package com.netflix.titus.gateway.kubernetes;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.kubernetes.client.openapi.models.V1Pod;
+
+public class PodAddedEvent extends PodEvent {
+    PodAddedEvent(Pod pod) {
+        super(pod);
+    }
+
+    @Override
+    public String toString() {
+        return "PodAddedEvent{" +
+                "taskId=" + taskId +
+                ", sequenceNumber=" + sequenceNumber +
+                ", pod=" + F8KubeObjectFormatter.formatPodEssentials(pod) +
+                '}';
+    }
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodDeletedEvent.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodDeletedEvent.java
@@ -1,0 +1,60 @@
+package com.netflix.titus.gateway.kubernetes;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+
+public class PodDeletedEvent extends PodEvent{
+
+    private final boolean deletedFinalStateUnknown;
+    private final Optional<Node> node;
+
+    PodDeletedEvent(Pod pod, boolean deletedFinalStateUnknown, Optional<Node> node) {
+        super(pod);
+        this.deletedFinalStateUnknown = deletedFinalStateUnknown;
+        this.node = node;
+    }
+
+    public boolean isDeletedFinalStateUnknown() {
+        return deletedFinalStateUnknown;
+    }
+
+    public Optional<Node> getNode() {
+        return node;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        PodDeletedEvent that = (PodDeletedEvent) o;
+        return deletedFinalStateUnknown == that.deletedFinalStateUnknown &&
+                Objects.equals(node, that.node);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), deletedFinalStateUnknown, node);
+    }
+
+    @Override
+    public String toString() {
+        return "PodDeletedEvent{" +
+                "taskId='" + taskId + '\'' +
+                ", sequenceNumber=" + sequenceNumber +
+                ", pod=" + F8KubeObjectFormatter.formatPodEssentials(pod) +
+                ", deletedFinalStateUnknown=" + deletedFinalStateUnknown +
+                ", node=" + node.map(n -> n.getMetadata().getName()).orElse("<not_assigned>") +
+                '}';
+    }
+
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodEvent.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodEvent.java
@@ -1,0 +1,83 @@
+package com.netflix.titus.gateway.kubernetes;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.TaskStatus;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+
+public abstract class PodEvent {
+
+    private static final AtomicLong SEQUENCE_NUMBER = new AtomicLong();
+
+    protected final String taskId;
+    protected final Pod pod;
+    protected final long sequenceNumber;
+
+    protected PodEvent(Pod pod) {
+        this.taskId = pod.getMetadata().getName();
+        this.pod = pod;
+        this.sequenceNumber = SEQUENCE_NUMBER.getAndIncrement();
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public Pod getPod() {
+        return pod;
+    }
+
+    public long getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PodEvent podEvent = (PodEvent) o;
+        return sequenceNumber == podEvent.sequenceNumber && Objects.equals(taskId, podEvent.taskId) && Objects.equals(pod, podEvent.pod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(taskId, pod, sequenceNumber);
+    }
+
+    @Override
+    public String toString() {
+        return "PodEvent{" +
+                "taskId='" + taskId + '\'' +
+                ", sequenceNumber=" + sequenceNumber +
+                ", pod=" + F8KubeObjectFormatter.formatPodEssentials(pod) +
+                '}';
+    }
+
+    public static long nextSequence() {
+        return SEQUENCE_NUMBER.get();
+    }
+
+    public static PodAddedEvent onAdd(Pod pod) {
+        return new PodAddedEvent(pod);
+    }
+
+    public static PodUpdatedEvent onUpdate(Pod oldPod, Pod newPod, Optional<Node> node) {
+        return new PodUpdatedEvent(oldPod, newPod, node);
+    }
+
+    public static PodDeletedEvent onDelete(Pod pod, boolean deletedFinalStateUnknown, Optional<Node> node) {
+        return new PodDeletedEvent(pod, deletedFinalStateUnknown, node);
+    }
+
+    /*public static PodNotFoundEvent onPodNotFound(Task task, TaskStatus finalTaskStatus) {
+        return new PodNotFoundEvent(task, finalTaskStatus);
+    }*/
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodUpdatedEvent.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/kubernetes/PodUpdatedEvent.java
@@ -1,0 +1,61 @@
+package com.netflix.titus.gateway.kubernetes;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1Pod;
+
+public class PodUpdatedEvent extends PodEvent {
+
+    private final Pod oldPod;
+    private final Optional<Node> node;
+
+    PodUpdatedEvent(Pod oldPod, Pod newPod, Optional<Node> node) {
+        super(newPod);
+        this.oldPod = oldPod;
+        this.node = node;
+    }
+
+    public Pod getOldPod() {
+        return oldPod;
+    }
+
+    public Optional<Node> getNode() {
+        return node;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        PodUpdatedEvent that = (PodUpdatedEvent) o;
+        return Objects.equals(oldPod, that.oldPod) &&
+                Objects.equals(node, that.node);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), oldPod, node);
+    }
+
+    @Override
+    public String toString() {
+        return "PodUpdatedEvent{" +
+                "taskId='" + taskId + '\'' +
+                ", sequenceNumber=" + sequenceNumber +
+                ", pod=" + F8KubeObjectFormatter.formatPodEssentials(pod) +
+                ", oldPod=" + F8KubeObjectFormatter.formatPodEssentials(oldPod) +
+                ", node=" + node.map(n -> n.getMetadata().getName()).orElse("<not_assigned>") +
+                '}';
+    }
+}

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/GatewayJobServiceGateway.java
@@ -66,6 +66,7 @@ import com.netflix.titus.grpc.protogen.TaskQuery;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
 import com.netflix.titus.grpc.protogen.TaskStatus;
 import com.netflix.titus.runtime.connector.GrpcRequestConfiguration;
+import com.netflix.titus.runtime.connector.kubernetes.KubeApiFacade;
 import com.netflix.titus.runtime.endpoint.JobQueryCriteria;
 import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobManagementModelConverters;
 import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobQueryModelConverters;

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjector.java
@@ -63,6 +63,7 @@ class TaskRelocationDataInjector {
     private final RelocationServiceClient relocationServiceClient;
     private final RelocationDataReplicator relocationDataReplicator;
     private final Scheduler scheduler;
+    private final KubeApiConnector kubeApiConnector;
 
     @Inject
     TaskRelocationDataInjector(
@@ -70,8 +71,9 @@ class TaskRelocationDataInjector {
             JobManagerConfiguration jobManagerConfiguration,
             FeatureActivationConfiguration featureActivationConfiguration,
             RelocationServiceClient relocationServiceClient,
-            RelocationDataReplicator relocationDataReplicator) {
-        this(configuration, jobManagerConfiguration, featureActivationConfiguration, relocationServiceClient, relocationDataReplicator, Schedulers.computation());
+            RelocationDataReplicator relocationDataReplicator,
+            KubeApiConnector kubeApiConnector) {
+        this(configuration, jobManagerConfiguration, featureActivationConfiguration, relocationServiceClient, relocationDataReplicator, kubeApiConnector, Schedulers.computation());
     }
 
     @VisibleForTesting
@@ -81,12 +83,14 @@ class TaskRelocationDataInjector {
             FeatureActivationConfiguration featureActivationConfiguration,
             RelocationServiceClient relocationServiceClient,
             RelocationDataReplicator relocationDataReplicator,
+            KubeApiConnector kubeApiConnector,
             Scheduler scheduler) {
         this.configuration = configuration;
         this.jobManagerConfiguration = jobManagerConfiguration;
         this.featureActivationConfiguration = featureActivationConfiguration;
         this.relocationServiceClient = relocationServiceClient;
         this.relocationDataReplicator = relocationDataReplicator;
+        this.kubeApiConnector = kubeApiConnector;
         this.scheduler = scheduler;
     }
 

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjector.java
@@ -56,6 +56,7 @@ class TaskRelocationDataInjector {
      * itself runs on 30sec plan refresh interval.
      */
     private static final long MAX_RELOCATION_DATA_STALENESS_MS = 30_000;
+    private static KubeApiConnector kubeApiConnector;
 
     private final GrpcClientConfiguration configuration;
     private final JobManagerConfiguration jobManagerConfiguration;
@@ -63,7 +64,6 @@ class TaskRelocationDataInjector {
     private final RelocationServiceClient relocationServiceClient;
     private final RelocationDataReplicator relocationDataReplicator;
     private final Scheduler scheduler;
-    private final KubeApiConnector kubeApiConnector;
 
     @Inject
     TaskRelocationDataInjector(
@@ -162,6 +162,10 @@ class TaskRelocationDataInjector {
         return (long) (configuration.getRequestTimeout() * jobManagerConfiguration.getRelocationTimeoutCoefficient());
     }
 
+    static Task newTaskWithContainerState(Task task) {
+        return task.toBuilder().setStatus(TaskStatus.newBuilder()
+                                                .addAllContainerState(kubeApiConnector.getContainerState(task.getId()))).build();
+    }
 
     static Task newTaskWithRelocationPlan(Task task, TaskRelocationPlan relocationPlan) {
         if(relocationPlan == null) {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjector.java
@@ -31,9 +31,11 @@ import com.netflix.titus.api.FeatureActivationConfiguration;
 import com.netflix.titus.api.relocation.model.TaskRelocationPlan;
 import com.netflix.titus.common.util.ExceptionExt;
 import com.netflix.titus.common.util.rx.ReactorExt;
+import com.netflix.titus.gateway.kubernetes.KubeApiConnector;
 import com.netflix.titus.grpc.protogen.MigrationDetails;
 import com.netflix.titus.grpc.protogen.Task;
 import com.netflix.titus.grpc.protogen.TaskQueryResult;
+import com.netflix.titus.grpc.protogen.TaskStatus;
 import com.netflix.titus.runtime.connector.GrpcClientConfiguration;
 import com.netflix.titus.runtime.connector.relocation.RelocationDataReplicator;
 import com.netflix.titus.runtime.connector.relocation.RelocationServiceClient;
@@ -155,6 +157,7 @@ class TaskRelocationDataInjector {
     private long getTaskRelocationTimeout() {
         return (long) (configuration.getRequestTimeout() * jobManagerConfiguration.getRelocationTimeoutCoefficient());
     }
+
 
     static Task newTaskWithRelocationPlan(Task task, TaskRelocationPlan relocationPlan) {
         if(relocationPlan == null) {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGateway.java
@@ -26,14 +26,9 @@ import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.governator.InjectorBuilder;
 import com.netflix.governator.LifecycleInjector;
 import com.netflix.governator.guice.jetty.Archaius2JettyModule;
-import com.netflix.titus.common.runtime.TitusRuntime;
-import com.netflix.titus.common.runtime.TitusRuntimes;
 import com.netflix.titus.common.util.guice.ContainerEventBus;
-import com.netflix.titus.gateway.kubernetes.KubeApiConnector;
-import com.netflix.titus.runtime.connector.kubernetes.Fabric8IOClients;
 import com.sampullara.cli.Args;
 import com.sampullara.cli.Argument;
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGateway.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGateway.java
@@ -33,6 +33,7 @@ import com.netflix.titus.gateway.kubernetes.KubeApiConnector;
 import com.netflix.titus.runtime.connector.kubernetes.Fabric8IOClients;
 import com.sampullara.cli.Args;
 import com.sampullara.cli.Argument;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,14 +52,6 @@ public class TitusGateway {
         }
 
         try {
-            KubeApiConnector kubeApiConnector = new KubeApiConnector(Fabric8IOClients.createFabric8IOClient(), TitusRuntimes.internal());
-            kubeApiConnector.enterActiveMode();
-        } catch (Exception e) {
-            logger.error("Unexpected error: {}", e.getMessage(), e);
-            System.exit(2);
-        }
-
-        try {
             LifecycleInjector injector = InjectorBuilder.fromModules(
                     new TitusGatewayModule(true),
                     new Archaius2JettyModule(),
@@ -72,11 +65,11 @@ public class TitusGateway {
                     }).createInjector();
             injector.getInstance(ContainerEventBus.class).submitInOrder(new ContainerEventBus.ContainerStartedEvent());
             injector.awaitTermination();
-
         } catch (Exception e) {
             logger.error("Unexpected error: {}", e.getMessage(), e);
             System.exit(2);
         }
+
     }
 
     private static MapConfig loadPropertiesFile(String propertiesFile) {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayConfiguration.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayConfiguration.java
@@ -23,4 +23,10 @@ import com.netflix.archaius.api.annotations.DefaultValue;
 public interface TitusGatewayConfiguration {
     @DefaultValue("true")
     boolean isProxyErrorLoggingEnabled();
+
+    /**
+     * Enable shared informer on Titus gateway
+     */
+    @DefaultValue("true")
+    boolean isKubeSharedInformerEnabled();
 }

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayModule.java
@@ -49,6 +49,7 @@ import com.netflix.titus.common.util.guice.ContainerEventBusModule;
 import com.netflix.titus.common.util.jackson.CommonObjectMappers;
 import com.netflix.titus.gateway.endpoint.GatewayEndpointModule;
 import com.netflix.titus.gateway.kubernetes.KubeApiClient;
+import com.netflix.titus.gateway.kubernetes.KubeApiConnector;
 import com.netflix.titus.gateway.service.v3.V3ServiceModule;
 import com.netflix.titus.gateway.store.StoreModule;
 import com.netflix.titus.runtime.FeatureFlagModule;
@@ -100,6 +101,7 @@ public final class TitusGatewayModule extends AbstractModule {
         bind(Registry.class).toInstance(new DefaultRegistry());
         bind(SystemLogService.class).to(LoggingSystemLogService.class);
         bind(SystemAbortListener.class).to(LoggingSystemAbortListener.class);
+        bind(KubeApiConnector.class).asEagerSingleton();
 
         install(new ContainerEventBusModule());
 

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayModule.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/startup/TitusGatewayModule.java
@@ -29,6 +29,7 @@ import com.netflix.titus.api.jobmanager.model.job.LogStorageInfo;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.model.callmetadata.CallMetadataConstants;
+import com.netflix.titus.common.environment.MyEnvironment;
 import com.netflix.titus.common.environment.MyEnvironments;
 import com.netflix.titus.common.runtime.SystemAbortListener;
 import com.netflix.titus.common.runtime.SystemLogService;
@@ -37,6 +38,7 @@ import com.netflix.titus.common.runtime.internal.DefaultTitusRuntime;
 import com.netflix.titus.common.runtime.internal.LoggingSystemAbortListener;
 import com.netflix.titus.common.runtime.internal.LoggingSystemLogService;
 import com.netflix.titus.common.util.archaius2.Archaius2ConfigurationLogger;
+import com.netflix.titus.common.util.archaius2.Archaius2Ext;
 import com.netflix.titus.common.util.code.CodeInvariants;
 import com.netflix.titus.common.util.code.CompositeCodeInvariants;
 import com.netflix.titus.common.util.code.LoggingCodeInvariants;
@@ -44,7 +46,9 @@ import com.netflix.titus.common.util.code.SpectatorCodeInvariants;
 import com.netflix.titus.common.util.grpc.reactor.GrpcToReactorServerFactory;
 import com.netflix.titus.common.util.grpc.reactor.server.DefaultGrpcToReactorServerFactory;
 import com.netflix.titus.common.util.guice.ContainerEventBusModule;
+import com.netflix.titus.common.util.jackson.CommonObjectMappers;
 import com.netflix.titus.gateway.endpoint.GatewayEndpointModule;
+import com.netflix.titus.gateway.kubernetes.KubeApiClient;
 import com.netflix.titus.gateway.service.v3.V3ServiceModule;
 import com.netflix.titus.gateway.store.StoreModule;
 import com.netflix.titus.runtime.FeatureFlagModule;
@@ -53,6 +57,8 @@ import com.netflix.titus.runtime.connector.eviction.EvictionConnectorModule;
 import com.netflix.titus.runtime.connector.jobmanager.JobEventPropagationUtil;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagerConnectorModule;
 import com.netflix.titus.runtime.connector.jobmanager.JobManagerDataReplicationModule;
+import com.netflix.titus.runtime.connector.kubernetes.Fabric8IOClients;
+import com.netflix.titus.runtime.connector.kubernetes.KubeConnectorConfiguration;
 import com.netflix.titus.runtime.connector.registry.TitusContainerRegistryModule;
 import com.netflix.titus.runtime.connector.relocation.RelocationClientConnectorModule;
 import com.netflix.titus.runtime.connector.relocation.RelocationDataReplicationModule;
@@ -61,6 +67,8 @@ import com.netflix.titus.runtime.endpoint.admission.JobSecurityValidatorModule;
 import com.netflix.titus.runtime.endpoint.admission.TitusAdmissionModule;
 import com.netflix.titus.runtime.endpoint.common.EmptyLogStorageInfo;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataResolver;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import org.springframework.context.annotation.Primary;
 
 // Common module dependencies
 // Server dependencies
@@ -142,4 +150,11 @@ public final class TitusGatewayModule extends AbstractModule {
                 () -> callMetadataResolver.resolve().orElse(CallMetadataConstants.UNDEFINED_CALL_METADATA)
         );
     }
+
+    @Provides
+    @Singleton
+    public NamespacedKubernetesClient getFabric8IOClient() {
+        return Fabric8IOClients.createFabric8IOClient();
+    }
+
 }

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjectorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjectorTest.java
@@ -27,6 +27,7 @@ import com.netflix.titus.api.relocation.model.TaskRelocationPlan;
 import com.netflix.titus.api.relocation.model.TaskRelocationPlan.TaskRelocationReason;
 import com.netflix.titus.common.runtime.TitusRuntime;
 import com.netflix.titus.common.runtime.TitusRuntimes;
+import com.netflix.titus.gateway.kubernetes.KubeApiConnector;
 import com.netflix.titus.runtime.connector.relocation.RelocationDataReplicator;
 import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobManagementModelConverters;
 import com.netflix.titus.runtime.jobmanager.JobManagerConfiguration;

--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjectorTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/TaskRelocationDataInjectorTest.java
@@ -69,6 +69,7 @@ public class TaskRelocationDataInjectorTest {
 
     private final RelocationServiceClient relocationServiceClient = mock(RelocationServiceClient.class);
     private final RelocationDataReplicator relocationDataReplicator = mock(RelocationDataReplicator.class);
+    private final KubeApiConnector kubeApiConnector = mock(KubeApiConnector.class);
 
     private final TaskRelocationDataInjector taskRelocationDataInjector = new TaskRelocationDataInjector(
             grpcConfiguration,
@@ -76,6 +77,7 @@ public class TaskRelocationDataInjectorTest {
             featureActivationConfiguration,
             relocationServiceClient,
             relocationDataReplicator,
+            kubeApiConnector,
             testScheduler
     );
 


### PR DESCRIPTION
We need to get container status from pods. The pods information is not available at the gateway layer until we add shared informer. This PR adds shared informer and code to get the container status. The shared informer will be behind a feature flag. 

