### PR TITLE
Added SaaSVolume support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.3-rc.10'
+        titusApiDefinitionsVersion = '0.0.3-rc.15'
 
         springVersion = '5.2.11.RELEASE'
         springSecurityVersion = '5.3.6.RELEASE'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/volume/SaaSVolumeSource.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/volume/SaaSVolumeSource.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job.volume;
+
+import java.util.Objects;
+import javax.validation.Valid;
+
+public class SaaSVolumeSource extends VolumeSource {
+
+    @Valid
+    private final String saaSVolumeID;
+
+    public SaaSVolumeSource(String saaSVolumeID) {
+        this.saaSVolumeID = saaSVolumeID;
+    }
+
+    public static SaaSVolumeSource.Builder newBuilder() {
+        return new SaaSVolumeSource.Builder();
+    }
+
+    public static SaaSVolumeSource.Builder newBuilder(SaaSVolumeSource saaSVolumeSource) {
+        return new SaaSVolumeSource.Builder()
+                .withSaaSVolumeID(saaSVolumeSource.saaSVolumeID);
+    }
+
+    public String getSaaSVolumeID() {
+        return saaSVolumeID;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SaaSVolumeSource that = (SaaSVolumeSource) o;
+        return Objects.equals(saaSVolumeID, that.saaSVolumeID);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(saaSVolumeID);
+    }
+
+    @Override
+    public String toString() {
+        return "SaaSVolumeSource{" +
+                "SaaSVolumeID='" + saaSVolumeID + '\'' +
+                '}';
+    }
+
+    public static final class Builder<E extends VolumeSource> {
+        private String saaSVolumeID;
+
+        public SaaSVolumeSource.Builder<E> withSaaSVolumeID(String saaSVolumeID) {
+            this.saaSVolumeID = saaSVolumeID;
+            return this;
+        }
+
+        public SaaSVolumeSource build() {
+            return new SaaSVolumeSource(
+                    saaSVolumeID
+            );
+        }
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/volume/SharedContainerVolumeSource.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/volume/SharedContainerVolumeSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.titus.api.jobmanager.model.job.volume;
 
 import javax.validation.Valid;

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/SaaSVolumeSourceMixin.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/store/mixin/SaaSVolumeSourceMixin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.store.mixin;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SaaSVolumeSourceMixin {
+    @JsonCreator
+    public SaaSVolumeSourceMixin(
+            @JsonProperty("saaSVolumeID") String saaSVolumeID
+    ) {
+    }
+}

--- a/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/json/ObjectMappers.java
@@ -85,6 +85,7 @@ import com.netflix.titus.api.jobmanager.model.job.retry.DelayedRetryPolicy;
 import com.netflix.titus.api.jobmanager.model.job.retry.ExponentialBackoffRetryPolicy;
 import com.netflix.titus.api.jobmanager.model.job.retry.ImmediateRetryPolicy;
 import com.netflix.titus.api.jobmanager.model.job.retry.RetryPolicy;
+import com.netflix.titus.api.jobmanager.model.job.volume.SaaSVolumeSource;
 import com.netflix.titus.api.jobmanager.model.job.volume.SharedContainerVolumeSource;
 import com.netflix.titus.api.jobmanager.model.job.volume.Volume;
 import com.netflix.titus.api.jobmanager.model.job.volume.VolumeSource;
@@ -125,6 +126,7 @@ import com.netflix.titus.api.jobmanager.store.mixin.RatePerIntervalDisruptionBud
 import com.netflix.titus.api.jobmanager.store.mixin.RatePercentagePerIntervalDisruptionBudgetRateMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.RelocationLimitDisruptionBudgetPolicyMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.RetryPolicyMixin;
+import com.netflix.titus.api.jobmanager.store.mixin.SaaSVolumeSourceMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.SecurityProfileMixin;
 import com.netflix.titus.api.jobmanager.store.mixin.SelfManagedDisruptionBudgetPolicyMixIn;
 import com.netflix.titus.api.jobmanager.store.mixin.SelfManagedMigrationPolicyMixin;
@@ -268,6 +270,7 @@ public class ObjectMappers {
         objectMapper.addMixIn(VolumeMount.class, VolumeMountMixin.class);
         objectMapper.addMixIn(VolumeSource.class, VolumeSourceMixin.class);
         objectMapper.addMixIn(SharedContainerVolumeSource.class, SharedContainerVolumeSourceMixin.class);
+        objectMapper.addMixIn(SaaSVolumeSource.class, SaaSVolumeSourceMixin.class);
         objectMapper.addMixIn(PlatformSidecar.class, PlatformSidecarMixin.class);
 
         objectMapper.addMixIn(IpAddressLocation.class, IpAddressLocationMixin.class);


### PR DESCRIPTION
This adds support for a new SaaS Volume type.
It only has the 1 string to worry about, the ID.

On the backend (TJC), pods are created using the Ceph
volume type, with the ID as the path.