### PR TITLE
Added image data and platform sidecar data to containerStatus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        titusApiDefinitionsVersion = '0.0.3-rc.17'
+        titusApiDefinitionsVersion = '0.0.3-rc.18'
 
         springVersion = '5.2.11.RELEASE'
         springSecurityVersion = '5.3.6.RELEASE'

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/kubernetes/KubeConstants.java
@@ -224,5 +224,18 @@ public final class KubeConstants {
     public static final String PLATFORM_SIDECAR_SUFFIX = ".platform-sidecars.netflix.com";
     public static final String PLATFORM_SIDECAR_CHANNEL_SUFFIX = PLATFORM_SIDECAR_SUFFIX + "/channel";
     public static final String PLATFORM_SIDECAR_ARGS_SUFFIX = PLATFORM_SIDECAR_SUFFIX + "/arguments";
-    ;
+
+    /**
+     * container annotations (specified on a pod about a container)
+     * Specific containers indicate they want to set something by appending
+     * a prefix key with their container name ($name.containers.netflix.com).
+     */
+    public static final String ANNOTATION_KEY_SUFFIX_CONTAINERS = "containers.netflix.com";
+    public static final String ANNOTATION_KEY_SUFFIX_CONTAINERS_SIDECAR = "platform-sidecar";
+
+    /**
+     * ANNOTATION_KEY_IMAGE_TAG_PREFIX Stores the original tag for the image.
+     * This is because on the v1 pod image field, there is only room for the digest and no room for the tag it came from
+     */
+    public static final String ANNOTATION_KEY_IMAGE_TAG_PREFIX = "pod.titus.netflix.com/image-tag-";
 }


### PR DESCRIPTION
Now that we have containerStatus plumbed all the way through, this is
the next pass which adds more data like image stuff and platform sidecar
stuff.

The reason this is difficult is because with platform sidecars, we need
to look at annotations to verify what the exact tag/digest/name that an
image comes from. The stock k8s v1 container status has no room for this
of course. And it doesn't have room for tag/digest, which we really
want.

This adds code for parsing and extracting annotations to be able to get
back the exact container image and (optionally) the platform sidecar
that added it.

I consider this code to be "best effort", as this is a new feature and
there are a number of ways that the data can simply not show up.

Once this data is in our API, I can make it visible to the Titus UI and
spinnaker to make it clear to our users exactly what sidecars are
running, what version, and why (like what platform sidecar mutator added
it).
