### PR TITLE
Don't bother validating docker images if the digest is specified

### DIFF
--- a/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
+++ b/titus-server-runtime/src/main/java/com/netflix/titus/runtime/endpoint/admission/JobImageSanitizer.java
@@ -86,7 +86,7 @@ public class JobImageSanitizer implements AdmissionSanitizer<JobDescriptor> {
     private Mono<Image> sanitizeImage(JobDescriptor jobDescriptor) {
         Image image = jobDescriptor.getContainer().getImage();
         if (StringExt.isNotEmpty(image.getDigest())) {
-            return checkImageDigestExist(image).then(Mono.empty());
+            return Mono.empty();
         }
         return registryClient.getImageDigest(image.getName(), image.getTag())
                 .map(digest -> image.toBuilder().withDigest(digest).build());


### PR DESCRIPTION
I'm working on moving docker image validation to titus-kube-validator.

While I'm doing that, I think we can relax this validator just a little
bit.

If there is already a digest, I think we can take the assumption that it
was added in there by titus-kube-validator.

If a user typos the digest, eh? Sure it will pass validation, but then
get expontially backed off or fail.

Either way this protects a bit better against the dreaded
```
TitusServiceException: Job sanitization error in TitusGateway: Image validation error: image=Image{name='drydock/big_data_services', tag='candidate', digest=''}, cause=Did not observe any item or terminal signal within 4500ms in 'map' (and no fallback has been configured)`
```
(granted titus-kube-validator will probably get the same error)

But at least users can protect against it by providing the sha in the first place.