### PR TITLE
Make v0 pods use the "main" container as the container name

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v0/V0SpecPodFactory.java
@@ -129,7 +129,7 @@ public class V0SpecPodFactory implements PodFactory {
                 .labels(labels);
 
         V1Container container = new V1Container()
-                .name(taskId)
+                .name("main")
                 .image("imageIsInContainerInfo")
                 .env(toV1EnvVar(containerEnvFactory.buildContainerEnv(job, task)))
                 .resources(buildV1ResourceRequirements(job.getJobDescriptor().getContainer().getContainerResources()))


### PR DESCRIPTION
This is the same as v1 pods, but bringing this feature to v0 pods
because I don't really see us getting to v1 pods any time soon.

But, platform sidecar developers need this feature, because we need to
be able to reference the main container "by name", and it is way easier
when that is a constant.
