### PR TITLE
Adding a pod annotation for disruption budget policy type

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
@@ -98,6 +98,7 @@ public final class KubePodConstants {
     public static final String JOB_TYPE = "v3.job.titus.netflix.com/type";
     public static final String JOB_DESCRIPTOR = "v3.job.titus.netflix.com/descriptor";
     public static final String ENTRYPOINT_SHELL_SPLITTING_ENABLED = "pod.titus.netflix.com/entrypoint-shell-splitting-enabled";
+    public static final String JOB_DISRUPTION_BUDGET_POLICY_NAME = "v3.job.titus.netflix.com/disruption-budget-policy";
 
     // Networking
     public static final String SUBNETS_LEGACY = "network.titus.netflix.com/subnets";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -105,6 +105,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.ENTRYPOIN
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.IAM_ROLE;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.INGRESS_BANDWIDTH;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.JOB_ACCEPTED_TIMESTAMP_MS;
+import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.JOB_DISRUPTION_BUDGET_POLICY_NAME;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.JOB_ID;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.JOB_TYPE;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LOG_KEEP_LOCAL_FILE;
@@ -332,6 +333,10 @@ public class V1SpecPodFactory implements PodFactory {
 
         annotations.put(JOB_ID, job.getId());
         annotations.put(JOB_TYPE, getJobType(job).name());
+        if (jobDescriptor.getDisruptionBudget().getDisruptionBudgetPolicy() != null) {
+            annotations.put(JOB_DISRUPTION_BUDGET_POLICY_NAME,
+                    jobDescriptor.getDisruptionBudget().getDisruptionBudgetPolicy().getClass().getSimpleName());
+        }
 
         JobGroupInfo jobGroupInfo = jobDescriptor.getJobGroupInfo();
         annotations.put(WORKLOAD_NAME, jobDescriptor.getApplicationName());


### PR DESCRIPTION
### Description of the Change

This annotation is set at the time of pod creation. It is being added to unblock work in agent deploy tooling where we need to look up type of the policy by the referenced job.

The type of policy set on the job may change after a pod is created which could render this annotation out of sync. A better approach is to create Disruption Budget CRDs and reference them by jobId. This will be future work.