### PR TITLE
Use awsElasticBlockStore instead of PVS pods

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/JobFunctions.java
@@ -607,6 +607,9 @@ public final class JobFunctions {
     }
 
     public static Optional<JobStatus> findJobStatus(Job<?> job, JobState checkedState) {
+        if (job.getStatus() == null) {
+            return Optional.empty();
+        }
         if (job.getStatus().getState() == checkedState) {
             return Optional.of(job.getStatus());
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -16,7 +16,6 @@
 
 package com.netflix.titus.master.kubernetes.pod.v0;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -33,8 +32,6 @@ import com.netflix.titus.api.jobmanager.model.job.BasicContainer;
 import com.netflix.titus.api.jobmanager.model.job.ContainerResources;
 import com.netflix.titus.api.jobmanager.model.job.Job;
 import com.netflix.titus.api.jobmanager.model.job.Task;
-import com.netflix.titus.api.jobmanager.model.job.volume.SharedContainerVolumeSource;
-import com.netflix.titus.api.jobmanager.model.job.volume.Volume;
 import com.netflix.titus.api.model.ApplicationSLA;
 import com.netflix.titus.common.util.tuple.Pair;
 import com.netflix.titus.master.jobmanager.service.JobManagerUtil;
@@ -70,7 +67,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.RESOURCE_
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.RESOURCE_GPU;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.RESOURCE_MEMORY;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.RESOURCE_NETWORK;
-import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1VolumeInfo;
+import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1EBSObjects;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createPlatformSidecarAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.selectScheduler;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.toV1EnvVar;
@@ -161,10 +158,10 @@ public class V0SpecPodFactory implements PodFactory {
         if (!useKubeScheduler) {
             spec.setNodeName(task.getTaskContext().get(TaskAttributes.TASK_ATTRIBUTES_AGENT_INSTANCE_ID));
         }
-        Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildV1VolumeInfo(job, task);
-        if (optionalEbsVolumeInfo.isPresent()) {
-            spec.addVolumesItem(optionalEbsVolumeInfo.get().getLeft());
-            container.addVolumeMountsItem(optionalEbsVolumeInfo.get().getRight());
+        Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeObjects = buildV1EBSObjects(job, task);
+        if (optionalEbsVolumeObjects.isPresent()) {
+            spec.addVolumesItem(optionalEbsVolumeObjects.get().getLeft());
+            container.addVolumeMountsItem(optionalEbsVolumeObjects.get().getRight());
         }
 
         return new V1Pod().metadata(metadata).spec(spec);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -146,7 +146,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_OWNER_EMAIL;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_SEQUENCE;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.WORKLOAD_STACK;
-import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1VolumeInfo;
+import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1EBSObjects;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createEbsPodAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createPlatformSidecarAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.sanitizeVolumeName;
@@ -259,7 +259,7 @@ public class V1SpecPodFactory implements PodFactory {
                 .topologySpreadConstraints(topologyFactory.buildTopologySpreadConstraints(job));
 
         // volumes need to be correctly added to pod spec
-        Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildV1VolumeInfo(job, task);
+        Optional<Pair<V1Volume, V1VolumeMount>> optionalEbsVolumeInfo = buildV1EBSObjects(job, task);
         if (optionalEbsVolumeInfo.isPresent()) {
             spec.addVolumesItem(optionalEbsVolumeInfo.get().getLeft());
             container.addVolumeMountsItem(optionalEbsVolumeInfo.get().getRight());

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactoryTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactoryTest.java
@@ -158,7 +158,7 @@ public class V0SpecPodFactoryTest {
                 .addToTaskContext(TaskAttributes.TASK_ATTRIBUTES_EBS_VOLUME_ID, volName2)
                 .build();
 
-        assertThat(KubePodUtil.buildV1VolumeInfo(job, task))
+        assertThat(KubePodUtil.buildV1EBSObjects(job, task))
                 .isPresent()
                 .hasValueSatisfying(pair -> {
                     V1Volume v1Volume = pair.getLeft();


### PR DESCRIPTION
This change makes it so we always use the awsElasticBlockStore
volumeSource on a volume, instead of using PV/PVCs.

This does leave a lot of leftover unused code that I will clean up on
the next PR, only after verifying there are no unintended side-effects
from configuring pods this way.

On v0 pods, nothing should change, because we still just use the
annotations as the source of truth.

For v1 pods, tests should go green (they fail currently), because the
titus-executor expects awsElasticBlockStore to be filled in, but is
currently not.
