### PR TITLE
Remove unused EBS PV code

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/client/DirectKubeConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/client/DirectKubeConfiguration.java
@@ -58,10 +58,4 @@ public interface DirectKubeConfiguration extends KubeConnectorConfiguration {
      */
     @DefaultValue("200")
     int getPodCreateConcurrencyLimit();
-
-    /**
-     * Set to true to enable EBS PV and PVC management.
-     */
-    @DefaultValue("false")
-    boolean isEbsVolumePvEnabled();
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/PodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/PodFactory.java
@@ -21,5 +21,5 @@ import com.netflix.titus.api.jobmanager.model.job.Task;
 import io.kubernetes.client.openapi.models.V1Pod;
 
 public interface PodFactory {
-    V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler, boolean useKubePv);
+    V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler);
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/RouterPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/RouterPodFactory.java
@@ -74,7 +74,7 @@ public class RouterPodFactory implements PodFactory {
      * route to the default version. e.g. v1=(app1,app2,cg1,cg3);v2=(app4)
      */
     @Override
-    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler, boolean useKubePv) {
+    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler) {
         Map<String, Pattern> versionPatterns = patternsByVersion.apply(podSpecVersionRoutingRules.get());
 
         for (Map.Entry<String, Pattern> versionPattern : versionPatterns.entrySet()) {
@@ -84,15 +84,15 @@ public class RouterPodFactory implements PodFactory {
             String applicationName = job.getJobDescriptor().getApplicationName();
             String capacityGroup = job.getJobDescriptor().getCapacityGroup();
             if (pattern.matcher(applicationName).matches() || pattern.matcher(capacityGroup).matches()) {
-                return buildV1PodByVersion(version, job, task, useKubeScheduler, useKubePv);
+                return buildV1PodByVersion(version, job, task, useKubeScheduler);
             }
         }
-        return buildV1PodByVersion(configuration.getDefaultPodSpecVersion(), job, task, useKubeScheduler, useKubePv);
+        return buildV1PodByVersion(configuration.getDefaultPodSpecVersion(), job, task, useKubeScheduler);
     }
 
-    private V1Pod buildV1PodByVersion(String version, Job<?> job, Task task, boolean useKubeScheduler, boolean useKubePv) {
+    private V1Pod buildV1PodByVersion(String version, Job<?> job, Task task, boolean useKubeScheduler) {
         if (versionedPodFactories.containsKey(version)) {
-            return versionedPodFactories.get(version).buildV1Pod(job, task, useKubeScheduler, useKubePv);
+            return versionedPodFactories.get(version).buildV1Pod(job, task, useKubeScheduler);
         } else {
             throw new RuntimeException("Unable to create pod spec with invalid version: " + version);
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -109,7 +109,7 @@ public class V0SpecPodFactory implements PodFactory {
     }
 
     @Override
-    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler, boolean useKubePv) {
+    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler) {
         String taskId = task.getId();
         TitanProtos.ContainerInfo containerInfo = podContainerInfoFactory.buildContainerInfo(job, task, true);
         Map<String, String> annotations = KubePodUtil.createPodAnnotations(job, task, containerInfo.toByteArray(),
@@ -162,7 +162,7 @@ public class V0SpecPodFactory implements PodFactory {
             spec.setNodeName(task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID));
         }
         Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildV1VolumeInfo(job, task);
-        if (useKubePv && optionalEbsVolumeInfo.isPresent()) {
+        if (optionalEbsVolumeInfo.isPresent()) {
             spec.addVolumesItem(optionalEbsVolumeInfo.get().getLeft());
             container.addVolumeMountsItem(optionalEbsVolumeInfo.get().getRight());
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -190,7 +190,7 @@ public class V1SpecPodFactory implements PodFactory {
     }
 
     @Override
-    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler, boolean useKubePv) {
+    public V1Pod buildV1Pod(Job<?> job, Task task, boolean useKubeScheduler) {
 
         String taskId = task.getId();
         Map<String, String> annotations = createPodAnnotations(job, task);
@@ -260,7 +260,7 @@ public class V1SpecPodFactory implements PodFactory {
 
         // volumes need to be correctly added to pod spec
         Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildV1VolumeInfo(job, task);
-        if (useKubePv && optionalEbsVolumeInfo.isPresent()) {
+        if (optionalEbsVolumeInfo.isPresent()) {
             spec.addVolumesItem(optionalEbsVolumeInfo.get().getLeft());
             container.addVolumeMountsItem(optionalEbsVolumeInfo.get().getRight());
         }

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/RouterPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/RouterPodFactoryTest.java
@@ -52,7 +52,7 @@ public class RouterPodFactoryTest {
 
         Job<BatchJobExt> job = createBatchJob("testApp3", "testCG3");
         BatchJobTask task = JobGenerator.oneBatchTask();
-        V1Pod v1Pod = routerPodFactory.buildV1Pod(job, task, true, false);
+        V1Pod v1Pod = routerPodFactory.buildV1Pod(job, task, true);
         assertThat(v1Pod.getMetadata().getAnnotations().get(POD_SCHEMA_VERSION)).isEqualTo("0");
     }
 
@@ -64,7 +64,7 @@ public class RouterPodFactoryTest {
 
         Job<BatchJobExt> job = createBatchJob("testApp1", "testCG1");
         BatchJobTask task = JobGenerator.oneBatchTask();
-        V1Pod v1Pod = routerPodFactory.buildV1Pod(job, task, true, false);
+        V1Pod v1Pod = routerPodFactory.buildV1Pod(job, task, true);
         assertThat(v1Pod.getMetadata().getAnnotations().get(POD_SCHEMA_VERSION)).isEqualTo("1");
     }
 
@@ -106,7 +106,7 @@ public class RouterPodFactoryTest {
 
         for (Pair<String, String> versionMapping : versionMappings) {
             PodFactory podFactory = mock(PodFactory.class);
-            when(podFactory.buildV1Pod(any(), any(), anyBoolean(), anyBoolean())).thenReturn(createPodWithVersion(versionMapping.getRight()));
+            when(podFactory.buildV1Pod(any(), any(), anyBoolean())).thenReturn(createPodWithVersion(versionMapping.getRight()));
             versionedPodFactories.put(versionMapping.getLeft(), podFactory);
         }
 


### PR DESCRIPTION
We had this code in previously for kubelet + the
AWS EBS CSI Driver.

Now that we are no longer using that driver, we no longer
need the complexity of PV / PVCs at all (pretty sure),
and all we need is a plain volume + volumeMount.

Also with this change, EBS volumes will be enabled in all
regions, and we'll no longer need a feature toggle.

----

Can we remove `boolean useKubeScheduler` next? :)