### PR TITLE
Fix schedBatch policy for v1 pods

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -406,7 +406,7 @@ public class V1SpecPodFactory implements PodFactory {
                     annotations.put(NETWORK_ELASTIC_IPS, v);
                     break;
                 case JOB_PARAMETER_ATTRIBUTES_SCHED_BATCH:
-                    annotations.put(POD_SCHED_POLICY, v);
+                    annotations.put(POD_SCHED_POLICY, "batch");
                     break;
                 case JOB_CONTAINER_ATTRIBUTE_SUBNETS:
                     annotations.put(NETWORK_SUBNET_IDS, v);


### PR DESCRIPTION
This was setting it to "true", but what we really want for the value of
the annotation is that actual sched policy itself.
