### PR TITLE
Enable IPv6 Only containers

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -134,7 +134,8 @@ public final class JobManagerUtil {
                     // a unique IP for that pod, but a shared one. This should not be consumed
                     // as a normal ip by normal tools, and deserves a special attribute
                     contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_TRANSITION_IPV4, ipv4);
-                } else {
+                } else if (!networkConfiguration.getNetworkMode().equals(NetworkMode.Ipv6Only.toString())) {
+                    // Only in the case of non IPv6-only mode do we want to set this attribute
                     contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV4, ipv4);
                 }
                 contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, primaryIP);


### PR DESCRIPTION
99% of the work needed to make ipv6-only containers has
either already been done, or is on the executor side.

This is the only place I found in the CP codebase that
assumes there is an IPv4 ready on every container.
