### PR TITLE
Added new MixedSchedulerResourcePoolResolver

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
@@ -95,6 +95,13 @@ public interface KubePodConfiguration {
     String getReservedCapacityKubeSchedulerNameForBinPacking();
 
     /**
+     * This bool indicates that we are in "mixed scheduling" mode, which means that we will launch pods
+     * on either elastic or reserved resource pools if they fit.
+     */
+    @DefaultValue("false")
+    boolean isMixedSchedulingEnabled();
+
+    /**
      * The grace period on the pod object to use when the pod is created.
      */
     @DefaultValue("600")

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodModule.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodModule.java
@@ -38,6 +38,7 @@ import com.netflix.titus.master.kubernetes.pod.resourcepool.FarzonePodResourcePo
 import com.netflix.titus.master.kubernetes.pod.resourcepool.FixedResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.GpuPodResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.KubeSchedulerPodResourcePoolResolver;
+import com.netflix.titus.master.kubernetes.pod.resourcepool.MixedSchedulerResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.PodResourcePoolResolver;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.PodResourcePoolResolverChain;
 import com.netflix.titus.master.kubernetes.pod.resourcepool.PodResourcePoolResolverFeatureGuard;
@@ -90,6 +91,7 @@ public class KubePodModule extends AbstractModule {
                         new ExplicitJobPodResourcePoolResolver(),
                         new FarzonePodResourcePoolResolver(configuration),
                         new GpuPodResourcePoolResolver(configuration, capacityGroupService),
+                        new MixedSchedulerResourcePoolResolver(configuration),
                         new KubeSchedulerPodResourcePoolResolver(capacityGroupService),
                         new CapacityGroupPodResourcePoolResolver(
                                 configuration,

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
@@ -254,8 +254,11 @@ public class DefaultPodAffinityFactory implements PodAffinityFactory {
                     );
             addNodeAffinitySelectorConstraint(KubeConstants.NODE_LABEL_RESOURCE_POOL, names, true);
 
-            List<String> preferredPools = resourcePools.stream().map(ResourcePoolAssignment::getPreferredResourcePoolName).distinct().collect(Collectors.toList());
-            addNodeAffinitySelectorConstraint(KubeConstants.NODE_LABEL_RESOURCE_POOL, preferredPools, false);
+            for (ResourcePoolAssignment assignment : resourcePools) {
+                if (assignment.isPreferred()) {
+                    addNodeAffinitySelectorConstraint(KubeConstants.NODE_LABEL_RESOURCE_POOL, assignment.getResourcePoolName(), false);
+                }
+            }
 
             annotations.put(KubeConstants.TITUS_SCALER_DOMAIN + "resource-pool-selection", rule);
             annotations.put(KubeConstants.NODE_LABEL_RESOURCE_POOL, String.join(",", names));

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
@@ -255,7 +255,7 @@ public class DefaultPodAffinityFactory implements PodAffinityFactory {
             addNodeAffinitySelectorConstraint(KubeConstants.NODE_LABEL_RESOURCE_POOL, names, true);
 
             for (ResourcePoolAssignment assignment : resourcePools) {
-                if (assignment.isPreferred()) {
+                if (assignment.preferred()) {
                     addNodeAffinitySelectorConstraint(KubeConstants.NODE_LABEL_RESOURCE_POOL, assignment.getResourcePoolName(), false);
                 }
             }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/affinity/DefaultPodAffinityFactory.java
@@ -252,8 +252,11 @@ public class DefaultPodAffinityFactory implements PodAffinityFactory {
                             ? resourcePools.get(0).getRule()
                             : resourcePools.stream().map(ResourcePoolAssignment::getRule).collect(Collectors.joining(","))
                     );
-
             addNodeAffinitySelectorConstraint(KubeConstants.NODE_LABEL_RESOURCE_POOL, names, true);
+
+            List<String> preferredPools = resourcePools.stream().map(ResourcePoolAssignment::getPreferredResourcePoolName).distinct().collect(Collectors.toList());
+            addNodeAffinitySelectorConstraint(KubeConstants.NODE_LABEL_RESOURCE_POOL, preferredPools, false);
+
             annotations.put(KubeConstants.TITUS_SCALER_DOMAIN + "resource-pool-selection", rule);
             annotations.put(KubeConstants.NODE_LABEL_RESOURCE_POOL, String.join(",", names));
         }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolResolver.java
@@ -26,12 +26,12 @@ public class MixedSchedulerResourcePoolResolver implements PodResourcePoolResolv
         String preferredPool = calculatePreferredPool(job);
         ResourcePoolAssignment elasticAssignment = ResourcePoolAssignment.newBuilder()
                 .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC)
-                .withIsPreferred(preferredPool.equals(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC))
+                .withPreferred(preferredPool.equals(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC))
                 .withRule("Mixed scheduling pool assignment " + PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC)
                 .build();
         ResourcePoolAssignment reservedAssignment = ResourcePoolAssignment.newBuilder()
                 .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
-                .withIsPreferred(preferredPool.equals(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED))
+                .withPreferred(preferredPool.equals(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED))
                 .withRule("Mixed scheduling pool assignment " + PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
                 .build();
         return Arrays.asList(elasticAssignment, reservedAssignment);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolResolver.java
@@ -26,12 +26,12 @@ public class MixedSchedulerResourcePoolResolver implements PodResourcePoolResolv
         String preferredPool = calculatePreferredPool(job);
         ResourcePoolAssignment elasticAssignment = ResourcePoolAssignment.newBuilder()
                 .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC)
-                .withPreferredResourcePoolName(preferredPool)
+                .withIsPreferred(preferredPool.equals(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC))
                 .withRule("Mixed scheduling pool assignment " + PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC)
                 .build();
         ResourcePoolAssignment reservedAssignment = ResourcePoolAssignment.newBuilder()
                 .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
-                .withPreferredResourcePoolName(preferredPool)
+                .withIsPreferred(preferredPool.equals(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED))
                 .withRule("Mixed scheduling pool assignment " + PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
                 .build();
         return Arrays.asList(elasticAssignment, reservedAssignment);

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolResolver.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolResolver.java
@@ -1,0 +1,70 @@
+package com.netflix.titus.master.kubernetes.pod.resourcepool;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.netflix.titus.api.jobmanager.model.job.ContainerResources;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.master.kubernetes.pod.KubePodConfiguration;
+import com.netflix.titus.master.service.management.ApplicationSlaManagementService;
+
+public class MixedSchedulerResourcePoolResolver implements PodResourcePoolResolver {
+
+    private final KubePodConfiguration configuration;
+
+    public MixedSchedulerResourcePoolResolver(KubePodConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+
+    @Override
+    public List<ResourcePoolAssignment> resolve(Job<?> job, Task task) {
+        if (!configuration.isMixedSchedulingEnabled()) {
+            return Collections.emptyList();
+        }
+        ResourcePoolAssignment elasticAssignment = ResourcePoolAssignment.newBuilder()
+                .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC)
+                .withRule("Mixed scheduling pool assignment " + PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC)
+                .build();
+        ResourcePoolAssignment reservedAssignment = ResourcePoolAssignment.newBuilder()
+                .withResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
+                .withRule("Mixed scheduling pool assignment " + PodResourcePoolResolvers.RESOURCE_POOL_RESERVED)
+                .build();
+
+        String preferredPool = calculatePreferredPool(job);
+        if (preferredPool == PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC) {
+            elasticAssignment.setPreferredResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+            reservedAssignment.setPreferredResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+        } else if (preferredPool == PodResourcePoolResolvers.RESOURCE_POOL_RESERVED) {
+            reservedAssignment.setPreferredResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
+            elasticAssignment.setPreferredResourcePoolName(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
+        }
+        return Arrays.asList(elasticAssignment, reservedAssignment);
+    }
+
+    /**
+     * calculatePreferredPool looks at a job and picks the "best" pool for the job,
+     * which is a function of its resources, *not* its capacity group!
+     * In a mixed scheduling world, we prefer to put jobs based on where they might fit best
+     * based on their ratio, and not due to a policy.
+     */
+    private String calculatePreferredPool(Job<?> job) {
+        double ratio = getRamCPURatio(job);
+        if (ratio > 12) {
+            return PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC;
+        }
+        return PodResourcePoolResolvers.RESOURCE_POOL_RESERVED;
+    }
+
+    private double getRamCPURatio(Job<?> job) {
+        ContainerResources resources = job.getJobDescriptor().getContainer().getContainerResources();
+        if (resources.getCpu() == 0) {
+            return 100;
+        }
+        return (resources.getMemoryMB() / 1024) / resources.getCpu();
+    }
+}
+
+

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
@@ -23,11 +23,11 @@ import com.google.common.base.Preconditions;
 public class ResourcePoolAssignment {
 
     private final String resourcePoolName;
-    private final boolean isPreferred;
+    private final boolean preferred;
     private final String rule;
 
-    public boolean isPreferred() {
-        return isPreferred;
+    public boolean preferred() {
+        return preferred;
     }
 
     @Override
@@ -39,22 +39,22 @@ public class ResourcePoolAssignment {
             return false;
         }
         ResourcePoolAssignment that = (ResourcePoolAssignment) o;
-        return Objects.equals(resourcePoolName, that.resourcePoolName) && Objects.equals(isPreferred, that.isPreferred) && Objects.equals(rule, that.rule);
+        return Objects.equals(resourcePoolName, that.resourcePoolName) && Objects.equals(preferred, that.preferred) && Objects.equals(rule, that.rule);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resourcePoolName, isPreferred, rule);
+        return Objects.hash(resourcePoolName, preferred, rule);
     }
 
     @Override
     public String toString() {
-        return "ResourcePoolAssignment{" + "resourcePoolName='" + resourcePoolName + '\'' + ", preferredPoolName='" + isPreferred + '\'' + ", rule='" + rule + '\'' + '}';
+        return "ResourcePoolAssignment{" + "resourcePoolName='" + resourcePoolName + '\'' + ", preferredPoolName='" + preferred + '\'' + ", rule='" + rule + '\'' + '}';
     }
 
-    public ResourcePoolAssignment(String resourcePoolName, boolean isPreferred, String rule) {
+    public ResourcePoolAssignment(String resourcePoolName, boolean preferred, String rule) {
         this.resourcePoolName = resourcePoolName;
-        this.isPreferred = isPreferred;
+        this.preferred = preferred;
         this.rule = rule;
     }
 
@@ -72,7 +72,7 @@ public class ResourcePoolAssignment {
 
     public static final class Builder {
         private String resourcePoolName;
-        private boolean isPreferred;
+        private boolean preferred;
         private String rule;
 
         private Builder() {
@@ -83,8 +83,8 @@ public class ResourcePoolAssignment {
             return this;
         }
 
-        public Builder withIsPreferred(Boolean isPreferred) {
-            this.isPreferred = isPreferred;
+        public Builder withPreferred(Boolean preferred) {
+            this.preferred = preferred;
             return this;
         }
 
@@ -96,7 +96,7 @@ public class ResourcePoolAssignment {
         public ResourcePoolAssignment build() {
             Preconditions.checkNotNull(resourcePoolName, "resource pool name is null");
             Preconditions.checkNotNull(rule, "rule is null");
-            return new ResourcePoolAssignment(resourcePoolName, isPreferred, rule);
+            return new ResourcePoolAssignment(resourcePoolName, preferred, rule);
         }
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
@@ -23,19 +23,15 @@ import com.google.common.base.Preconditions;
 public class ResourcePoolAssignment {
 
     private final String resourcePoolName;
+    private String preferredResourcePoolName;
     private final String rule;
 
-    public ResourcePoolAssignment(String resourcePoolName, String rule) {
-        this.resourcePoolName = resourcePoolName;
-        this.rule = rule;
+    public String getPreferredResourcePoolName() {
+        return preferredResourcePoolName;
     }
 
-    public String getResourcePoolName() {
-        return resourcePoolName;
-    }
-
-    public String getRule() {
-        return rule;
+    public void setPreferredResourcePoolName(String preferredResourcePoolName) {
+        this.preferredResourcePoolName = preferredResourcePoolName;
     }
 
     @Override
@@ -47,21 +43,31 @@ public class ResourcePoolAssignment {
             return false;
         }
         ResourcePoolAssignment that = (ResourcePoolAssignment) o;
-        return Objects.equals(resourcePoolName, that.resourcePoolName) &&
-                Objects.equals(rule, that.rule);
+        return Objects.equals(resourcePoolName, that.resourcePoolName) && Objects.equals(preferredResourcePoolName, that.preferredResourcePoolName) && Objects.equals(rule, that.rule);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resourcePoolName, rule);
+        return Objects.hash(resourcePoolName, preferredResourcePoolName, rule);
     }
 
     @Override
     public String toString() {
-        return "ResourcePoolAssignment{" +
-                "resourcePoolName='" + resourcePoolName + '\'' +
-                ", rule='" + rule + '\'' +
-                '}';
+        return "ResourcePoolAssignment{" + "resourcePoolName='" + resourcePoolName + '\'' + ", preferredPoolName='" + preferredResourcePoolName + '\'' + ", rule='" + rule + '\'' + '}';
+    }
+
+    public ResourcePoolAssignment(String resourcePoolName, String preferredPoolName, String rule) {
+        this.resourcePoolName = resourcePoolName;
+        this.preferredResourcePoolName = preferredPoolName;
+        this.rule = rule;
+    }
+
+    public String getResourcePoolName() {
+        return resourcePoolName;
+    }
+
+    public String getRule() {
+        return rule;
     }
 
     public static Builder newBuilder() {
@@ -70,6 +76,7 @@ public class ResourcePoolAssignment {
 
     public static final class Builder {
         private String resourcePoolName;
+        private String preferredResourcePoolName;
         private String rule;
 
         private Builder() {
@@ -77,6 +84,11 @@ public class ResourcePoolAssignment {
 
         public Builder withResourcePoolName(String resourcePoolName) {
             this.resourcePoolName = resourcePoolName;
+            return this;
+        }
+
+        public Builder withPreferredResourcePoolName(String preferredPoolName) {
+            this.preferredResourcePoolName = preferredPoolName;
             return this;
         }
 
@@ -88,7 +100,7 @@ public class ResourcePoolAssignment {
         public ResourcePoolAssignment build() {
             Preconditions.checkNotNull(resourcePoolName, "resource pool name is null");
             Preconditions.checkNotNull(rule, "rule is null");
-            return new ResourcePoolAssignment(resourcePoolName, rule);
+            return new ResourcePoolAssignment(resourcePoolName, preferredResourcePoolName, rule);
         }
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
@@ -23,11 +23,11 @@ import com.google.common.base.Preconditions;
 public class ResourcePoolAssignment {
 
     private final String resourcePoolName;
-    private final String preferredResourcePoolName;
+    private final boolean isPreferred;
     private final String rule;
 
-    public String getPreferredResourcePoolName() {
-        return preferredResourcePoolName;
+    public boolean isPreferred() {
+        return isPreferred;
     }
 
     @Override
@@ -39,22 +39,22 @@ public class ResourcePoolAssignment {
             return false;
         }
         ResourcePoolAssignment that = (ResourcePoolAssignment) o;
-        return Objects.equals(resourcePoolName, that.resourcePoolName) && Objects.equals(preferredResourcePoolName, that.preferredResourcePoolName) && Objects.equals(rule, that.rule);
+        return Objects.equals(resourcePoolName, that.resourcePoolName) && Objects.equals(isPreferred, that.isPreferred) && Objects.equals(rule, that.rule);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resourcePoolName, preferredResourcePoolName, rule);
+        return Objects.hash(resourcePoolName, isPreferred, rule);
     }
 
     @Override
     public String toString() {
-        return "ResourcePoolAssignment{" + "resourcePoolName='" + resourcePoolName + '\'' + ", preferredPoolName='" + preferredResourcePoolName + '\'' + ", rule='" + rule + '\'' + '}';
+        return "ResourcePoolAssignment{" + "resourcePoolName='" + resourcePoolName + '\'' + ", preferredPoolName='" + isPreferred + '\'' + ", rule='" + rule + '\'' + '}';
     }
 
-    public ResourcePoolAssignment(String resourcePoolName, String preferredPoolName, String rule) {
+    public ResourcePoolAssignment(String resourcePoolName, boolean isPreferred, String rule) {
         this.resourcePoolName = resourcePoolName;
-        this.preferredResourcePoolName = preferredPoolName;
+        this.isPreferred = isPreferred;
         this.rule = rule;
     }
 
@@ -72,7 +72,7 @@ public class ResourcePoolAssignment {
 
     public static final class Builder {
         private String resourcePoolName;
-        private String preferredResourcePoolName;
+        private boolean isPreferred;
         private String rule;
 
         private Builder() {
@@ -83,8 +83,8 @@ public class ResourcePoolAssignment {
             return this;
         }
 
-        public Builder withPreferredResourcePoolName(String preferredPoolName) {
-            this.preferredResourcePoolName = preferredPoolName;
+        public Builder withIsPreferred(Boolean isPreferred) {
+            this.isPreferred = isPreferred;
             return this;
         }
 
@@ -96,7 +96,7 @@ public class ResourcePoolAssignment {
         public ResourcePoolAssignment build() {
             Preconditions.checkNotNull(resourcePoolName, "resource pool name is null");
             Preconditions.checkNotNull(rule, "rule is null");
-            return new ResourcePoolAssignment(resourcePoolName, preferredResourcePoolName, rule);
+            return new ResourcePoolAssignment(resourcePoolName, isPreferred, rule);
         }
     }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/resourcepool/ResourcePoolAssignment.java
@@ -23,15 +23,11 @@ import com.google.common.base.Preconditions;
 public class ResourcePoolAssignment {
 
     private final String resourcePoolName;
-    private String preferredResourcePoolName;
+    private final String preferredResourcePoolName;
     private final String rule;
 
     public String getPreferredResourcePoolName() {
         return preferredResourcePoolName;
-    }
-
-    public void setPreferredResourcePoolName(String preferredResourcePoolName) {
-        this.preferredResourcePoolName = preferredResourcePoolName;
     }
 
     @Override

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/CapacityGroupPodResourcePoolResolverTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/CapacityGroupPodResourcePoolResolverTest.java
@@ -47,7 +47,7 @@ public class CapacityGroupPodResourcePoolResolverTest {
 
     private final DefaultSettableConfig config = new DefaultSettableConfig();
 
-    private final KubePodConfiguration configuration = Archaius2Ext.newConfiguration(KubePodConfiguration.class);
+    private final KubePodConfiguration configuration = Archaius2Ext.newConfiguration(KubePodConfiguration.class, config);
 
     private final ApplicationSlaManagementService capacityGroupService = mock(ApplicationSlaManagementService.class);
 

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolTest.java
@@ -53,8 +53,9 @@ public class MixedSchedulerResourcePoolTest {
         List<ResourcePoolAssignment> result = resolver.resolve(newCPUJob(), task);
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+        assertThat(result.get(0).isPreferred()).isFalse();
         assertThat(result.get(1).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
-        assertThat(result.get(1).getPreferredResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
+        assertThat(result.get(1).isPreferred()).isTrue();
     }
 
     @Test
@@ -62,8 +63,9 @@ public class MixedSchedulerResourcePoolTest {
         List<ResourcePoolAssignment> result = resolver.resolve(newRamJob(), task);
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+        assertThat(result.get(0).isPreferred()).isTrue();
         assertThat(result.get(1).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
-        assertThat(result.get(0).getPreferredResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+        assertThat(result.get(1).isPreferred()).isFalse();
     }
 
     private Job newCPUJob() {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolTest.java
@@ -53,9 +53,9 @@ public class MixedSchedulerResourcePoolTest {
         List<ResourcePoolAssignment> result = resolver.resolve(newCPUJob(), task);
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
-        assertThat(result.get(0).isPreferred()).isFalse();
+        assertThat(result.get(0).preferred()).isFalse();
         assertThat(result.get(1).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
-        assertThat(result.get(1).isPreferred()).isTrue();
+        assertThat(result.get(1).preferred()).isTrue();
     }
 
     @Test
@@ -63,9 +63,9 @@ public class MixedSchedulerResourcePoolTest {
         List<ResourcePoolAssignment> result = resolver.resolve(newRamJob(), task);
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
-        assertThat(result.get(0).isPreferred()).isTrue();
+        assertThat(result.get(0).preferred()).isTrue();
         assertThat(result.get(1).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
-        assertThat(result.get(1).isPreferred()).isFalse();
+        assertThat(result.get(1).preferred()).isFalse();
     }
 
     private Job newCPUJob() {

--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/resourcepool/MixedSchedulerResourcePoolTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.master.kubernetes.pod.resourcepool;
+
+import java.util.List;
+
+import com.netflix.archaius.config.DefaultSettableConfig;
+import com.netflix.titus.api.jobmanager.model.job.ContainerResources;
+import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
+import com.netflix.titus.api.jobmanager.model.job.Task;
+import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
+import com.netflix.titus.common.util.archaius2.Archaius2Ext;
+import com.netflix.titus.master.kubernetes.pod.KubePodConfiguration;
+import com.netflix.titus.testkit.model.job.JobGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.netflix.titus.testkit.model.job.JobDescriptorGenerator.oneTaskBatchJobDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class MixedSchedulerResourcePoolTest {
+
+    private final Task task = JobGenerator.oneBatchTask();
+
+    private final DefaultSettableConfig config = new DefaultSettableConfig();
+    private final KubePodConfiguration configuration = Archaius2Ext.newConfiguration(KubePodConfiguration.class, config);
+    private MixedSchedulerResourcePoolResolver resolver;
+
+    @Before
+    public void setUp() throws Exception {
+        config.setProperty("titusMaster.kubernetes.pod.mixedSchedulingEnabled", "true");
+        resolver = new MixedSchedulerResourcePoolResolver(configuration);
+    }
+
+    @Test
+    public void testCPUHeavyJobGetsBothPoolsAndPrefersReserved() {
+        List<ResourcePoolAssignment> result = resolver.resolve(newCPUJob(), task);
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+        assertThat(result.get(1).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
+        assertThat(result.get(1).getPreferredResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
+    }
+
+    @Test
+    public void testRamHeavyJobGetsBothPoolsAndPrefersElastic() {
+        List<ResourcePoolAssignment> result = resolver.resolve(newRamJob(), task);
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+        assertThat(result.get(1).getResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_RESERVED);
+        assertThat(result.get(0).getPreferredResourcePoolName()).isEqualTo(PodResourcePoolResolvers.RESOURCE_POOL_ELASTIC);
+    }
+
+    private Job newCPUJob() {
+        JobDescriptor<BatchJobExt> j = oneTaskBatchJobDescriptor().but(jd -> jd.getContainer().toBuilder()
+                .withContainerResources(ContainerResources.newBuilder()
+                        .withCpu(100)
+                        .withMemoryMB(1_000)
+                        .build()
+                )
+                .build()
+        );
+        return JobGenerator.oneBatchJob().toBuilder()
+                .withJobDescriptor(j).build();
+    }
+
+    private Job newRamJob() {
+        JobDescriptor<BatchJobExt> j = oneTaskBatchJobDescriptor().but(jd -> jd.getContainer().toBuilder()
+                .withContainerResources(ContainerResources.newBuilder()
+                        .withCpu(1)
+                        .withMemoryMB(472_000)
+                        .build()
+                )
+                .build()
+        );
+        return JobGenerator.oneBatchJob().toBuilder()
+                .withJobDescriptor(j).build();
+    }
+}


### PR DESCRIPTION
This new resource pool resolver, if enabled, will take precidence over
the normal capacity group-based resource pool selectors.

It won't apply to GPU workloads or other more specific things, those
will go to the same resource pools as always.

It contains the hard-coded rule for ram/cpu ratio to provide a
preference for the "best" instance type, but won't actually prevent it
from being scheduled wherever it fits.

----

I'll make PRs for setting the scheduler name and priority class 
like the webhook did (https://github.com/Netflix-Skunkworks/titus-agent-controllers/blob/master/mixedscheduling/router.go) in the next prs.

Example affinity on my dev stack:
``` "spec": {
        "affinity": {
            "nodeAffinity": {
                "preferredDuringSchedulingIgnoredDuringExecution": [
                    {
                        "preference": {
                            "matchExpressions": [
                                {
                                    "key": "scaler.titus.netflix.com/resource-pool",
                                    "operator": "In",
                                    "values": [
                                        "reserved"
                                    ]
                                }
                            ]
                        },
                        "weight": 100
                    }
                ],
                "requiredDuringSchedulingIgnoredDuringExecution": {
                    "nodeSelectorTerms": [
                        {
                            "matchExpressions": [
                                {
                                    "key": "scaler.titus.netflix.com/resource-pool",
                                    "operator": "In",
                                    "values": [
                                        "elastic",
                                        "reserved"
                                    ]
                                },
                                {
                                    "key": "failure-domain.beta.kubernetes.io/zone",
                                    "operator": "In",
                                    "values": [
                                        "us-east-1c",
                                        "us-east-1d",
                                        "us-east-1e"
                                    ]
                                }
                            ]
                        }
                    ]
                }

```