### PR TITLE
refactoring job submit limiter

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/JobManagerException.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/service/JobManagerException.java
@@ -49,6 +49,7 @@ public class JobManagerException extends RuntimeException {
         InvalidContainerResources,
         InvalidDesiredCapacity,
         InvalidMaxCapacity,
+        InvalidSequenceId,
         BelowMinCapacity,
         AboveMaxCapacity,
         TerminateAndShrinkNotAllowed,
@@ -94,6 +95,7 @@ public class JobManagerException extends RuntimeException {
             case InvalidContainerResources:
             case InvalidDesiredCapacity:
             case InvalidMaxCapacity:
+            case InvalidSequenceId:
             case BelowMinCapacity:
             case AboveMaxCapacity:
             case TerminateAndShrinkNotAllowed:
@@ -114,6 +116,10 @@ public class JobManagerException extends RuntimeException {
 
     public static JobManagerException jobCreateLimited(String violation) {
         return new JobManagerException(ErrorCode.JobCreateLimited, violation);
+    }
+
+    public static JobManagerException invalidSequenceId(String violation) {
+        return new JobManagerException(ErrorCode.InvalidSequenceId, violation);
     }
 
     public static JobManagerException jobNotFound(String jobId) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -245,6 +245,7 @@ public class DefaultV3JobOperations implements V3JobOperations {
                     }
                     Optional<JobManagerException> jobLimitError = jobSubmitLimiter.checkIfAllowed(jobDescriptorWithCallerId);
                     if (jobLimitError.isPresent()) {
+                        jobSubmitLimiter.releaseId(jobDescriptorWithCallerId);
                         return Observable.error(jobLimitError.get());
                     }
 

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/DefaultV3JobOperations.java
@@ -243,10 +243,9 @@ public class DefaultV3JobOperations implements V3JobOperations {
                     if (reservationFailure.isPresent()) {
                         return Observable.error(JobManagerException.jobCreateLimited(reservationFailure.get()));
                     }
-                    Optional<String> limited = jobSubmitLimiter.checkIfAllowed(jobDescriptorWithCallerId);
-                    if (limited.isPresent()) {
-                        jobSubmitLimiter.releaseId(jobDescriptorWithCallerId);
-                        return Observable.error(JobManagerException.jobCreateLimited(limited.get()));
+                    Optional<JobManagerException> jobLimitError = jobSubmitLimiter.checkIfAllowed(jobDescriptorWithCallerId);
+                    if (jobLimitError.isPresent()) {
+                        return Observable.error(jobLimitError.get());
                     }
 
                     Job<?> job = newJob(jobDescriptorWithCallerId);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/limiter/JobSubmitLimiter.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/limiter/JobSubmitLimiter.java
@@ -17,12 +17,14 @@ package com.netflix.titus.master.jobmanager.service.limiter;
 
 import java.util.Optional;
 
+import com.netflix.titus.api.jobmanager.service.JobManagerException;
+
 public interface JobSubmitLimiter {
 
     /**
      * Check if it is ok to schedule a given job. If not, the result contains a reason message.
      */
-    <JOB_DESCR> Optional<String> checkIfAllowed(JOB_DESCR jobDescriptor);
+    <JOB_DESCR> Optional<JobManagerException> checkIfAllowed(JOB_DESCR jobDescriptor);
 
     /**
      * Reserve job id sequence. If reservation fails, the result contains a reason message.

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/integration/scenario/JobsScenarioBuilder.java
@@ -30,6 +30,7 @@ import com.netflix.titus.api.jobmanager.model.job.event.JobManagerEvent;
 import com.netflix.titus.api.jobmanager.model.job.sanitizer.JobAssertions;
 import com.netflix.titus.api.jobmanager.model.job.sanitizer.JobConfiguration;
 import com.netflix.titus.api.jobmanager.model.job.sanitizer.JobSanitizerBuilder;
+import com.netflix.titus.api.jobmanager.service.JobManagerException;
 import com.netflix.titus.api.model.ResourceDimension;
 import com.netflix.titus.api.model.callmetadata.CallMetadata;
 import com.netflix.titus.common.model.sanitizer.EntitySanitizer;
@@ -150,7 +151,7 @@ public class JobsScenarioBuilder {
 
         JobSubmitLimiter jobSubmitLimiter = new JobSubmitLimiter() {
             @Override
-            public <JOB_DESCR> Optional<String> checkIfAllowed(JOB_DESCR jobDescriptor) {
+            public <JOB_DESCR> Optional<JobManagerException> checkIfAllowed(JOB_DESCR jobDescriptor) {
                 return Optional.empty();
             }
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/limiter/DefaultJobSubmitLimiterTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/limiter/DefaultJobSubmitLimiterTest.java
@@ -1,0 +1,61 @@
+package com.netflix.titus.master.jobmanager.service.limiter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
+import com.netflix.titus.api.jobmanager.service.JobManagerException;
+import com.netflix.titus.api.jobmanager.service.V3JobOperations;
+import com.netflix.titus.master.jobmanager.service.JobManagerConfiguration;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import org.junit.Test;
+
+import static com.netflix.titus.testkit.model.job.JobGenerator.serviceJobs;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultJobSubmitLimiterTest {
+
+    @Test
+    public void checkDuplicateJobSequence() {
+        JobManagerConfiguration config = mock(JobManagerConfiguration.class);
+        when(config.getMaxActiveJobs()).thenReturn(2L);
+        V3JobOperations v3JobOperations = mock(V3JobOperations.class);
+        DefaultJobSubmitLimiter limiter = new DefaultJobSubmitLimiter(config, v3JobOperations);
+
+        Job<ServiceJobExt> job = serviceJobs(JobDescriptorGenerator.oneTaskServiceJobDescriptor()).getValue();
+        List<Job> currentJobs = new ArrayList<>();
+        currentJobs.add(job);
+        when(v3JobOperations.getJobs()).thenReturn(currentJobs);
+
+        // Using the same job description containing the existing job group (stack, detail, sequence)
+        Optional<JobManagerException> result = limiter.checkIfAllowed(job.getJobDescriptor());
+        assertThat(result).isNotNull();
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isNotNull();
+        assertThat(result.get().getErrorCode()).isEqualTo(JobManagerException.ErrorCode.InvalidSequenceId);
+    }
+
+    @Test
+    public void checkMaxActiveJobsLimit() {
+        JobManagerConfiguration config = mock(JobManagerConfiguration.class);
+        when(config.getMaxActiveJobs()).thenReturn(1L);
+        V3JobOperations v3JobOperations = mock(V3JobOperations.class);
+        DefaultJobSubmitLimiter limiter = new DefaultJobSubmitLimiter(config, v3JobOperations);
+
+        Job<ServiceJobExt> job = serviceJobs(JobDescriptorGenerator.oneTaskServiceJobDescriptor()).getValue();
+        List<Job> currentJobs = new ArrayList<>();
+        currentJobs.add(job);
+        when(v3JobOperations.getJobs()).thenReturn(currentJobs);
+
+        // Max active jobs already running
+        Optional<JobManagerException> result = limiter.checkIfAllowed(job.getJobDescriptor());
+        assertThat(result).isNotNull();
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isNotNull();
+        assertThat(result.get().getErrorCode()).isEqualTo(JobManagerException.ErrorCode.JobCreateLimited);
+    }
+}

--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/v3/grpc/ErrorResponses.java
@@ -152,9 +152,11 @@ public final class ErrorResponses {
                 case NotEnabled:
                     return Status.PERMISSION_DENIED;
                 case JobCreateLimited:
+                    return Status.RESOURCE_EXHAUSTED;
                 case InvalidContainerResources:
                 case InvalidDesiredCapacity:
                 case InvalidMaxCapacity:
+                case InvalidSequenceId:
                 case NotServiceJob:
                 case NotServiceJobDescriptor:
                 case NotBatchJob:


### PR DESCRIPTION
Currently two error conditions are clubbed together in the job submit limiter that makes it hard to distinguish between 
1.  Duplicate job sequence ID submission
2. Max active jobs limit reached.

This code change is aimed at separating the two error conditions into their own JobManagerException error codes. It enables the API to return `RESOURCE_EXHAUSTED` when max active job limit is reached.