### PR TITLE
Added container image tag to v1 pod schema pods

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
@@ -135,6 +135,7 @@ public final class KubePodConstants {
     public static final String POD_SCHED_POLICY = "pod.netflix.com/sched-policy";
     public static final String POD_SECCOMP_AGENT_NET_ENABLED = "pod.netflix.com/seccomp-agent-net-enabled";
     public static final String POD_SECCOMP_AGENT_PERF_ENABLED = "pod.netflix.com/seccomp-agent-perf-enabled";
+    public static final String POD_IMAGE_TAG_PREFIX = "pod.titus.netflix.com/image-tag-";
 
     // Container Logging Config
     public static final String LOG_KEEP_LOCAL_FILE = "log.netflix.com/keep-local-file-after-upload";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -129,6 +129,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.NEVER_RES
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.POD_CPU_BURSTING_ENABLED;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.POD_FUSE_ENABLED;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.POD_HOSTNAME_STYLE;
+import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.POD_IMAGE_TAG_PREFIX;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.POD_SCHED_POLICY;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.POD_SCHEMA_VERSION;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.POD_SECCOMP_AGENT_NET_ENABLED;
@@ -206,6 +207,10 @@ public class V1SpecPodFactory implements PodFactory {
         Map<String, String> labels = new HashMap<>();
         labels.put("v3.job.titus.netflix.com/job-id", job.getId());
         labels.put("v3.job.titus.netflix.com/task-id", taskId);
+
+        // A V1Container has no room to store the original tag that the Image came from, so we store it as an
+        // annotation. Only saving the 'main' one for now.
+        annotations.put(POD_IMAGE_TAG_PREFIX + "main", job.getJobDescriptor().getContainer().getImage().getTag());
 
         JobDescriptor<?> jobDescriptor = job.getJobDescriptor();
         String capacityGroup = JobManagerUtil.getCapacityGroupDescriptorName(job.getJobDescriptor(), capacityGroupManagement).toLowerCase();

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactoryTest.java
@@ -99,6 +99,21 @@ public class V1SpecPodFactoryTest {
     }
 
     @Test
+    public void basicMainContainerTranslation() {
+        Job<BatchJobExt> job = JobGenerator.oneBatchJob();
+        BatchJobTask task = JobGenerator.oneBatchTask();
+        job = job.toBuilder().withJobDescriptor(job.getJobDescriptor().toBuilder().build()).build();
+        when(podAffinityFactory.buildV1Affinity(job, task)).thenReturn(Pair.of(new V1Affinity(), new HashMap<>()));
+
+        V1Pod pod = podFactory.buildV1Pod(job, task, true, false);
+        V1Container mainContainer = pod.getSpec().getContainers().get(0);
+
+        String mainContainerImageTag = pod.getMetadata().getAnnotations().get("pod.titus.netflix.com/image-tag-main");
+        assertThat(mainContainerImageTag).isEqualTo("latest");
+        assertThat(mainContainer.getImage()).contains("titusops/alpine@");
+    }
+
+    @Test
     public void multipleContainers() {
         Job<BatchJobExt> job = JobGenerator.oneBatchJob();
         BatchJobTask task = JobGenerator.oneBatchTask();


### PR DESCRIPTION
We need to preserve this Image Tag somehow into
the v1 pod so that we can retrieve it on the backend
and use it for Metatron to validate.
