### PR TITLE
Emit job/task archive events in the GRPC job event stream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.3-rc.6'
+        titusApiDefinitionsVersion = '0.0.3-rc.9'
 
         springVersion = '5.2.11.RELEASE'
         springSecurityVersion = '5.3.6.RELEASE'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobKeepAliveEvent.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobKeepAliveEvent.java
@@ -31,7 +31,7 @@ public class JobKeepAliveEvent extends JobManagerEvent<Job> {
     private final long timestamp;
 
     JobKeepAliveEvent(long timestamp) {
-        super(Job.newBuilder().build(), Optional.empty(), KEEP_ALIVE_CALL_METADATA);
+        super(Job.newBuilder().build(), Optional.empty(), false, KEEP_ALIVE_CALL_METADATA);
         this.timestamp = timestamp;
     }
 

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobUpdateEvent.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/JobUpdateEvent.java
@@ -18,12 +18,13 @@ package com.netflix.titus.api.jobmanager.model.job.event;
 
 import java.util.Optional;
 
-import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 
 public class JobUpdateEvent extends JobManagerEvent<Job> {
-    private JobUpdateEvent(Job current, Optional<Job> previous, CallMetadata callMetadata) {
-        super(current, previous, callMetadata);
+
+    private JobUpdateEvent(Job current, Optional<Job> previous, boolean archived, CallMetadata callMetadata) {
+        super(current, previous, archived, callMetadata);
     }
 
     @Override
@@ -31,15 +32,20 @@ public class JobUpdateEvent extends JobManagerEvent<Job> {
         return "JobUpdateEvent{" +
                 "current=" + getCurrent() +
                 ", previous=" + getPrevious() +
+                ", archived=" + isArchived() +
                 ", callMetadata" + getCallMetadata() +
                 "}";
     }
 
     public static JobUpdateEvent newJob(Job current, CallMetadata callMetadata) {
-        return new JobUpdateEvent(current, Optional.empty(), callMetadata);
+        return new JobUpdateEvent(current, Optional.empty(), false, callMetadata);
     }
 
     public static JobUpdateEvent jobChange(Job current, Job previous, CallMetadata callMetadata) {
-        return new JobUpdateEvent(current, Optional.of(previous), callMetadata);
+        return new JobUpdateEvent(current, Optional.of(previous), false, callMetadata);
+    }
+
+    public static JobUpdateEvent jobArchived(Job archivedJob, CallMetadata callMetadata) {
+        return new JobUpdateEvent(archivedJob, Optional.empty(), true, callMetadata);
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/TaskUpdateEvent.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/event/TaskUpdateEvent.java
@@ -19,21 +19,21 @@ package com.netflix.titus.api.jobmanager.model.job.event;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.model.callmetadata.CallMetadata;
 
 public class TaskUpdateEvent extends JobManagerEvent<Task> {
 
     private final Job<?> currentJob;
     private final boolean movedFromAnotherJob;
 
-    private TaskUpdateEvent(Job<?> currentJob, Task currentTask, CallMetadata callMetadata, Optional<Task> previousTask) {
-        this(currentJob, currentTask, previousTask, false, callMetadata);
+    private TaskUpdateEvent(Job<?> currentJob, Task currentTask, boolean archived, CallMetadata callMetadata, Optional<Task> previousTask) {
+        this(currentJob, currentTask, previousTask, archived, false, callMetadata);
     }
 
-    private TaskUpdateEvent(Job<?> currentJob, Task currentTask, Optional<Task> previousTask, boolean moved, CallMetadata callMetadata) {
-        super(currentTask, previousTask, callMetadata);
+    private TaskUpdateEvent(Job<?> currentJob, Task currentTask, Optional<Task> previousTask, boolean archived, boolean moved, CallMetadata callMetadata) {
+        super(currentTask, previousTask, archived, callMetadata);
         this.currentJob = currentJob;
         this.movedFromAnotherJob = moved;
     }
@@ -81,19 +81,24 @@ public class TaskUpdateEvent extends JobManagerEvent<Task> {
                 "currentJob=" + currentJob +
                 ", currentTask=" + getCurrent() +
                 ", previousTask=" + getPrevious() +
+                ", archived=" + isArchived() +
                 ", movedFromAnotherJob=" + movedFromAnotherJob +
                 '}';
     }
 
     public static TaskUpdateEvent newTask(Job job, Task current, CallMetadata callMetadata) {
-        return new TaskUpdateEvent(job, current, callMetadata, Optional.empty());
+        return new TaskUpdateEvent(job, current, false, callMetadata, Optional.empty());
     }
 
     public static TaskUpdateEvent newTaskFromAnotherJob(Job job, Task current, CallMetadata callMetadata) {
-        return new TaskUpdateEvent(job, current, Optional.empty(), true, callMetadata);
+        return new TaskUpdateEvent(job, current, Optional.empty(), false, true, callMetadata);
     }
 
     public static TaskUpdateEvent taskChange(Job job, Task current, Task previous, CallMetadata callMetadata) {
-        return new TaskUpdateEvent(job, current, callMetadata, Optional.of(previous));
+        return new TaskUpdateEvent(job, current, false, callMetadata, Optional.of(previous));
+    }
+
+    public static TaskUpdateEvent taskArchived(Job job, Task current, CallMetadata callMetadata) {
+        return new TaskUpdateEvent(job, current, true, callMetadata, Optional.empty());
     }
 }

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/V3JobOperations.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/V3JobOperations.java
@@ -40,6 +40,7 @@ public interface V3JobOperations extends ReadOnlyJobOperations {
         API,
         ComputeProvider,
         Reconciler,
+        ReconcilerServiceTaskRemoved,
         Scheduler,
         TaskMigration,
         Eviction,

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobConnectorConfiguration.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobConnectorConfiguration.java
@@ -37,7 +37,7 @@ public interface JobConnectorConfiguration {
     /**
      * Enable {@link JobDataReplicator} with the server side keep alive mechanism. Use only in TitusGateway.
      */
-    @DefaultValue("true")
+    @DefaultValue("false")
     boolean isKeepAliveReplicatedStreamEnabled();
 
     /**

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagerConnectorModule.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/JobManagerConnectorModule.java
@@ -73,7 +73,12 @@ public class JobManagerConnectorModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public JobSnapshotFactory getJobSnapshotFactory(TitusRuntime titusRuntime) {
-        return JobSnapshotFactories.newDefault(titusRuntime);
+    public JobSnapshotFactory getJobSnapshotFactory(JobConnectorConfiguration configuration,
+                                                    TitusRuntime titusRuntime) {
+        return JobSnapshotFactories.newDefault(false,
+                configuration.isKeepAliveReplicatedStreamEnabled(),
+                error -> titusRuntime.getCodeInvariants().inconsistent(error),
+                titusRuntime
+        );
     }
 }

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/RemoteJobManagementClient.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/RemoteJobManagementClient.java
@@ -203,6 +203,11 @@ public class RemoteJobManagementClient implements JobManagementClient {
 
                                 Job oldJob = jobMap.get(newJob.getId());
                                 jobMap.put(newJob.getId(), newJob);
+
+                                if (event.getJobUpdate().getArchived()) {
+                                    return JobUpdateEvent.jobArchived(newJob, JobManagerConstants.GRPC_REPLICATOR_CALL_METADATA);
+                                }
+
                                 return oldJob == null
                                         ? JobUpdateEvent.newJob(newJob, JobManagerConstants.GRPC_REPLICATOR_CALL_METADATA)
                                         : JobUpdateEvent.jobChange(newJob, oldJob, JobManagerConstants.GRPC_REPLICATOR_CALL_METADATA);
@@ -222,6 +227,9 @@ public class RemoteJobManagementClient implements JobManagementClient {
                                 // Check if task moved
                                 if (isTaskMoved(newTask, oldTask)) {
                                     return TaskUpdateEvent.newTaskFromAnotherJob(job, newTask, JobManagerConstants.GRPC_REPLICATOR_CALL_METADATA);
+                                }
+                                if (event.getTaskUpdate().getArchived()) {
+                                    return TaskUpdateEvent.taskArchived(job, newTask, JobManagerConstants.GRPC_REPLICATOR_CALL_METADATA);
                                 }
 
                                 return oldTask == null

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/CachedJob.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/CachedJob.java
@@ -61,9 +61,9 @@ abstract class CachedJob {
 
     public abstract Optional<JobSnapshot> removeTask(PCollectionJobSnapshot snapshot, Task task);
 
-    public static CachedJob newInstance(Job<?> job, PMap<String, Task> tasks, TitusRuntime titusRuntime) {
+    public static CachedJob newInstance(Job<?> job, PMap<String, Task> tasks, boolean archiveMode, TitusRuntime titusRuntime) {
         if (JobFunctions.isServiceJob(job)) {
-            return CachedServiceJob.newServiceInstance(job, tasks, titusRuntime);
+            return CachedServiceJob.newServiceInstance(job, tasks, archiveMode, titusRuntime);
         }
         int size = JobFunctions.getJobDesiredSize(job);
         if (size == 1) {

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/JobSnapshot.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/JobSnapshot.java
@@ -74,5 +74,9 @@ public abstract class JobSnapshot extends ReplicatedSnapshot {
 
     public abstract Optional<JobSnapshot> updateJob(Job<?> job);
 
+    public abstract Optional<JobSnapshot> removeArchivedJob(Job<?> job);
+
     public abstract Optional<JobSnapshot> updateTask(Task task, boolean moved);
+
+    public abstract Optional<JobSnapshot> removeArchivedTask(Task task);
 }

--- a/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/JobSnapshotFactories.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/JobSnapshotFactories.java
@@ -29,10 +29,11 @@ public final class JobSnapshotFactories {
 
     /**
      * Default {@link JobSnapshotFactory} throws an exception if inconsistent state is detected.
-     * Use {@link #newDefault(boolean, Consumer, TitusRuntime)} to change this behavior.
+     * Use {@link #newDefault(boolean, boolean, Consumer, TitusRuntime)} to change this behavior.
      */
     public static JobSnapshotFactory newDefault(TitusRuntime titusRuntime) {
         return new PCollectionJobSnapshotFactory(
+                false,
                 false,
                 message -> {
                 },
@@ -48,21 +49,25 @@ public final class JobSnapshotFactories {
     }
 
     public static JobSnapshotFactory newDefault(boolean autoFixInconsistencies,
+                                                boolean archiveMode,
                                                 Consumer<String> inconsistentDataListener,
                                                 TitusRuntime titusRuntime) {
-        return new PCollectionJobSnapshotFactory(autoFixInconsistencies, inconsistentDataListener, titusRuntime);
+        return new PCollectionJobSnapshotFactory(autoFixInconsistencies, archiveMode, inconsistentDataListener, titusRuntime);
     }
 
     private static class PCollectionJobSnapshotFactory implements JobSnapshotFactory {
 
         private final boolean autoFixInconsistencies;
+        private final boolean archiveMode;
         private final Consumer<String> inconsistentDataListener;
         private final TitusRuntime titusRuntime;
 
         private PCollectionJobSnapshotFactory(boolean autoFixInconsistencies,
+                                              boolean archiveMode,
                                               Consumer<String> inconsistentDataListener,
                                               TitusRuntime titusRuntime) {
             this.autoFixInconsistencies = autoFixInconsistencies;
+            this.archiveMode = archiveMode;
             this.inconsistentDataListener = inconsistentDataListener;
             this.titusRuntime = titusRuntime;
         }
@@ -74,6 +79,7 @@ public final class JobSnapshotFactories {
                     jobsById,
                     tasksByJobId,
                     autoFixInconsistencies,
+                    archiveMode,
                     inconsistentDataListener,
                     titusRuntime
             );

--- a/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
+++ b/titus-client/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/GrpcJobManagementModelConverters.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -1379,6 +1378,7 @@ public final class GrpcJobManagementModelConverters {
             return JobChangeNotification.newBuilder()
                     .setJobUpdate(JobChangeNotification.JobUpdate.newBuilder()
                             .setJob(grpcObjectsCache.getJob(jobUpdateEvent.getCurrent()))
+                            .setArchived(event.isArchived())
                     )
                     .setTimestamp(now)
                     .build();
@@ -1389,6 +1389,7 @@ public final class GrpcJobManagementModelConverters {
                     .setTaskUpdate(
                             JobChangeNotification.TaskUpdate.newBuilder()
                                     .setTask(grpcObjectsCache.getTask(taskUpdateEvent.getCurrent()))
+                                    .setArchived(event.isArchived())
                                     .setMovedFromAnotherJob(taskUpdateEvent.isMovedFromAnotherJob())
                     )
                     .setTimestamp(now)

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/replicator/GrpcJobReplicatorEventStreamTest.java
@@ -258,7 +258,7 @@ public class GrpcJobReplicatorEventStreamTest {
         Job<?> finishedJob = JobFunctions.changeJobStatus(acceptedJob, JobStatus.newBuilder().withState(JobState.Finished).build());
         Task finishedTask = JobFunctions.changeTaskStatus(acceptedTask, TaskStatus.newBuilder().withState(TaskState.Finished).build());
 
-        CacheUpdater cacheUpdater = new CacheUpdater(JobSnapshotFactories.newDefault(titusRuntime), titusRuntime);
+        CacheUpdater cacheUpdater = new CacheUpdater(JobSnapshotFactories.newDefault(titusRuntime), false, titusRuntime);
         assertThat(cacheUpdater.onEvent(JobUpdateEvent.newJob(acceptedJob, CallMetadataConstants.UNDEFINED_CALL_METADATA))).isEmpty();
         assertThat(cacheUpdater.onEvent(TaskUpdateEvent.newTask(acceptedJob, acceptedTask, CallMetadataConstants.UNDEFINED_CALL_METADATA))).isEmpty();
         assertThat(cacheUpdater.onEvent(TaskUpdateEvent.taskChange(acceptedJob, finishedTask, acceptedTask, CallMetadataConstants.UNDEFINED_CALL_METADATA))).isEmpty();

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/CachedBatchJobTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/CachedBatchJobTest.java
@@ -138,9 +138,10 @@ public class CachedBatchJobTest {
             }
         }
 
-        PCollectionJobSnapshot snapshot = (PCollectionJobSnapshot) PCollectionJobSnapshot.newInstance("test",
+        PCollectionJobSnapshot snapshot = PCollectionJobSnapshot.newInstance("test",
                 Collections.singletonMap(job.getId(), job),
                 Collections.singletonMap(job.getId(), tasks),
+                false,
                 false,
                 error -> {
                     throw new IllegalStateException(error);

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/CachedBatchJobWithOneTaskTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/CachedBatchJobWithOneTaskTest.java
@@ -138,6 +138,7 @@ public class CachedBatchJobWithOneTaskTest {
                 Collections.singletonMap(job.getId(), job),
                 Collections.singletonMap(job.getId(), create ? Collections.singletonMap(task.getId(), task) : Collections.emptyMap()),
                 false,
+                false,
                 error -> {
                     throw new IllegalStateException(error);
                 },

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/JobSnapshotPerf.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/JobSnapshotPerf.java
@@ -74,7 +74,7 @@ public class JobSnapshotPerf {
             jobAndTasks = jobAndTasks.plus(Pair.of(job, HashTreePMap.from(tasks)));
         }
         this.snapshot = PCollectionJobSnapshot.newInstance(
-                "test", jobs, taskByJobId, false, message -> {
+                "test", jobs, taskByJobId, false, false, message -> {
                 },
                 titusRuntime
         );

--- a/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/PCollectionJobSnapshotTest.java
+++ b/titus-client/src/test/java/com/netflix/titus/runtime/connector/jobmanager/snapshot/PCollectionJobSnapshotTest.java
@@ -68,6 +68,6 @@ public class PCollectionJobSnapshotTest {
     }
 
     private JobSnapshotFactory newFactory(boolean autoFix) {
-        return JobSnapshotFactories.newDefault(autoFix, inconsistenciesReports::add, titusRuntime);
+        return JobSnapshotFactories.newDefault(autoFix, false, inconsistenciesReports::add, titusRuntime);
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/DefaultJobManagementServiceGrpc.java
@@ -601,12 +601,12 @@ public class DefaultJobManagementServiceGrpc extends JobManagementServiceGrpc.Jo
 
     @Override
     public void observeJobs(ObserveJobsQuery query, StreamObserver<JobChangeNotification> responseObserver) {
-        new ObserveJobsSubscription(eventProcessingContext).observeJobs(query, responseObserver);
+        new ObserveJobsSubscription(eventProcessingContext, false).observeJobs(query, responseObserver);
     }
 
     @Override
     public StreamObserver<ObserveJobsWithKeepAliveRequest> observeJobsWithKeepAlive(StreamObserver<JobChangeNotification> responseObserver) {
-        return new ObserveJobsSubscription(eventProcessingContext).observeJobsWithKeepAlive(responseObserver);
+        return new ObserveJobsSubscription(eventProcessingContext, true).observeJobsWithKeepAlive(responseObserver);
     }
 
     @Override

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -758,7 +758,7 @@ public class DefaultV3JobOperations implements V3JobOperations {
             }
 
             // A task is archived at the same time as its replacement is created. We store the finished task which the
-            // new one replaces in the EntityHolder attribute `CreateOrReplaceBatchTaskActions.ATTR_REPLACEMENT_OF`.
+            // new one replaces in the EntityHolder attribute `JobEntityHolders.ATTR_REPLACEMENT_OF`.
             Task archivedTask = (Task) modelUpdateEvent.getChangedEntityHolder().getAttributes().get(JobEntityHolders.ATTR_REPLACEMENT_OF);
             if (archivedTask == null) {
                 return Collections.singletonList(toNewTaskUpdateEvent(job, changed, modelUpdateEvent.getCallMetadata()));

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/JobEntityHolders.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/JobEntityHolders.java
@@ -32,6 +32,8 @@ import rx.Observable;
  */
 public final class JobEntityHolders {
 
+    public static final String ATTR_REPLACEMENT_OF = "replacementOf";
+
     public static Optional<EntityHolder> expectTaskHolder(ReconciliationEngine<JobManagerReconcilerEvent> engine, String taskId, TitusRuntime titusRuntime) {
         Optional<EntityHolder> taskHolder = engine.getReferenceView().findById(taskId);
         if (taskHolder.isPresent()) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/TitusChangeAction.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/TitusChangeAction.java
@@ -18,6 +18,7 @@ package com.netflix.titus.master.jobmanager.service.common.action;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import com.google.common.base.Preconditions;
@@ -32,6 +33,7 @@ import com.netflix.titus.common.framework.reconciler.ModelActionHolder;
 import rx.Observable;
 
 /**
+ *
  */
 public abstract class TitusChangeAction implements ChangeAction {
 
@@ -41,6 +43,7 @@ public abstract class TitusChangeAction implements ChangeAction {
 
     private final V3JobOperations.Trigger trigger;
     private final String id;
+    private final Optional<Task> task;
     private final String name;
     private final String summary;
     private final CallMetadata callMetadata;
@@ -48,14 +51,16 @@ public abstract class TitusChangeAction implements ChangeAction {
     protected TitusChangeAction(TitusChangeAction delegate) {
         this.trigger = delegate.getTrigger();
         this.id = delegate.getId();
+        this.task = delegate.getTask();
         this.name = delegate.getName();
         this.summary = delegate.getSummary();
         this.callMetadata = delegate.getCallMetadata();
     }
 
-    public TitusChangeAction(Trigger trigger, String id, String name, String summary, CallMetadata callMetadata) {
+    public TitusChangeAction(Trigger trigger, String id, Task task, String name, String summary, CallMetadata callMetadata) {
         this.trigger = trigger;
         this.id = id;
+        this.task = Optional.ofNullable(task);
         this.name = name;
         this.summary = summary;
         this.callMetadata = callMetadata == null ? NOT_SET_CALLMETADATA : callMetadata;
@@ -67,6 +72,10 @@ public abstract class TitusChangeAction implements ChangeAction {
 
     public String getId() {
         return id;
+    }
+
+    public Optional<Task> getTask() {
+        return task;
     }
 
     public String getName() {
@@ -97,6 +106,7 @@ public abstract class TitusChangeAction implements ChangeAction {
 
         final String name;
         String id;
+        Task task;
         String summary = "None";
         Trigger trigger;
         CallMetadata callMetadata;
@@ -117,6 +127,7 @@ public abstract class TitusChangeAction implements ChangeAction {
 
         public Builder task(Task task) {
             this.id = task.getId();
+            this.task = task;
             return this;
         }
 
@@ -137,7 +148,7 @@ public abstract class TitusChangeAction implements ChangeAction {
 
         public TitusChangeAction changeWithModelUpdate(Function<Builder, Observable<ModelActionHolder>> actionFun) {
             check();
-            return new TitusChangeAction(trigger, id, name, summary, callMetadata) {
+            return new TitusChangeAction(trigger, id, task, name, summary, callMetadata) {
                 @Override
                 public Observable<List<ModelActionHolder>> apply() {
                     return actionFun.apply(Builder.this).map(Collections::singletonList);
@@ -147,7 +158,7 @@ public abstract class TitusChangeAction implements ChangeAction {
 
         public TitusChangeAction changeWithModelUpdates(Function<Builder, Observable<List<ModelActionHolder>>> actionFun) {
             check();
-            return new TitusChangeAction(trigger, id, name, summary, callMetadata) {
+            return new TitusChangeAction(trigger, id, task, name, summary, callMetadata) {
                 @Override
                 public Observable<List<ModelActionHolder>> apply() {
                     return actionFun.apply(Builder.this);
@@ -157,7 +168,7 @@ public abstract class TitusChangeAction implements ChangeAction {
 
         public TitusChangeAction applyModelUpdate(Function<Builder, ModelActionHolder> actionFun) {
             check();
-            return new TitusChangeAction(trigger, id, name, summary, callMetadata) {
+            return new TitusChangeAction(trigger, id, task, name, summary, callMetadata) {
                 @Override
                 public Observable<List<ModelActionHolder>> apply() {
                     return Observable.fromCallable(() -> actionFun.apply(Builder.this)).map(Collections::singletonList);
@@ -167,7 +178,7 @@ public abstract class TitusChangeAction implements ChangeAction {
 
         public TitusChangeAction applyModelUpdates(Function<Builder, List<ModelActionHolder>> actionFun) {
             check();
-            return new TitusChangeAction(trigger, id, name, summary, callMetadata) {
+            return new TitusChangeAction(trigger, id, task, name, summary, callMetadata) {
                 @Override
                 public Observable<List<ModelActionHolder>> apply() {
                     return Observable.fromCallable(() -> actionFun.apply(Builder.this));

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/task/BasicJobActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/common/action/task/BasicJobActions.java
@@ -41,7 +41,7 @@ import rx.Observable;
 
 public class BasicJobActions {
 
-    private static final String ATTR_JOB_CLOSED = "job.closed";
+    public static final String ATTR_JOB_CLOSED = "job.closed";
 
     /**
      * Write an updated job record to a store. This command calls {@link JobStore#updateJob(Job)}, which assumes

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/event/JobModelReconcilerEvent.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/event/JobModelReconcilerEvent.java
@@ -25,6 +25,8 @@ import com.netflix.titus.common.framework.reconciler.EntityHolder;
 import com.netflix.titus.common.framework.reconciler.ModelActionHolder;
 import com.netflix.titus.master.jobmanager.service.common.action.TitusChangeAction;
 
+import static com.netflix.titus.master.jobmanager.service.common.action.task.BasicJobActions.ATTR_JOB_CLOSED;
+
 public abstract class JobModelReconcilerEvent extends JobManagerReconcilerEvent {
 
     protected JobModelReconcilerEvent(Job<?> job, String transactionId, CallMetadata callMetadata) {
@@ -50,6 +52,7 @@ public abstract class JobModelReconcilerEvent extends JobManagerReconcilerEvent 
         private final ModelActionHolder modelActionHolder;
         private final EntityHolder changedEntityHolder;
         private final Optional<EntityHolder> previousEntityHolder;
+        private final boolean archived;
 
         public JobModelUpdateReconcilerEvent(Job<?> job,
                                              TitusChangeAction changeAction,
@@ -62,6 +65,13 @@ public abstract class JobModelReconcilerEvent extends JobManagerReconcilerEvent 
             this.modelActionHolder = modelActionHolder;
             this.changedEntityHolder = changedEntityHolder;
             this.previousEntityHolder = previousEntityHolder;
+
+            if (changedEntityHolder.getEntity() instanceof Job) {
+                Boolean closed = (Boolean) changedEntityHolder.getAttributes().get(ATTR_JOB_CLOSED);
+                this.archived = closed != null && closed;
+            } else {
+                this.archived = false;
+            }
         }
 
         public TitusChangeAction getChangeAction() {
@@ -78,6 +88,10 @@ public abstract class JobModelReconcilerEvent extends JobManagerReconcilerEvent 
 
         public Optional<EntityHolder> getPreviousEntityHolder() {
             return previousEntityHolder;
+        }
+
+        public boolean isArchived() {
+            return archived;
         }
     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceTaskActions.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/service/action/BasicServiceTaskActions.java
@@ -32,7 +32,7 @@ public final class BasicServiceTaskActions {
     public static TitusChangeAction removeFinishedServiceTaskAction(JobStore jobStore, ServiceJobTask task) {
         return TitusChangeAction.newAction("removeFinishedServiceTaskAction")
                 .task(task)
-                .trigger(Trigger.Reconciler)
+                .trigger(Trigger.ReconcilerServiceTaskRemoved)
                 .summary("Removing completed task from reconciler")
                 .changeWithModelUpdates(self ->
                         jobStore.deleteTask(task).andThen(

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/SampleTitusChangeActions.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/SampleTitusChangeActions.java
@@ -45,7 +45,7 @@ public final class SampleTitusChangeActions {
     private static class SuccessfulChangeAction extends TitusChangeAction {
 
         private SuccessfulChangeAction(Trigger trigger, String id) {
-            super(trigger, id, "simulatedChangeAction", "Simulated successful action", TEST_CALLMETADATA);
+            super(trigger, id, null, "simulatedChangeAction", "Simulated successful action", TEST_CALLMETADATA);
         }
 
         @Override
@@ -59,7 +59,7 @@ public final class SampleTitusChangeActions {
         private final AtomicInteger failureCounter;
 
         protected FailingChangeAction(Trigger trigger, String id, int failureCount) {
-            super(trigger, id, "simulatedFailingAction", "Simulated initial failure repeated " + failureCount + " times", TEST_CALLMETADATA);
+            super(trigger, id, null, "simulatedFailingAction", "Simulated initial failure repeated " + failureCount + " times", TEST_CALLMETADATA);
             this.failureCounter = new AtomicInteger(failureCount);
         }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscriptionTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/endpoint/v3/grpc/ObserveJobsSubscriptionTest.java
@@ -69,7 +69,7 @@ public class ObserveJobsSubscriptionTest {
             titusRuntime
     );
 
-    private final ObserveJobsSubscription jobsSubscription = new ObserveJobsSubscription(context);
+    private final ObserveJobsSubscription jobsSubscription = new ObserveJobsSubscription(context, true);
 
     private StreamObserver<JobChangeNotification> responseStreamObserver;
     private final BlockingQueue<JobChangeNotification> responseEvents = new LinkedBlockingDeque<>();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/JobSchedulingCommonTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/JobSchedulingCommonTest.java
@@ -70,8 +70,8 @@ public class JobSchedulingCommonTest {
     }
 
     /**
-     * This test covers the case where a task is created in store, but not added to Fenzo yet, and the job while in this
-     * state is terminated.
+     * This test covers the case where a task is created in store, but not added to the compute provider yet, and
+     * the job while in this state is terminated.
      */
     private void testJobWithTaskInAcceptedStateNotScheduledYet(JobDescriptor<?> oneTaskJobDescriptor) {
         jobsScenarioBuilder.scheduleJob(oneTaskJobDescriptor, jobScenario -> jobScenario

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/ServiceJobSchedulingTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/ServiceJobSchedulingTest.java
@@ -234,6 +234,7 @@ public class ServiceJobSchedulingTest {
                 .expectTaskStateChangeEvent(0, 0, TaskState.Finished, TaskStatus.REASON_TASK_KILLED)
                 .expectTaskUpdatedInStore(0, 0, task -> assertThat(task.getStatus().getState()).isEqualTo(TaskState.Finished))
                 .expectedTaskArchivedInStore(0, 0)
+                .expectArchivedTaskEvent(0, 0)
                 .advance()
                 .advance()
                 .expectNoTaskStateChangeEvent()

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobScenarioBuilder.java
@@ -414,6 +414,16 @@ public class JobScenarioBuilder {
         return taskUpdateEvent;
     }
 
+    public JobScenarioBuilder expectArchivedTaskEvent(int taskIdx, int resubmit) {
+        JobManagerEvent<?> event = autoAdvance(() -> jobEventsSubscriber.takeNextTaskEvent(taskIdx, resubmit));
+        assertThat(event).isNotNull();
+        assertThat(event).isInstanceOf(TaskUpdateEvent.class);
+
+        TaskUpdateEvent taskUpdateEvent = (TaskUpdateEvent) event;
+        assertThat(taskUpdateEvent.isArchived()).isTrue();
+        return this;
+    }
+
     public JobScenarioBuilder expectTaskEvent(int taskIdx, int resubmit, Consumer<TaskUpdateEvent> validator) {
         TaskUpdateEvent event = expectTaskEvent(taskIdx, resubmit);
         validator.accept(event);
@@ -674,6 +684,10 @@ public class JobScenarioBuilder {
             advance();
         }
         action.run();
+    }
+
+    Job getJob() {
+        return jobOperations.getJob(jobId).orElseThrow(() -> new IllegalArgumentException("Job not found: " + jobId));
     }
 
     /**


### PR DESCRIPTION
This change extends the job GRPC event stream by the job/task archive events. These events are only emitted by `ObserveJobsWithKeepAlive` endpoint for backward compatibility (and because they are meant for the internal consumption only).