### PR TITLE
v1 pod schema: Handle multiple complex efs volumes

### DIFF
--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -49,7 +49,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -i build --max-workers 4 --stacktrace
+        run: ./gradlew build --max-workers 4 --stacktrace
   integrationTestExcludeMaster:
     if: |
       github.event_name == 'pull_request' ||
@@ -119,7 +119,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -i -PintegrationTestScope=onlyMaster1 integrationTest
+        run: ./gradlew -PintegrationTestScope=onlyMaster1 integrationTest
   integrationTestMaster2:
     if: |
       github.event_name == 'pull_request' ||
@@ -154,7 +154,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -i -PintegrationTestScope=onlyMaster2 integrationTest
+        run: ./gradlew -PintegrationTestScope=onlyMaster2 integrationTest
   integrationTestMaster3:
     if: |
       github.event_name == 'pull_request' ||
@@ -189,7 +189,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -i -PintegrationTestScope=onlyMaster3 integrationTest
+        run: ./gradlew -PintegrationTestScope=onlyMaster3 integrationTest
   integrationTestNonParallelizable:
     if: |
       github.event_name == 'pull_request' ||
@@ -224,7 +224,7 @@ jobs:
       - name: docker test
         run: docker --help
       - name: Gradle build
-        run: ./gradlew -i integrationNotParallelizableTest
+        run: ./gradlew integrationNotParallelizableTest
   publish:
     if: |
       github.event_name != 'pull_request' &&

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -539,7 +539,8 @@ public class V1SpecPodFactory implements PodFactory {
 
             V1VolumeMount volumeMount = new V1VolumeMount()
                     .name(name)
-                    .mountPath(efsMountPoint);
+                    .mountPath(efsMountPoint)
+                    .readOnly(readOnly);
             container.addVolumeMountsItem(volumeMount);
 
             // We can't have duplicate volumes in here. In theory there should be a many:one mapping between
@@ -549,7 +550,7 @@ public class V1SpecPodFactory implements PodFactory {
             if (!allNames.contains(name)) {
                 V1NFSVolumeSource nfsVolumeSource = new V1NFSVolumeSource()
                         .server(efsIdToNFSServer(efsId))
-                        .readOnly(readOnly);
+                        .readOnly(false);
                 // "path" here represents the server-side relative mount path, sometimes called
                 // the "exported directory", and goes into the v1 Volume
                 nfsVolumeSource.setPath(efsRelativeMountPoint);


### PR DESCRIPTION
Previously, we did not handle the case where we had
multiple volumes with a mix of RO/RW on the same source.

This change makes it so we always put the burden of RW/RO
on the volume *mount* (not the volume), and re-use the
volume itself (always RW, doesn't really matter too much).
