### PR TITLE
Use a special EIP task context attribute instead of the primary IP

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -57,6 +57,8 @@ public final class TaskAttributes {
     public static final String TASK_ATTRIBUTES_CONTAINER_IP = "task.containerIp";
     public static final String TASK_ATTRIBUTES_CONTAINER_IPV4 = "task.containerIPv4";
     public static final String TASK_ATTRIBUTES_CONTAINER_IPV6 = "task.containerIPv6";
+    public static final String TASK_ATTRIBUTES_ELASTIC_IPV4 = "task.elasticIPv4";
+
     /*
      * TASK_ATTRIBUTES_TRANSITION_IPV4 is a special IP that represents the IP that
      * Tasks in the special Ipv6AndIpv4Fallback network Mode use.

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -137,8 +137,7 @@ public final class JobManagerUtil {
             contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV4, eniIPAddress);
         }
 
-        //If we did assign an EIP, we set that as the "main" ip address
-        contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, elasticIPAddress);
+        contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_ELASTIC_IPV4, elasticIPAddress);
 
         return task.toBuilder().addAllToTaskContext(newContext).build();
     }


### PR DESCRIPTION
I incorrectly added code in https://github.com/Netflix/titus-control-plane/pull/1220/
that made the EIP of a task be the "primary" ip.

This broke LB registration.

I liked the idea of getting the EIP context data back out, but it should
be the primary ip. Instead this adds a new piece of context data so that
one can still see what the EIP was in the UI and other tools, but the
primary ip will remain the private ipv4 address.
