### PR TITLE
Use Titus job attributies to configure PlatformSidecars

### DIFF
--- a/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/KubePodUtilTest.java
+++ b/titus-server-master/src/test/java/com/netflix/titus/master/kubernetes/pod/KubePodUtilTest.java
@@ -24,9 +24,19 @@ import com.netflix.titus.api.jobmanager.model.job.ext.BatchJobExt;
 import com.netflix.titus.common.util.CollectionsExt;
 import com.netflix.titus.runtime.kubernetes.KubeConstants;
 import com.netflix.titus.testkit.model.job.JobGenerator;
+import com.netflix.titus.api.jobmanager.model.job.ext.ServiceJobExt;
+import com.netflix.titus.testkit.model.job.JobDescriptorGenerator;
+import com.netflix.titus.api.jobmanager.model.job.PlatformSidecar;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.netflix.titus.common.kube.Annotations.AnnotationKeySuffixSidecars;
+
 
 public class KubePodUtilTest {
 
@@ -54,5 +64,33 @@ public class KubePodUtilTest {
     public void testSanitizeVolumeName() {
         String name = "Ab9bac3e:6ea1:4bc3:a803:e0070ca434c3/";
         assertThat(KubePodUtil.sanitizeVolumeName(name)).matches("ab9bac3e-6ea1-4bc3-a803-e0070ca434c3--vol");
+    }
+
+    @Test
+    public void testCreatePlatformSidecarAnnotations() {
+        List<PlatformSidecar> platformSidecars = Arrays.asList(
+                PlatformSidecar.newBuilder().withName("test_sc_v1").withChannel("dev").withArguments("{\"foo\":\"fromPS\"}").build()
+        );
+        JobDescriptor<ServiceJobExt> jobDescriptor = JobDescriptorGenerator.oneTaskServiceJobDescriptor().but(jd ->
+                jd.toBuilder().withPlatformSidecars(platformSidecars).build()
+        );
+        Job<ServiceJobExt> job = JobGenerator.serviceJobs(jobDescriptor).getValue();
+        job = JobFunctions.appendContainerAttribute(job, "test_sc_v1." + AnnotationKeySuffixSidecars, "True");
+        job = JobFunctions.appendContainerAttribute(job, "test_sc_v1." + AnnotationKeySuffixSidecars + "/channel", "dev");
+        job = JobFunctions.appendContainerAttribute(job, "test_sc_v1." + AnnotationKeySuffixSidecars + "/arguments", "{\"foo\":\"false\"}");
+        job = JobFunctions.appendContainerAttribute(job, "test_sc_v2." + AnnotationKeySuffixSidecars, "True");
+        job = JobFunctions.appendContainerAttribute(job, "test_sc_v2." + AnnotationKeySuffixSidecars + "/channel", "dev");
+        job = JobFunctions.appendContainerAttribute(job, "test_sc_v2." + AnnotationKeySuffixSidecars + "/arguments", "{\"foo\":\"false\"}");
+        Map<String, String> annotations = KubePodUtil.createPlatformSidecarAnnotations(job);
+        assertThat(annotations.containsKey("test_sc_v1." + AnnotationKeySuffixSidecars));
+        assertThat(annotations.containsKey("test_sc_v1." + AnnotationKeySuffixSidecars + "/channel"));
+        assertThat(annotations.containsKey("test_sc_v1." + AnnotationKeySuffixSidecars + "/arguments"));
+        assertThat(annotations.containsKey("test_sc_v2." + AnnotationKeySuffixSidecars));
+        assertThat(annotations.containsKey("test_sc_v2." + AnnotationKeySuffixSidecars + "/channel"));
+        assertThat(annotations.containsKey("test_sc_v2." + AnnotationKeySuffixSidecars + "/arguments"));
+        assertThat(annotations.get("test_sc_v1." + AnnotationKeySuffixSidecars + "/channel")).isEqualTo("dev");
+        assertThat(annotations.get("test_sc_v2." + AnnotationKeySuffixSidecars + "/channel")).isEqualTo("dev");
+        assertThat(annotations.get("test_sc_v1." + AnnotationKeySuffixSidecars + "/arguments")).isEqualTo("{\"foo\":\"fromPS\"}");
+        assertThat(annotations.get("test_sc_v2." + AnnotationKeySuffixSidecars + "/arguments")).isEqualTo("{\"foo\":\"false\"}");
     }
 }


### PR DESCRIPTION
### Description of the Change

- Added feature to configure Platform Sidecars by using container attributes. Platform Sidecar statement has priority over container attributes and will override them.