### PR TITLE
Refactor class name to TaskDataInjector and fix task status builder

### DIFF
--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/NeedsMigrationQueryHandler.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/NeedsMigrationQueryHandler.java
@@ -46,7 +46,7 @@ import com.netflix.titus.runtime.endpoint.v3.grpc.GrpcJobManagementModelConverte
 import com.netflix.titus.runtime.endpoint.v3.grpc.query.V3TaskQueryCriteriaEvaluator;
 import com.netflix.titus.runtime.jobmanager.JobManagerCursors;
 
-import static com.netflix.titus.gateway.service.v3.internal.TaskRelocationDataInjector.newTaskWithRelocationPlan;
+import static com.netflix.titus.gateway.service.v3.internal.TaskDataInjector.newTaskWithRelocationPlan;
 
 @Singleton
 class NeedsMigrationQueryHandler {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskDataInjector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskDataInjector.java
@@ -204,8 +204,12 @@ class TaskDataInjector {
     }
 
     private Task newTaskWithContainerState(Task task) {
-        return task.toBuilder().setStatus(task.getStatus().toBuilder()
-                .addAllContainerState(kubeApiConnector.getContainerState(task.getId()))).build();
+        if(task.hasStatus()){
+            return task.toBuilder().setStatus(task.getStatus().toBuilder()
+                    .addAllContainerState(kubeApiConnector.getContainerState(task.getId()))).build();
+        }
+        return task.toBuilder().setStatus(TaskStatus.newBuilder()
+                    .addAllContainerState(kubeApiConnector.getContainerState(task.getId()))).build();
     }
 
     static Task newTaskWithRelocationPlan(Task task, TaskRelocationPlan relocationPlan) {

--- a/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskDataInjector.java
+++ b/titus-server-gateway/src/main/java/com/netflix/titus/gateway/service/v3/internal/TaskDataInjector.java
@@ -48,9 +48,9 @@ import rx.Scheduler;
 import rx.schedulers.Schedulers;
 
 @Singleton
-class TaskRelocationDataInjector {
+class TaskDataInjector {
 
-    private static final Logger logger = LoggerFactory.getLogger(TaskRelocationDataInjector.class);
+    private static final Logger logger = LoggerFactory.getLogger(TaskDataInjector.class);
 
     /**
      * We can tolerate task relocation cache staleness up to 60sec. This should be ok, as the relocation service
@@ -67,7 +67,7 @@ class TaskRelocationDataInjector {
     private final Scheduler scheduler;
 
     @Inject
-    TaskRelocationDataInjector(
+    TaskDataInjector(
             GrpcClientConfiguration configuration,
             JobManagerConfiguration jobManagerConfiguration,
             FeatureActivationConfiguration featureActivationConfiguration,
@@ -79,7 +79,7 @@ class TaskRelocationDataInjector {
     }
 
     @VisibleForTesting
-    TaskRelocationDataInjector(
+    TaskDataInjector(
             GrpcClientConfiguration configuration,
             JobManagerConfiguration jobManagerConfiguration,
             FeatureActivationConfiguration featureActivationConfiguration,
@@ -204,7 +204,7 @@ class TaskRelocationDataInjector {
     }
 
     private Task newTaskWithContainerState(Task task) {
-        return task.toBuilder().setStatus(TaskStatus.newBuilder()
+        return task.toBuilder().setStatus(task.getStatus().toBuilder()
                 .addAllContainerState(kubeApiConnector.getContainerState(task.getId()))).build();
     }
 


### PR DESCRIPTION
Looks like we were overriding task status with the latest changes. Fixed that. 