### PR TITLE
image sanitizer fix

### DIFF
--- a/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageSanitizerTest.java
+++ b/titus-server-gateway/src/test/java/com/netflix/titus/gateway/service/v3/internal/JobImageSanitizerTest.java
@@ -118,6 +118,16 @@ public class JobImageSanitizerTest {
     }
 
     @Test
+    public void testRegistryRuntimeError() {
+        when(registryClient.getImageDigest(anyString(), anyString()))
+                .thenReturn(Mono.error(new RuntimeException("Unable to reach the registry")));
+
+        StepVerifier.create(sanitizer.sanitizeAndApply(jobDescriptorWithTag))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+    }
+
+    @Test
     public void testJobWithDigestExists() {
         Image image = jobDescriptorWithDigest.getContainer().getImage();
         when(registryClient.getImageDigest(image.getName(), image.getDigest())).thenReturn(Mono.just(digest));

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
@@ -130,7 +130,8 @@ public class JobImageSanitizer implements AdmissionSanitizer<JobDescriptor> {
                 imageResource,
                 throwable.getClass().getSimpleName()
         );
-        return true;
+        // unknown errors should prevent job creation
+        return false;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Sanitizer behavior change

With this change, we fail early on resolving image digest. For an unknown error, it'd fail job creation instead of letting the job scheduling progress without image digest only to fail during the container launch time.