### PR TITLE
RFC: Added more swagger annotations, hid others

### DIFF
--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/metadata/spring/CallMetadataAuthentication.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/metadata/spring/CallMetadataAuthentication.java
@@ -19,6 +19,7 @@ package com.netflix.titus.runtime.endpoint.metadata.spring;
 import java.util.Collection;
 
 import com.netflix.titus.api.model.callmetadata.CallMetadata;
+import io.swagger.annotations.ApiModelProperty;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -27,7 +28,9 @@ import org.springframework.security.core.GrantedAuthority;
  */
 public class CallMetadataAuthentication implements Authentication {
 
+    @ApiModelProperty(hidden = true)
     private final Authentication delegate;
+    @ApiModelProperty(hidden = true)
     private final CallMetadata callMetadata;
 
     public CallMetadataAuthentication(CallMetadata callMetadata, Authentication delegate) {
@@ -35,36 +38,43 @@ public class CallMetadataAuthentication implements Authentication {
         this.callMetadata = callMetadata;
     }
 
+    @ApiModelProperty(hidden = true)
     public CallMetadata getCallMetadata() {
         return callMetadata;
     }
 
     @Override
+    @ApiModelProperty(hidden = true)
     public String getName() {
         return delegate.getName();
     }
 
     @Override
+    @ApiModelProperty(hidden = true)
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return delegate.getAuthorities();
     }
 
     @Override
+    @ApiModelProperty(hidden = true)
     public Object getCredentials() {
         return delegate.getCredentials();
     }
 
     @Override
+    @ApiModelProperty(hidden = true)
     public Object getDetails() {
         return delegate.getDetails();
     }
 
     @Override
+    @ApiModelProperty(hidden = true)
     public Object getPrincipal() {
         return delegate.getPrincipal();
     }
 
     @Override
+    @ApiModelProperty(hidden = true)
     public boolean isAuthenticated() {
         return delegate.isAuthenticated();
     }

--- a/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/metadata/spring/SpringCallMetadataInterceptor.java
+++ b/titus-common-server/src/main/java/com/netflix/titus/runtime/endpoint/metadata/spring/SpringCallMetadataInterceptor.java
@@ -27,6 +27,7 @@ import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.api.model.callmetadata.Caller;
 import com.netflix.titus.api.model.callmetadata.CallerType;
 import com.netflix.titus.runtime.endpoint.metadata.CallMetadataHeaders;
+import io.swagger.annotations.ApiModelProperty;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -39,6 +40,7 @@ import static java.util.Arrays.asList;
 public class SpringCallMetadataInterceptor extends HandlerInterceptorAdapter {
 
     @VisibleForTesting
+    @ApiModelProperty(required = false, hidden = true)
     static final String DEBUG_QUERY_PARAM = "debug";
 
     @Override

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementSpringResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/JobManagementSpringResource.java
@@ -52,6 +52,7 @@ import com.netflix.titus.runtime.endpoint.metadata.spring.CallMetadataAuthentica
 import com.netflix.titus.runtime.jobmanager.gateway.JobServiceGateway;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -243,13 +244,13 @@ public class JobManagementSpringResource {
         return Responses.fromCompletable(jobServiceGateway.killJob(jobId, authentication.getCallMetadata()), HttpStatus.OK);
     }
 
-    @ApiOperation("Find the task with the specified ID")
+    @ApiOperation(value = "Find a task with the specified ID", notes = "Returns an exact task if you already know the task ID", response = Job.class)
     @GetMapping(path = "/tasks/{taskId}")
     public Task findTask(@PathVariable("taskId") String taskId, CallMetadataAuthentication authentication) {
         return Responses.fromSingleValueObservable(jobServiceGateway.findTask(taskId, authentication.getCallMetadata()));
     }
 
-    @ApiOperation("Find tasks")
+    @ApiOperation(value = "Find tasks", notes = "Find tasks with optional filtering criteria")
     @GetMapping(path = "/tasks")
     public TaskQueryResult findTasks(@RequestParam MultiValueMap<String, String> queryParameters, CallMetadataAuthentication authentication) {
         TaskQuery.Builder queryBuilder = TaskQuery.newBuilder();
@@ -261,11 +262,14 @@ public class JobManagementSpringResource {
         return Responses.fromSingleValueObservable(jobServiceGateway.findTasks(queryBuilder.build(), authentication.getCallMetadata()));
     }
 
-    @ApiOperation("Kill task")
+    @ApiOperation(value = "Kill task", notes = "Terminates a Titus Task given a particular Task ID.")
     @DeleteMapping(path = "/tasks/{taskId}")
     public ResponseEntity<Void> killTask(
+            @ApiParam(name = "taskId", value = "Titus Task ID you which to terminate")
             @PathVariable("taskId") String taskId,
+            @ApiParam(name = "shrink", value = "Set true to shrink the desired of the job after killing the task. Defaults to false.", defaultValue = "false")
             @RequestParam(name = "shrink", defaultValue = "false") boolean shrink,
+            @ApiParam(name = "preventMinSizeUpdate", value = "Set true to prevent the job from going below its minimum size. Defaults to false.", defaultValue = "false")
             @RequestParam(name = "preventMinSizeUpdate", defaultValue = "false") boolean preventMinSizeUpdate,
             CallMetadataAuthentication authentication
     ) {

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerSpringResource.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/rest/LoadBalancerSpringResource.java
@@ -60,7 +60,7 @@ public class LoadBalancerSpringResource {
         this.systemLog = systemLog;
     }
 
-    @ApiOperation("Find the load balancer(s) with the specified ID")
+    @ApiOperation("Find the load balancer(s) with the specified Job ID")
     @GetMapping(path = "/{jobId}")
     public GetJobLoadBalancersResult getJobLoadBalancers(@PathVariable("jobId") String jobId, CallMetadataAuthentication authentication) {
         return Responses.fromSingleValueObservable(loadBalancerService.getLoadBalancers(


### PR DESCRIPTION
I was looking at our API docs and wondered what it might take to get our
swagger page into a position where it could replace our (outdated)
markdown docs.

I don't think it is too bad. In fact I think it is good that the params
and what they do are so closely tied to the docs like this.

I still can't hide `authorities[0].authority` and 6 other params that
are crowding out the page, but maybe on the next pass?
