### PR TITLE
Enabled the new HighScale network mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.3-rc.16'
+        titusApiDefinitionsVersion = '0.0.3-rc.17'
 
         springVersion = '5.2.11.RELEASE'
         springSecurityVersion = '5.3.6.RELEASE'

--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/NetworkConfiguration.java
@@ -95,6 +95,8 @@ public class NetworkConfiguration {
                 return "Ipv6AndIpv4Fallback";
             case 4:
                 return "Ipv6Only";
+            case 5:
+                return "HighScale";
             default:
                 return "";
         }


### PR DESCRIPTION
This extends the model to include the new HighScale network mode so it
can be selected. No other business logic at this time (most will
actually be done on titus-executor).

----

I've tried to replace the `networkModeToName` with some sort of autogen'd thing, but I always end up with java naming conflicts because they are both called `NetworkConfiguration` (ie, I can't import the auto-gen java protobuf class at all).

It isn't a big deal, but if anyone has any suggestions, please let me know.