### PR TITLE
RFC: Allow service jobs higher scheduling priority compared to batch

### DIFF
--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/KubePodUtil.java
@@ -29,12 +29,14 @@ import com.netflix.titus.api.jobmanager.JobAttributes;
 import com.netflix.titus.api.jobmanager.TaskAttributes;
 import com.netflix.titus.api.jobmanager.model.job.Image;
 import com.netflix.titus.api.jobmanager.model.job.Job;
+import com.netflix.titus.api.jobmanager.model.job.JobDescriptor;
 import com.netflix.titus.api.jobmanager.model.job.JobFunctions;
 import com.netflix.titus.api.jobmanager.model.job.PlatformSidecar;
 import com.netflix.titus.api.jobmanager.model.job.Task;
 import com.netflix.titus.api.jobmanager.model.job.VolumeMount;
 import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolume;
 import com.netflix.titus.api.jobmanager.model.job.ebs.EbsVolumeUtils;
+import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
 import com.netflix.titus.api.jobmanager.model.job.volume.SaaSVolumeSource;
 import com.netflix.titus.api.jobmanager.model.job.volume.SharedContainerVolumeSource;
 import com.netflix.titus.api.jobmanager.model.job.volume.Volume;
@@ -296,7 +298,7 @@ public class KubePodUtil {
         return schedulerName;
     }
 
-    public static String selectPriorityClassName(ApplicationSLA capacityGroupDescriptor, KubePodConfiguration configuration) {
+    public static String selectPriorityClassName(ApplicationSLA capacityGroupDescriptor, Job<?> job, KubePodConfiguration configuration) {
         if (!configuration.isMixedSchedulingEnabled()) {
             // Returning null here means it will be unset when we create the pod,
             // but will in turn get the `globalDefault` of whatever the priority class is for the cluster
@@ -305,6 +307,10 @@ public class KubePodUtil {
         if (capacityGroupDescriptor != null && capacityGroupDescriptor.getTier() == Tier.Critical) {
             // TODO: Put these in titus-kube-common
             return "sched-latency-fast";
+        }
+        JobDescriptor.JobDescriptorExt jobDescriptorExt = job.getJobDescriptor().getExtensions();
+        if (jobDescriptorExt instanceof ServiceJobExt) {
+            return "sched-latency-medium";
         }
         return "sched-latency-delay";
     }

--- a/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
+++ b/titus-server-master/src/main/java/com/netflix/titus/master/kubernetes/pod/v1/V1SpecPodFactory.java
@@ -254,7 +254,7 @@ public class V1SpecPodFactory implements PodFactory {
 
         ApplicationSLA capacityGroupDescriptor = JobManagerUtil.getCapacityGroupDescriptor(job.getJobDescriptor(), capacityGroupManagement);
         String schedulerName = selectScheduler(schedulerConfiguration, capacityGroupDescriptor, configuration);
-        String priorityClassName = selectPriorityClassName(capacityGroupDescriptor, configuration);
+        String priorityClassName = selectPriorityClassName(capacityGroupDescriptor, job, configuration);
 
         V1PodSpec spec = new V1PodSpec()
                 .schedulerName(schedulerName)


### PR DESCRIPTION
We are slowly dipping our toes into a new world of scheduling with the
introduction of mixed scheduling.

Soon we'll have 1 unified scheduler handling things.

In that world, I do not want users _1_ Red/Black deploy job having to wait
behind 1000 batch jobs that got queued up from a CMB run.

Therefore, I would like to introduce a new priorityclass for service
jobs to run in, that is not as high as those that have reserved
capacity, but higher than batch.

**Someday** we'll continue to expand this function to allow for more
cases, like high priority batch jobs, or preemptable stuff, etc. But for
now I would like to ease us towards the mixed scheduling world.
But I don't want mixed scheduling to be *worse* than the world we have
today, and I think a medium tier will fix that.

Google Doc: https://docs.google.com/document/d/1F0N6Fljuuxy4n2qQ-9boXtSY5YrmSU_yzNcn-hmd3-w/edit#