### PR TITLE
Added scheduler priority and scheduler name when in mixed mode

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodConfiguration.java
@@ -86,6 +86,9 @@ public interface KubePodConfiguration {
     @DefaultValue("titus-kube-scheduler-reserved")
     String getReservedCapacityKubeSchedulerName();
 
+    @DefaultValue("titus-kube-scheduler-mixed")
+    String getMixedSchedulingSchedulerName();
+
     /**
      * This string corresponds to a kube-scheduler profile name which implements exact same set of scheduler plugins as
      * the standard reserved capacity scheduler (titus-kube-scheduler-reserved) except

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -280,6 +280,9 @@ public class KubePodUtil {
     }
 
     public static String selectScheduler(SchedulerConfiguration schedulerConfiguration, ApplicationSLA capacityGroupDescriptor, KubePodConfiguration configuration) {
+        if (configuration.isMixedSchedulingEnabled()) {
+            return configuration.getMixedSchedulingSchedulerName();
+        }
         String schedulerName;
         if (capacityGroupDescriptor != null && capacityGroupDescriptor.getTier() == Tier.Critical) {
             if (schedulerConfiguration.isCriticalServiceJobSpreadingEnabled()) {

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -295,4 +295,17 @@ public class KubePodUtil {
         }
         return schedulerName;
     }
+
+    public static String selectPriorityClassName(ApplicationSLA capacityGroupDescriptor, KubePodConfiguration configuration) {
+        if (!configuration.isMixedSchedulingEnabled()) {
+            // Returning null here means it will be unset when we create the pod,
+            // but will in turn get the `globalDefault` of whatever the priority class is for the cluster
+            return null;
+        }
+        if (capacityGroupDescriptor != null && capacityGroupDescriptor.getTier() == Tier.Critical) {
+            // TODO: Put these in titus-kube-common
+            return "sched-latency-fast";
+        }
+        return "sched-latency-delay";
+    }
 }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -157,6 +157,7 @@ import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.buildV1Volumes
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createEbsPodAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.createPlatformSidecarAnnotations;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.sanitizeVolumeName;
+import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.selectPriorityClassName;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.selectScheduler;
 import static com.netflix.titus.master.kubernetes.pod.KubePodUtil.toV1EnvVar;
 
@@ -253,7 +254,7 @@ public class V1SpecPodFactory implements PodFactory {
 
         ApplicationSLA capacityGroupDescriptor = JobManagerUtil.getCapacityGroupDescriptor(job.getJobDescriptor(), capacityGroupManagement);
         String schedulerName = selectScheduler(schedulerConfiguration, capacityGroupDescriptor, configuration);
-
+        String priorityClassName = selectPriorityClassName(capacityGroupDescriptor, configuration);
 
         V1PodSpec spec = new V1PodSpec()
                 .schedulerName(schedulerName)
@@ -263,6 +264,7 @@ public class V1SpecPodFactory implements PodFactory {
                 .restartPolicy(NEVER_RESTART_POLICY)
                 .dnsPolicy(DEFAULT_DNS_POLICY)
                 .affinity(affinityWithMetadata.getLeft())
+                .priorityClassName(priorityClassName)
                 .tolerations(taintTolerationFactory.buildV1Toleration(job, task))
                 .topologySpreadConstraints(topologyFactory.buildTopologySpreadConstraints(job));
 


### PR DESCRIPTION
Porting the webhook logic, this adds a new priority class for reserved/elastic workloads when in mixed mode, as well as setting the actual scheduler name.

I'm pretty sure the scheduler name may be TBD? (@joshi-keyur have you picked it out yet? How about `titus-kube-scheduler-mixed` ?)

----

For titus-kube-common constants, I currently only auto-generate annotations.
I'll make a subsequent PR to do labels and other misc constants like these scheduler names too.