### PR TITLE
Added task.networkMode context attribute

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/TaskAttributes.java
@@ -68,6 +68,7 @@ public final class TaskAttributes {
     public static final String TASK_ATTRIBUTES_TRANSITION_IPV4 = "task.transitionIPv4";
     public static final String TASK_ATTRIBUTES_NETWORK_INTERFACE_ID = "task.networkInterfaceId";
     public static final String TASK_ATTRIBUTES_NETWORK_INTERFACE_INDEX = "task.networkInterfaceIndex";
+    public static final String TASK_ATTRIBUTES_NETWORK_EFFECTIVE_MODE = "task.effectiveNetworkMode";
     public static final String TASK_ATTRIBUTES_EXECUTOR_URI_OVERRIDE = "task.executorUriOverride";
     public static final String TASK_ATTRIBUTES_TIER = "task.tier";
     public static final String TASK_ATTRIBUTES_IP_ALLOCATION_ID = "task.ipAllocationId";

--- a/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/jobmanager/service/JobManagerUtil.java
@@ -45,7 +45,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_AN
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_ENI_IP_ADDRESS;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_ENI_IPV6_ADDRESS;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_IP_ADDRESS;
-import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_NETWORK_MODE;
+import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.NETWORK_EFFECTIVE_NETWORK_MODE;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.NETWORK_SECURITY_GROUPS;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.NETWORK_SUBNET_IDS;
 
@@ -120,7 +120,7 @@ public final class JobManagerUtil {
         String elasticIPAddress = annotations.get(LEGACY_ANNOTATION_ELASTIC_IP_ADDRESS);
         String eniIPAddress = annotations.get(LEGACY_ANNOTATION_ENI_IP_ADDRESS);
         String eniIPv6Address = annotations.get(LEGACY_ANNOTATION_ENI_IPV6_ADDRESS);
-        String effectiveNetworkMode = annotations.get(LEGACY_ANNOTATION_NETWORK_MODE);
+        String effectiveNetworkMode = annotations.get(NETWORK_EFFECTIVE_NETWORK_MODE);
         String eniID = annotations.get(LEGACY_ANNOTATION_ENI_ID);
 
         Map<String, String> newContext = new HashMap<>(task.getTaskContext());
@@ -128,6 +128,7 @@ public final class JobManagerUtil {
         contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IP, ipaddress);
         contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV6, eniIPv6Address);
         contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_NETWORK_INTERFACE_ID, eniID);
+        contextSetter.accept(TaskAttributes.TASK_ATTRIBUTES_NETWORK_EFFECTIVE_MODE, effectiveNetworkMode);
 
         if (effectiveNetworkMode != null && effectiveNetworkMode.equals(NetworkConfiguration.NetworkMode.Ipv6AndIpv4Fallback.toString())) {
             // In the IPV6_ONLY_WITH_TRANSITION mode, the ipv4 on the pod doesn't represent

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConstants.java
@@ -72,7 +72,6 @@ public final class KubePodConstants {
     public static final String LEGACY_ANNOTATION_ELASTIC_IP_ADDRESS = "ElasticIPAddress";
     public static final String LEGACY_ANNOTATION_ENI_IP_ADDRESS = "EniIpAddress";
     public static final String LEGACY_ANNOTATION_ENI_IPV6_ADDRESS = "EniIPv6Address";
-    public static final String LEGACY_ANNOTATION_NETWORK_MODE = "NetworkMode";
     public static final String LEGACY_ANNOTATION_ENI_ID = "EniId";
     public static final String LEGACY_ANNOTATION_RESOURCE_ID = "ResourceId";
 
@@ -113,6 +112,7 @@ public final class KubePodConstants {
     public static final String NETWORK_SECURITY_GROUPS = "network.netflix.com/security-groups";
     public static final String NETWORK_SUBNET_IDS = "network.netflix.com/subnet-ids";
     public static final String NETWORK_STATIC_IP_ALLOCATION_UUID = "network.netflix.com/static-ip-allocation-uuid";
+    public static final String NETWORK_EFFECTIVE_NETWORK_MODE = "network.netflix.com/effective-network-mode";
 
     // Storage
     public static final String STORAGE_EBS_VOLUME_ID = "ebs.volume.netflix.com/volume-id";

--- a/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/jobmanager/service/KubeNotificationProcessorTest.java
@@ -70,7 +70,7 @@ import static com.netflix.titus.master.kubernetes.PodDataGenerator.newPod;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_ENI_IP_ADDRESS;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_ENI_IPV6_ADDRESS;
 import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_IP_ADDRESS;
-import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.LEGACY_ANNOTATION_NETWORK_MODE;
+import static com.netflix.titus.master.kubernetes.pod.KubePodConstants.NETWORK_EFFECTIVE_NETWORK_MODE;
 import static com.netflix.titus.runtime.kubernetes.KubeConstants.TITUS_NODE_DOMAIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -167,7 +167,7 @@ public class KubeNotificationProcessorTest {
         UpdatedAnnotations.put(LEGACY_ANNOTATION_IP_ADDRESS, "2001:db8:0:1234:0:567:8:1");
         UpdatedAnnotations.put(LEGACY_ANNOTATION_ENI_IP_ADDRESS, "192.0.2.1");
         UpdatedAnnotations.put(LEGACY_ANNOTATION_ENI_IPV6_ADDRESS, "2001:db8:0:1234:0:567:8:1");
-        UpdatedAnnotations.put(LEGACY_ANNOTATION_NETWORK_MODE, NetworkConfiguration.NetworkMode.Ipv6AndIpv4Fallback.toString());
+        UpdatedAnnotations.put(NETWORK_EFFECTIVE_NETWORK_MODE, NetworkConfiguration.NetworkMode.Ipv6AndIpv4Fallback.toString());
         pod.getMetadata().setAnnotations(UpdatedAnnotations);
 
         Task updatedTask = processor.updateTaskStatus(
@@ -187,6 +187,7 @@ public class KubeNotificationProcessorTest {
         // be unique to that task, and tools would try to use it, people would try to ssh to it, etc.
         assertThat(updatedTask.getTaskContext()).doesNotContainKey(TaskAttributes.TASK_ATTRIBUTES_CONTAINER_IPV4);
         assertThat(updatedTask.getTaskContext()).containsEntry(TaskAttributes.TASK_ATTRIBUTES_TRANSITION_IPV4, "192.0.2.1");
+        assertThat(updatedTask.getTaskContext()).containsEntry(TaskAttributes.TASK_ATTRIBUTES_NETWORK_EFFECTIVE_MODE, NetworkConfiguration.NetworkMode.Ipv6AndIpv4Fallback.toString());
     }
 
     @Test


### PR DESCRIPTION
This exposes the effective network mode of a task out via the task
context.

This is "effective" because it represents the actual network mode used
on a task, which is not necissarily what was selected on the job that
created it. (most of the time, is unset!).