### PR TITLE
Use EBS annotations for v0, and vol/volmount for v1 pods

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -607,6 +607,9 @@ public final class JobFunctions {
     }
 
     public static Optional<JobStatus> findJobStatus(Job<?> job, JobState checkedState) {
+        if (job.getStatus() == null) {
+            return Optional.empty();
+        }
         if (job.getStatus().getState() == checkedState) {
             return Optional.of(job.getStatus());
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
@@ -103,12 +103,6 @@ public final class KubePodConstants {
     public static final String NETWORK_SUBNET_IDS = "network.netflix.com/subnet-ids";
     public static final String NETWORK_STATIC_IP_ALLOCATION_UUID = "network.netflix.com/static-ip-allocation-uuid";
 
-    // Storage
-    public static final String STORAGE_EBS_VOLUME_ID = "ebs.volume.netflix.com/volume-id";
-    public static final String STORAGE_EBS_MOUNT_PATH = "ebs.volume.netflix.com/mount-path";
-    public static final String STORAGE_EBS_MOUNT_PERM = "ebs.volume.netflix.com/mount-perm";
-    public static final String STORAGE_EBS_FS_TYPE = "ebs.volume.netflix.com/fs-type";
-
     // Security
     public static final String SECURITY_APP_METADATA = "security.netflix.com/workload-metadata";
     public static final String SECURITY_APP_METADATA_SIG = "security.netflix.com/workload-metadata-sig";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -103,8 +103,6 @@ public class KubePodUtil {
                 modeName -> annotations.put(KubeConstants.NETWORK_MODE, modeName)
         );
 
-        annotations.putAll(createEbsPodAnnotations(job, task));
-
         if (includeJobDescriptor) {
             annotations.put("jobDescriptor", createEncodedJobDescriptor(job));
         }
@@ -195,9 +193,9 @@ public class KubePodUtil {
     }
 
     /**
-     * Builds the various objects needed to for PersistentVolume and Pod objects to use an volume.
+     * Build EBS Volume + VolumeMounts if needed
      */
-    public static Optional<Pair<V1Volume, V1VolumeMount>> buildV1VolumeInfo(Job<?> job, Task task) {
+    public static Optional<Pair<V1Volume, V1VolumeMount>> buildEBSV1VolumeInfo(Job<?> job, Task task) {
         return EbsVolumeUtils.getEbsVolumeForTask(job, task)
                 .map(ebsVolume -> {
                     boolean readOnly = ebsVolume.getMountPermissions().equals(EbsVolume.MountPerm.RO);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -146,8 +146,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_OWNER_EMAIL;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_SEQUENCE;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_STACK;
-import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1VolumeInfo;
-import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createEbsPodAnnotations;
+import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildEBSV1VolumeInfo;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createPlatformSidecarAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.sanitizeVolumeName;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.selectScheduler;
@@ -258,8 +257,7 @@ public class V1SpecPodFactory implements PodFactory {
                 .tolerations(taintTolerationFactory.buildV1Toleration(job, task, useKubeScheduler))
                 .topologySpreadConstraints(topologyFactory.buildTopologySpreadConstraints(job));
 
-        // volumes need to be correctly added to pod spec
-        Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildV1VolumeInfo(job, task);
+        Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildEBSV1VolumeInfo(job, task);
         if (optionalEbsVolumeInfo.isPresent()) {
             spec.addVolumesItem(optionalEbsVolumeInfo.get().getLeft());
             container.addVolumeMountsItem(optionalEbsVolumeInfo.get().getRight());
@@ -460,7 +458,6 @@ public class V1SpecPodFactory implements PodFactory {
         });
 
         appendS3WriterRole(annotations, job, task);
-        annotations.putAll(createEbsPodAnnotations(job, task));
         annotations.putAll(PerformanceToolUtil.toAnnotations(job));
         annotations.putAll(createPlatformSidecarAnnotations(job));
 


### PR DESCRIPTION
Previously we were always creating annotations *and* vol/volmount
for EBS on v0 *and* v1 pods. I found this confusing, because
annotations are used on v0 and vols are used on v1.

I didn't want to perpetuate the annotations (wasting space)
for no reason on v1 pods.

This change makes it more clear that on v0 we use annotations
only, and on v1 we use pod constructs only.
