### PR TITLE
Call remote federation for ObserveJob(s) when enabled

### DIFF
--- a/titus-server-federation/src/main/java/com/netflix/titus/federation/service/FallbackJobServiceGateway.java
+++ b/titus-server-federation/src/main/java/com/netflix/titus/federation/service/FallbackJobServiceGateway.java
@@ -145,17 +145,21 @@ public class FallbackJobServiceGateway implements JobServiceGateway {
 
     @Override
     public Observable<JobChangeNotification> observeJob(String jobId, CallMetadata callMetadata) {
-        // TODO: Direct stream APIs to the remote (primary) JobServiceGateway.
-        // A failure in a stream which is in progress on the primary falling back to the secondary
-        // is not the right behavior.
+        // Fallback is not applicable to streaming APIs.
+        if (federationConfiguration.isRemoteFederationEnabled()) {
+            return primary.observeJob(jobId, callMetadata);
+        }
+
         return secondary.observeJob(jobId, callMetadata);
     }
 
     @Override
     public Observable<JobChangeNotification> observeJobs(ObserveJobsQuery query, CallMetadata callMetadata) {
-        // TODO: Direct stream APIs to the remote (primary) JobServiceGateway.
-        // A failure in a stream which is in progress on the primary falling back to the secondary
-        // is not the right behavior.
+        // Fallback is not applicable to streaming APIs.
+        if (federationConfiguration.isRemoteFederationEnabled()) {
+            return primary.observeJobs(query, callMetadata);
+        }
+
         return secondary.observeJobs(query, callMetadata);
     }
 


### PR DESCRIPTION
Fallback is not applicable to streaming api calls like ObserveJob(s).  So we call the `RemoteJobServiceGateway` when enabled and the original `AggregatingJobServiceGateway` when disabled.  Failure is just a failure and we do not attempt to fallback.